### PR TITLE
fix(platform): localize workflow template copy

### DIFF
--- a/turbo/apps/platform/i18next.config.ts
+++ b/turbo/apps/platform/i18next.config.ts
@@ -26,6 +26,8 @@ export default defineConfig({
     defaultNS: "common",
     functions: ["i18n.t"],
     preservePatterns: [
+      "artifacts.templates.workflowCatalog.*",
+      "artifacts.templates.workflowCategories.*",
       "onboarding.categories.*",
       "onboarding.make.options.*",
       "onboarding.templates.*.*",

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -669,7 +669,325 @@
       "useThisTemplate": "Verwenden Sie diese Vorlage",
       "website": "Webseite",
       "websitePreview": "{{title}} Vorschau der Website-Vorlage",
-      "workflow": "Workflow"
+      "workflow": "Workflow",
+      "workflowCatalog": {
+        "alert-metric-moves-slack": {
+          "description": "Beobachten Sie Ihre wichtigsten Kennzahlen und benachrichtigen Sie Slack, wenn sich eine starke Veränderung abzeichnet.",
+          "shortDescription": "Slack melden, wenn eine Kennzahl stark ausschlägt.",
+          "title": "Warnung, wenn sich eine Metrik ändert"
+        },
+        "auto-inbox-label": {
+          "description": "Erstellen Sie einen Workflow, der startet, sobald ein Gmail-Label gesetzt wird, und die markierte E-Mail bearbeitet.",
+          "shortDescription": "Workflow starten, sobald Sie ein Gmail-Label setzen.",
+          "title": "Automatisches Posteingang-Label"
+        },
+        "auto-merge-github-prs": {
+          "description": "PRs mit dem Label „Ready-to-Merge“ prüfen, auf CI warten, mergen und das Ergebnis in Slack posten.",
+          "shortDescription": "Fertige PRs mergen, sobald die CI grün ist.",
+          "title": "GitHub-PRs automatisch mergen"
+        },
+        "blog-posts-to-x": {
+          "description": "Machen Sie aus jedem neuen Blogbeitrag Social-Varianten in der Buffer-Warteschlange.",
+          "shortDescription": "Aus jedem neuen Blogbeitrag Social-Posts machen.",
+          "title": "Verwandeln Sie Blog-Beiträge in soziale Beiträge"
+        },
+        "build-weekly-deck-gamma": {
+          "description": "Verwandeln Sie die Kennzahlen der Woche in ein präsentationsfertiges Deck in Gamma.",
+          "shortDescription": "Die Wochenzahlen zu einem Gamma-Deck machen.",
+          "title": "Baue das wöchentliche Deck in Gamma"
+        },
+        "business-review-gamma": {
+          "description": "Verwandeln Sie die Kennzahlen des Monats in ein Business-Review-Deck in Gamma.",
+          "shortDescription": "Die Monatszahlen zu einem Review-Deck machen.",
+          "title": "Business-Review in Gamma erstellen"
+        },
+        "catch-calendar-conflicts": {
+          "description": "Scannen Sie Ihren Kalender auf Doppelbuchungen und benachrichtigen Sie frühzeitig.",
+          "shortDescription": "Doppelbuchungen im Kalender früh erkennen.",
+          "title": "Google Calendar-Konflikte erkennen"
+        },
+        "catch-leads-gmail": {
+          "description": "Erkennen Sie Kaufsignale in neuen E-Mails und protokollieren Sie die qualifizierten Leads.",
+          "shortDescription": "Kaufsignale erkennen und Leads erfassen.",
+          "title": "Erfassen Sie Leads von Gmail"
+        },
+        "chase-overdue-asana-tasks": {
+          "description": "Finden Sie überfällige Asana-Aufgaben und stoßen Sie deren Besitzer auf Slack an.",
+          "shortDescription": "Zuständige an überfällige Asana-Aufgaben erinnern.",
+          "title": "Verfolgen Sie überfällige Asana-Aufgaben"
+        },
+        "check-posthog-signup-funnel": {
+          "description": "Verfolgen Sie den Anmeldetrichter und posten Sie den größten Drop-off an Slack.",
+          "shortDescription": "Den größten Abbruch im Anmeldefunnel posten.",
+          "title": "Schauen Sie sich den PostHog-Anmeldetrichter an"
+        },
+        "clickup-slack-standup": {
+          "description": "Holen Sie jeden Morgen die ClickUp-Aufgaben und posten Sie eine Standup-Zusammenfassung des Teams in Slack.",
+          "shortDescription": "Ein Morgen-Standup aus ClickUp-Aufgaben posten.",
+          "title": "ClickUp-Standup in Slack"
+        },
+        "compare-google-ads-last-month": {
+          "description": "Vergleichen Sie Werbeausgaben und ROAS mit dem Vormonat und melden Sie Auffälligkeiten in Slack.",
+          "shortDescription": "Werbeausgaben und ROAS mit dem Vormonat vergleichen.",
+          "title": "Vergleichen Sie Google Ads mit dem letzten Monat"
+        },
+        "competitive-intel-monitor": {
+          "description": "Beobachten Sie Preise und Funktionen auf Wettbewerber-Websites, sichern Sie die Funde in Notion und melden Sie sie in Slack.",
+          "shortDescription": "Preisänderungen der Wettbewerber in Notion festhalten.",
+          "title": "Wettbewerbsbeobachtung"
+        },
+        "daily-company-brief-slack": {
+          "description": "Fassen Sie Produkte, Wachstum und Umsatz in einem täglichen Briefing auf Slack zusammen.",
+          "shortDescription": "Produkt, Wachstum und Umsatz in einem Briefing.",
+          "title": "Veröffentlichen Sie täglich ein Unternehmensbriefing auf Slack"
+        },
+        "daily-industry-news-slack": {
+          "description": "Fassen Sie die relevanten Branchennachrichten des Tages in einem Slack-Briefing zusammen.",
+          "shortDescription": "Die Branchennews des Tages für Slack bündeln.",
+          "title": "Veröffentlichen Sie täglich Branchennachrichten auf Slack"
+        },
+        "daily-standup-report": {
+          "description": "Sammeln Sie jeden Morgen Produkt- und Engineering-Signale, erstellen Sie einen kurzen Bericht und posten Sie ihn in Slack.",
+          "shortDescription": "Morgens ein Produkt- und Engineering-Briefing posten.",
+          "title": "Täglicher Standup-Bericht"
+        },
+        "draft-github-release-notes-notion": {
+          "description": "Wandeln Sie die seit der letzten Veröffentlichung zusammengeführten PRs in saubere Notizen in Notion um.",
+          "shortDescription": "Gemergte PRs zu Release Notes in Notion machen.",
+          "title": "Entwurf von GitHub-Versionshinweisen in Notion"
+        },
+        "draft-newsletter-mailchimp": {
+          "description": "Fassen Sie die jüngsten Neuigkeiten zu einem Newsletter-Entwurf in Mailchimp zusammen.",
+          "shortDescription": "Neuigkeiten zu einem Newsletter zusammenstellen.",
+          "title": "Entwerfen Sie den Newsletter in Mailchimp"
+        },
+        "draft-replies-notion-faq": {
+          "description": "Entwürfe von Ticketantworten basieren auf Ihren Notion-FAQ.",
+          "shortDescription": "Ticket-Antworten aus Ihrer Notion-FAQ entwerfen.",
+          "title": "Antwortentwürfe aus Ihren Notion-FAQs"
+        },
+        "feedback-router": {
+          "description": "Beobachten Sie einen Slack-Kanal und leiten Sie Produktfeedback mit Labels und Zuständigen nach Notion weiter.",
+          "shortDescription": "Produktfeedback aus Slack nach Notion leiten.",
+          "title": "Feedback-Verteilung"
+        },
+        "file-gmail-invoices-drive": {
+          "description": "Legen Sie Rechnungs-E-Mails in Google Drive ab und protokollieren Sie jede einzelne in Google Sheets.",
+          "shortDescription": "Rechnungsmails in Drive ablegen und erfassen.",
+          "title": "Reichen Sie Gmail-Rechnungen in Google Drive ein"
+        },
+        "file-sentry-crashes-github": {
+          "description": "Ordnen Sie neue Sentry-Fehler nach ihren Auswirkungen auf Benutzer und erfassen Sie die wichtigsten als GitHub-Issues.",
+          "shortDescription": "Die schwersten Sentry-Fehler als GitHub-Issues anlegen.",
+          "title": "Sentry-Abstürze als GitHub-Issues erfassen"
+        },
+        "flag-figma-designs-no-task": {
+          "description": "Markieren Sie Figma-Designs, mit denen noch keine Linear-Aufgabe verknüpft ist.",
+          "shortDescription": "Figma-Designs ohne Linear-Aufgabe markieren.",
+          "title": "Markieren Sie Figma-Designs ohne Aufgabe"
+        },
+        "flagged-gmail-todoist-tasks": {
+          "description": "Wandeln Sie die E-Mails, die Sie markieren, automatisch in Todoist-Aufgaben um.",
+          "shortDescription": "Markierte E-Mails zu Todoist-Aufgaben machen.",
+          "title": "Verwandle markiertes Gmail in Todoist-Aufgaben"
+        },
+        "github-idea-to-notion-spec": {
+          "description": "Erweitern Sie ein gekennzeichnetes GitHub-Issue in eine strukturierte Produktspezifikation in Notion.",
+          "shortDescription": "Ein GitHub-Issue zu einer Notion-Spec ausbauen.",
+          "title": "Verwandeln Sie eine GitHub-Idee in eine Notion-Spezifikation"
+        },
+        "github-pr-summarizer": {
+          "description": "Sammeln Sie gemergte Pull Requests, speichern Sie einen strukturierten Bericht in Notion und posten Sie ihn optional in Slack.",
+          "shortDescription": "Gemergte Pull Requests zu einem Bericht bündeln.",
+          "title": "GitHub-PR-Zusammenfassung"
+        },
+        "gmail-followups-auto": {
+          "description": "Suchen Sie nach Kontakten, die nicht geantwortet haben, und verfassen Sie das nächste Follow-up.",
+          "shortDescription": "Nachfassen bei Kontakten, die nicht geantwortet haben.",
+          "title": "Senden Sie Gmail-Follow-ups automatisch"
+        },
+        "gmail-reconnect-reminders": {
+          "description": "Zeigen Sie wichtige Kontakte an, die Sie schon lange nicht mehr per E-Mail verschickt haben.",
+          "shortDescription": "Kontakte zeigen, denen Sie lange nicht schrieben.",
+          "title": "Erhalten Sie Erinnerungen für die Wiederverbindung mit Gmail"
+        },
+        "highlight-key-emails-gmail": {
+          "description": "Decken Sie die wenigen E-Mails auf, die tatsächlich Ihre Aufmerksamkeit erfordern.",
+          "shortDescription": "Die E-Mails zeigen, die Sie jetzt brauchen.",
+          "title": "Markieren Sie wichtige E-Mails in Gmail"
+        },
+        "investor-update-google-docs": {
+          "description": "Fassen Sie Kennzahlen und Highlights in einem Anleger-Update in Docs zusammen.",
+          "shortDescription": "Kennzahlen zu einem Investoren-Update bündeln.",
+          "title": "Entwerfen Sie das Investoren-Update in Google Docs"
+        },
+        "log-gong-calls-hubspot": {
+          "description": "Ziehen Sie Notizen und nächste Schritte aus einem Gong-Anruf in den HubSpot-Deal ein.",
+          "shortDescription": "Gong-Gesprächsnotizen in den HubSpot-Deal holen.",
+          "title": "Gong-Anrufe bei HubSpot protokollieren"
+        },
+        "meeting-notes-asana-tasks": {
+          "description": "Wandeln Sie Besprechungsnotizen in Asana in zugewiesene, fällige Aufgaben um.",
+          "shortDescription": "Aus Meetingnotizen Aufgaben in Asana machen.",
+          "title": "Verwandeln Sie Besprechungsnotizen in Asana-Aufgaben"
+        },
+        "meeting-recaps-slack": {
+          "description": "Teilen Sie nach jedem Meeting eine Zusammenfassung mit Entscheidungen und Aktionspunkten.",
+          "shortDescription": "Entscheidungen und To-dos nach dem Meeting teilen.",
+          "title": "Erhalten Sie Besprechungsrückblicke in Slack"
+        },
+        "morning-brief": {
+          "description": "Machen Sie aus Gmail-, Kalender- und Notion-Updates einen kurzen Tagesplan in Slack.",
+          "shortDescription": "Aus Mails und Terminen einen kurzen Tagesplan machen.",
+          "title": "Morgenbriefing"
+        },
+        "new-gmail-contacts-hubspot": {
+          "description": "Fügen Sie unbekannte E-Mail-Absender als HubSpot-Kontakte hinzu und bereichern Sie sie.",
+          "shortDescription": "Unbekannte Absender in HubSpot anlegen.",
+          "title": "Fügen Sie neue Gmail-Kontakte zu HubSpot hinzu"
+        },
+        "onboard-new-hires-asana": {
+          "description": "Erstellen Sie die Checkliste für die Onboarding-Aufgaben für jeden neuen Mitarbeiter in Asana.",
+          "shortDescription": "Pro neuer Person eine Onboarding-Checkliste anlegen.",
+          "title": "Onboarding neuer Mitarbeiter in Asana"
+        },
+        "personal-weekly-digest": {
+          "description": "Fassen Sie GitHub-, Gmail- und Kalenderaktivität zu einem wöchentlichen Slack-Update zusammen.",
+          "shortDescription": "Ihre Woche aus GitHub und Gmail zusammenfassen.",
+          "title": "Persönlicher Wochenüberblick"
+        },
+        "post-daily-metrics-slack": {
+          "description": "Veröffentlichen Sie tägliche Besucher, Anmeldungen und Aktivierungsnummern in Slack.",
+          "shortDescription": "Tägliche Besucher und Anmeldungen in Slack posten.",
+          "title": "Veröffentlichen Sie tägliche Kennzahlen auf Slack"
+        },
+        "post-release-notes-slack": {
+          "description": "Erstellen Sie ein Änderungsprotokoll der kürzlich versendeten Arbeit und veröffentlichen Sie es in Slack.",
+          "shortDescription": "Ein Changelog entwerfen und in Slack posten.",
+          "title": "Veröffentlichen Sie Versionshinweise in Slack"
+        },
+        "prep-google-calendar-meetings": {
+          "description": "Recherchieren Sie externe Teilnehmer und senden Sie vor Besprechungen ein Vorbereitungsbriefing.",
+          "shortDescription": "Vor externen Terminen ein Briefing schicken.",
+          "title": "Auf Google Calendar-Meetings vorbereiten"
+        },
+        "publish-scheduled-posts-buffer": {
+          "description": "Veröffentlichen Sie die für den Tag geplanten Inhalte und stellen Sie die Social-Beiträge in die Warteschlange.",
+          "shortDescription": "Die für heute geplanten Social-Beiträge posten.",
+          "title": "Veröffentlichen Sie geplante Beiträge in Buffer"
+        },
+        "research-calendar-meetings": {
+          "description": "Informieren Sie sich vor jedem Kalenderereignis über die Personen, die Sie treffen.",
+          "shortDescription": "Vor jedem Termin die Teilnehmenden recherchieren.",
+          "title": "Recherchieren Sie Ihre Kalenderbesprechungen"
+        },
+        "research-new-signups-apollo": {
+          "description": "Recherchieren Sie jede neue Anmeldung und veröffentlichen Sie einen kurzen Schnappschuss.",
+          "shortDescription": "Jede neue Anmeldung recherchieren und posten.",
+          "title": "Recherchieren Sie neue Anmeldungen"
+        },
+        "revenuecat-subscription-digest": {
+          "description": "Verfolgen Sie Abos in Sheets und melden Sie in Slack, wenn sich Kündigungs- oder Abwanderungsmuster ändern.",
+          "shortDescription": "Abos verfolgen und Abwanderung in Slack melden.",
+          "title": "RevenueCat-Abo-Überblick"
+        },
+        "run-daily-query-sheets": {
+          "description": "Führen Sie Ihr gespeichertes SQL nach einem Zeitplan aus und hängen Sie die Ergebnisse an ein Blatt an.",
+          "shortDescription": "Gespeichertes SQL ausführen und in ein Sheet schreiben.",
+          "title": "Führen Sie täglich eine Abfrage in Google Sheets durch"
+        },
+        "salesforce-pipeline-digest": {
+          "description": "Fassen Sie wöchentlich Änderungen an Salesforce-Opportunities und Risiken beim Abschlussdatum in Slack zusammen.",
+          "shortDescription": "Wöchentlich die Risiken der Salesforce-Pipeline bündeln.",
+          "title": "Salesforce-Pipeline-Überblick"
+        },
+        "send-bugs-github-slack": {
+          "description": "Erfassen Sie als Fehler gekennzeichnete Berichte als GitHub-Issues und benachrichtigen Sie das Team in Slack.",
+          "shortDescription": "Fehlermeldungen als GitHub-Issues anlegen.",
+          "title": "Senden Sie Fehler an GitHub und Slack"
+        },
+        "sentry-issue-digest": {
+          "description": "Senden Sie täglich eine Übersicht der kritischen und schwerwiegenden Sentry-Issues an Slack.",
+          "shortDescription": "Täglich die kritischen Sentry-Issues senden.",
+          "title": "Sentry-Issue-Überblick"
+        },
+        "sort-gmail-draft-replies": {
+          "description": "Sortieren Sie Ihren Posteingang und entwerfen Sie Antworten auf die E-Mails, die sie benötigen.",
+          "shortDescription": "Posteingang sortieren und Antworten entwerfen.",
+          "title": "Sortieren Sie Gmail- und Antwortentwürfe"
+        },
+        "spot-churn-risk-stripe-zendesk": {
+          "description": "Kennzeichnen Sie Konten, bei denen das Risiko einer Abwanderung besteht, und verfassen Sie eine Wiederherstellungs-E-Mail.",
+          "shortDescription": "Abwanderungsrisiko erkennen und Mail entwerfen.",
+          "title": "Erkennen Sie das Abwanderungsrisiko bei Stripe und Zendesk"
+        },
+        "summarize-gmail-newsletters": {
+          "description": "Fassen Sie die Newsletter in Ihrem Posteingang in einer kurzen Zusammenfassung zusammen.",
+          "shortDescription": "Ihre Newsletter zu einer Zusammenfassung bündeln.",
+          "title": "Fassen Sie Gmail-Newsletter zusammen"
+        },
+        "summarize-zendesk-tickets-daily": {
+          "description": "Fassen Sie die Zendesk-Tickets des letzten Tages zusammen und veröffentlichen Sie sie auf Slack.",
+          "shortDescription": "Täglich die Zendesk-Tickets zusammenfassen.",
+          "title": "Fassen Sie Zendesk-Tickets täglich zusammen"
+        },
+        "support-ticket-router": {
+          "description": "Klassifizieren Sie Support-E-Mails, legen Sie Notion-Einträge an und melden Sie kritische Tickets in Slack.",
+          "shortDescription": "Support-Mails einordnen und Kritisches markieren.",
+          "title": "Support-Ticket-Verteilung"
+        },
+        "sync-asana-projects-notion": {
+          "description": "Fassen Sie den Asana-Projektstatus in einem einzigen Board in Notion zusammen.",
+          "shortDescription": "Asana-Projektstatus in Notion zusammenführen.",
+          "title": "Synchronisieren Sie Asana-Projekte mit Notion"
+        },
+        "sync-linear-roadmap-notion": {
+          "description": "Halten Sie eine Notion-Roadmap mit dem Status Ihrer Linear-Issues synchron.",
+          "shortDescription": "Eine Notion-Roadmap mit Linear synchron halten.",
+          "title": "Linear-Roadmap mit Notion synchronisieren"
+        },
+        "track-feature-usage-posthog": {
+          "description": "Entdecken Sie die größten wöchentlichen Veränderungen bei der Funktionsnutzung von PostHog.",
+          "shortDescription": "Die größten Nutzungsänderungen der Woche zeigen.",
+          "title": "Verfolgen Sie die Funktionsnutzung mit PostHog"
+        },
+        "track-keyword-ranks-ahrefs": {
+          "description": "Verfolgen Sie Keyword-Rankings in Ahrefs und halten Sie die größten Bewegungen in Notion fest.",
+          "shortDescription": "Die Keyword-Bewegungen der Woche berichten.",
+          "title": "Verfolgen Sie Keyword-Ränge mit Ahrefs"
+        },
+        "track-signup-sources-sheets": {
+          "description": "Ordnen Sie jede neue Anmeldung in einem Tracking-Sheet ihrer Quelle zu.",
+          "shortDescription": "Jede Anmeldung ihrer Quelle im Sheet zuordnen.",
+          "title": "Verfolgen Sie Anmeldequellen in Google Sheets"
+        },
+        "vercel-deploy-digest": {
+          "description": "Überwachen Sie Vercel-Deployments, verknüpfen Sie sie mit GitHub-Commits und melden Sie Fehlschläge in Slack.",
+          "shortDescription": "Slack melden, wenn ein Vercel-Deploy fehlschlägt.",
+          "title": "Vercel-Deploy-Überblick"
+        },
+        "x-brand-monitor": {
+          "description": "Verfolgen Sie Markenerwähnungen auf X, sichern Sie relevante Beiträge in Notion und melden Sie wichtige Erwähnungen in Slack.",
+          "shortDescription": "Starke Markenerwähnungen auf X in Slack melden.",
+          "title": "Markenbeobachtung auf X"
+        },
+        "zendesk-knowledge-base": {
+          "description": "Finden Sie wiederkehrende Zendesk-Fragen, entwerfen Sie FAQ-Einträge und speichern Sie sie in Notion.",
+          "shortDescription": "Wiederkehrende Fragen zu FAQ-Einträgen machen.",
+          "title": "Zendesk-Wissensdatenbank"
+        }
+      },
+      "workflowCategories": {
+        "CEO": "CEO",
+        "Data": "Daten",
+        "Engineering": "Engineering",
+        "Everyone": "Alle",
+        "Marketing": "Marketing",
+        "Operations": "Betrieb",
+        "Product": "Produkt",
+        "Sales": "Vertrieb",
+        "Support": "Support"
+      }
     },
     "title": "Artefakte",
     "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -669,7 +669,325 @@
       "useThisTemplate": "Use this template",
       "website": "Website",
       "websitePreview": "{{title}} website template preview",
-      "workflow": "Workflow"
+      "workflow": "Workflow",
+      "workflowCatalog": {
+        "alert-metric-moves-slack": {
+          "description": "Watch your key metrics and alert Slack when one moves sharply.",
+          "shortDescription": "Alert Slack when a key metric moves sharply.",
+          "title": "Alert when a metric moves"
+        },
+        "auto-inbox-label": {
+          "description": "Create a workflow that runs when a Gmail label is applied and handles the labeled inbox item.",
+          "shortDescription": "Run a workflow when you apply a Gmail label.",
+          "title": "Auto-inbox label"
+        },
+        "auto-merge-github-prs": {
+          "description": "Review PRs labeled ready-to-merge, wait for CI, then merge and post to Slack.",
+          "shortDescription": "Merge ready-to-merge PRs once CI passes.",
+          "title": "Auto-merge GitHub PRs"
+        },
+        "blog-posts-to-x": {
+          "description": "Turn each new blog post into social variants queued via Buffer.",
+          "shortDescription": "Turn each new blog post into social posts.",
+          "title": "Turn blog posts into social posts"
+        },
+        "build-weekly-deck-gamma": {
+          "description": "Turn the week's metrics into a ready-to-present deck in Gamma.",
+          "shortDescription": "Turn the week's metrics into a Gamma deck.",
+          "title": "Build the weekly deck in Gamma"
+        },
+        "business-review-gamma": {
+          "description": "Turn the month's metrics into a business review deck in Gamma.",
+          "shortDescription": "Turn the month's metrics into a review deck.",
+          "title": "Build the business review in Gamma"
+        },
+        "catch-calendar-conflicts": {
+          "description": "Scan your calendar for double-bookings and alert you early.",
+          "shortDescription": "Catch double-bookings in your calendar early.",
+          "title": "Catch Google Calendar conflicts"
+        },
+        "catch-leads-gmail": {
+          "description": "Spot buying signals in new email and log the qualified leads.",
+          "shortDescription": "Spot buying signals and log qualified leads.",
+          "title": "Catch leads from Gmail"
+        },
+        "chase-overdue-asana-tasks": {
+          "description": "Find overdue Asana tasks and nudge their owners on Slack.",
+          "shortDescription": "Nudge the owners of overdue Asana tasks.",
+          "title": "Chase overdue Asana tasks"
+        },
+        "check-posthog-signup-funnel": {
+          "description": "Track the signup funnel and post the biggest drop-off to Slack.",
+          "shortDescription": "Post the signup funnel's biggest drop-off.",
+          "title": "Check the PostHog signup funnel"
+        },
+        "clickup-slack-standup": {
+          "description": "Pull ClickUp tasks each morning and post a team standup summary to Slack.",
+          "shortDescription": "Post a morning standup from ClickUp tasks.",
+          "title": "ClickUp Slack standup"
+        },
+        "compare-google-ads-last-month": {
+          "description": "Compare ad spend and ROAS to last month and flag anomalies in Slack.",
+          "shortDescription": "Compare ad spend and ROAS to last month.",
+          "title": "Compare Google Ads vs last month"
+        },
+        "competitive-intel-monitor": {
+          "description": "Monitor competitor sites for pricing and feature changes, save findings to Notion, and alert Slack.",
+          "shortDescription": "Log competitor pricing changes in Notion.",
+          "title": "Competitive intel monitor"
+        },
+        "daily-company-brief-slack": {
+          "description": "Pull product, growth, and revenue into a daily brief on Slack.",
+          "shortDescription": "Pull product, growth, and revenue into a brief.",
+          "title": "Post a daily company brief to Slack"
+        },
+        "daily-industry-news-slack": {
+          "description": "Round up the day's relevant industry news into a Slack brief.",
+          "shortDescription": "Round up the day's industry news for Slack.",
+          "title": "Post daily industry news to Slack"
+        },
+        "daily-standup-report": {
+          "description": "Pull product and engineering signals each morning, create a short report, and post it to Slack.",
+          "shortDescription": "Post a morning product and engineering brief.",
+          "title": "Daily standup report"
+        },
+        "draft-github-release-notes-notion": {
+          "description": "Turn the PRs merged since the last release into clean notes in Notion.",
+          "shortDescription": "Turn merged PRs into release notes in Notion.",
+          "title": "Draft GitHub release notes in Notion"
+        },
+        "draft-newsletter-mailchimp": {
+          "description": "Assemble recent updates into a newsletter draft in Mailchimp.",
+          "shortDescription": "Assemble recent updates into a newsletter.",
+          "title": "Draft the newsletter in Mailchimp"
+        },
+        "draft-replies-notion-faq": {
+          "description": "Draft ticket replies grounded in your Notion FAQ.",
+          "shortDescription": "Draft ticket replies from your Notion FAQ.",
+          "title": "Draft replies from your Notion FAQ"
+        },
+        "feedback-router": {
+          "description": "Watch a Slack channel and route product feedback into Notion with labels and owners.",
+          "shortDescription": "Route product feedback from Slack into Notion.",
+          "title": "Feedback router"
+        },
+        "file-gmail-invoices-drive": {
+          "description": "File invoice emails to Drive and log each one in a Sheet.",
+          "shortDescription": "File invoice emails to Drive and log them.",
+          "title": "File Gmail invoices to Google Drive"
+        },
+        "file-sentry-crashes-github": {
+          "description": "Rank new Sentry errors by user impact and file the worst as GitHub issues.",
+          "shortDescription": "File the worst Sentry errors as GitHub issues.",
+          "title": "File Sentry crashes as GitHub issues"
+        },
+        "flag-figma-designs-no-task": {
+          "description": "Flag Figma designs that have no linked Linear task yet.",
+          "shortDescription": "Flag Figma designs with no Linear task.",
+          "title": "Flag Figma designs without a task"
+        },
+        "flagged-gmail-todoist-tasks": {
+          "description": "Turn the emails you flag into Todoist tasks automatically.",
+          "shortDescription": "Turn flagged emails into Todoist tasks.",
+          "title": "Turn flagged Gmail into Todoist tasks"
+        },
+        "github-idea-to-notion-spec": {
+          "description": "Expand a labeled GitHub issue into a structured product spec in Notion.",
+          "shortDescription": "Expand a GitHub issue into a Notion spec.",
+          "title": "Turn a GitHub idea into a Notion spec"
+        },
+        "github-pr-summarizer": {
+          "description": "Collect merged pull requests, save a structured report in Notion, and optionally post to Slack.",
+          "shortDescription": "Collect merged pull requests into a report.",
+          "title": "GitHub PR summarizer"
+        },
+        "gmail-followups-auto": {
+          "description": "Find contacts who didn't reply and draft the next follow-up.",
+          "shortDescription": "Draft follow-ups for contacts who didn't reply.",
+          "title": "Send Gmail follow-ups automatically"
+        },
+        "gmail-reconnect-reminders": {
+          "description": "Surface important contacts you haven't emailed in a while.",
+          "shortDescription": "Surface contacts you haven't emailed lately.",
+          "title": "Get Gmail reconnect reminders"
+        },
+        "highlight-key-emails-gmail": {
+          "description": "Surface the few emails that actually need your attention.",
+          "shortDescription": "Surface the emails that need your attention.",
+          "title": "Highlight key emails in Gmail"
+        },
+        "investor-update-google-docs": {
+          "description": "Assemble metrics and highlights into an investor update in Docs.",
+          "shortDescription": "Assemble metrics into an investor update.",
+          "title": "Draft the investor update in Google Docs"
+        },
+        "log-gong-calls-hubspot": {
+          "description": "Pull notes and next steps from a Gong call into the HubSpot deal.",
+          "shortDescription": "Pull Gong call notes into the HubSpot deal.",
+          "title": "Log Gong calls to HubSpot"
+        },
+        "meeting-notes-asana-tasks": {
+          "description": "Turn meeting notes into assigned, due-dated tasks in Asana.",
+          "shortDescription": "Turn meeting notes into tasks in Asana.",
+          "title": "Turn meeting notes into Asana tasks"
+        },
+        "meeting-recaps-slack": {
+          "description": "Share a recap with decisions and action items after each meeting.",
+          "shortDescription": "Share decisions and action items after meetings.",
+          "title": "Get meeting recaps in Slack"
+        },
+        "morning-brief": {
+          "description": "Turn Gmail, Calendar, and Notion updates into a short daily plan in Slack.",
+          "shortDescription": "Turn mail and meetings into a short daily plan.",
+          "title": "Morning brief"
+        },
+        "new-gmail-contacts-hubspot": {
+          "description": "Add and enrich unknown email senders as HubSpot contacts.",
+          "shortDescription": "Add unknown email senders to HubSpot.",
+          "title": "Add new Gmail contacts to HubSpot"
+        },
+        "onboard-new-hires-asana": {
+          "description": "Create the onboarding task checklist for each new hire in Asana.",
+          "shortDescription": "Create an onboarding checklist per new hire.",
+          "title": "Onboard new hires in Asana"
+        },
+        "personal-weekly-digest": {
+          "description": "Summarize GitHub, Gmail, and Calendar activity into one weekly Slack update.",
+          "shortDescription": "Summarize your week across GitHub and Gmail.",
+          "title": "Personal weekly digest"
+        },
+        "post-daily-metrics-slack": {
+          "description": "Post daily visitors, signups, and activation numbers to Slack.",
+          "shortDescription": "Post daily visitors and signups to Slack.",
+          "title": "Post daily metrics to Slack"
+        },
+        "post-release-notes-slack": {
+          "description": "Draft a changelog from recently shipped work and post it to Slack.",
+          "shortDescription": "Draft a changelog and post it to Slack.",
+          "title": "Post release notes to Slack"
+        },
+        "prep-google-calendar-meetings": {
+          "description": "Research external attendees and send a prep brief before meetings.",
+          "shortDescription": "Send a prep brief before external meetings.",
+          "title": "Prep for Google Calendar meetings"
+        },
+        "publish-scheduled-posts-buffer": {
+          "description": "Publish the day's scheduled content and queue the social posts.",
+          "shortDescription": "Publish the day's scheduled social posts.",
+          "title": "Publish scheduled posts to Buffer"
+        },
+        "research-calendar-meetings": {
+          "description": "Research the people you're meeting before each calendar event.",
+          "shortDescription": "Research the people you meet before each event.",
+          "title": "Research your calendar meetings"
+        },
+        "research-new-signups-apollo": {
+          "description": "Research each new signup and post a quick snapshot.",
+          "shortDescription": "Research each new signup and post a snapshot.",
+          "title": "Research new signups"
+        },
+        "revenuecat-subscription-digest": {
+          "description": "Track subscriptions in Sheets and alert Slack when churn or cancellation patterns change.",
+          "shortDescription": "Track subscriptions and alert Slack on churn.",
+          "title": "RevenueCat subscription digest"
+        },
+        "run-daily-query-sheets": {
+          "description": "Run your saved SQL on a schedule and append the results to a Sheet.",
+          "shortDescription": "Run saved SQL and append results to a Sheet.",
+          "title": "Run a daily query into Google Sheets"
+        },
+        "salesforce-pipeline-digest": {
+          "description": "Summarize Salesforce opportunity changes and close-date risks in Slack each week.",
+          "shortDescription": "Summarize Salesforce pipeline risks weekly.",
+          "title": "Salesforce pipeline digest"
+        },
+        "send-bugs-github-slack": {
+          "description": "File bug-tagged reports as GitHub issues and alert the team on Slack.",
+          "shortDescription": "File bug reports as GitHub issues.",
+          "title": "Send bugs to GitHub and Slack"
+        },
+        "sentry-issue-digest": {
+          "description": "Send a daily digest of critical and high-severity Sentry issues to Slack.",
+          "shortDescription": "Send a daily digest of critical Sentry issues.",
+          "title": "Sentry issue digest"
+        },
+        "sort-gmail-draft-replies": {
+          "description": "Sort your inbox and draft replies to the emails that need them.",
+          "shortDescription": "Sort your inbox and draft the replies needed.",
+          "title": "Sort Gmail and draft replies"
+        },
+        "spot-churn-risk-stripe-zendesk": {
+          "description": "Flag accounts at risk of churn and draft a recovery email.",
+          "shortDescription": "Flag churn risk and draft a recovery email.",
+          "title": "Spot churn risk in Stripe and Zendesk"
+        },
+        "summarize-gmail-newsletters": {
+          "description": "Digest the newsletters in your inbox into one short summary.",
+          "shortDescription": "Digest your newsletters into one summary.",
+          "title": "Summarize Gmail newsletters"
+        },
+        "summarize-zendesk-tickets-daily": {
+          "description": "Summarize the last day of Zendesk tickets and post it to Slack.",
+          "shortDescription": "Post a daily summary of Zendesk tickets.",
+          "title": "Summarize Zendesk tickets daily"
+        },
+        "support-ticket-router": {
+          "description": "Classify support emails, create Notion records, and alert Slack for critical tickets.",
+          "shortDescription": "Classify support email and flag critical ones.",
+          "title": "Support ticket router"
+        },
+        "sync-asana-projects-notion": {
+          "description": "Roll up Asana project status into a single board in Notion.",
+          "shortDescription": "Roll up Asana project status into Notion.",
+          "title": "Sync Asana projects to Notion"
+        },
+        "sync-linear-roadmap-notion": {
+          "description": "Keep a Notion roadmap in sync with your Linear issue status.",
+          "shortDescription": "Keep a Notion roadmap in sync with Linear.",
+          "title": "Sync the Linear roadmap to Notion"
+        },
+        "track-feature-usage-posthog": {
+          "description": "Surface the biggest weekly shifts in feature usage from PostHog.",
+          "shortDescription": "Surface the week's biggest usage shifts.",
+          "title": "Track feature usage with PostHog"
+        },
+        "track-keyword-ranks-ahrefs": {
+          "description": "Track keyword rankings in Ahrefs and report the movers in Notion.",
+          "shortDescription": "Report the week's keyword rank movers.",
+          "title": "Track keyword ranks with Ahrefs"
+        },
+        "track-signup-sources-sheets": {
+          "description": "Attribute each new signup to its source in a tracking Sheet.",
+          "shortDescription": "Attribute each signup to its source in a Sheet.",
+          "title": "Track signup sources in Google Sheets"
+        },
+        "vercel-deploy-digest": {
+          "description": "Monitor Vercel deployments, link them to GitHub commits, and alert Slack on failures.",
+          "shortDescription": "Alert Slack when a Vercel deploy fails.",
+          "title": "Vercel deploy digest"
+        },
+        "x-brand-monitor": {
+          "description": "Track brand mentions on X, save relevant posts in Notion, and alert Slack on high-signal mentions.",
+          "shortDescription": "Alert Slack on strong brand mentions on X.",
+          "title": "X brand monitor"
+        },
+        "zendesk-knowledge-base": {
+          "description": "Find recurring Zendesk questions, draft FAQ entries, and save them to Notion.",
+          "shortDescription": "Turn recurring questions into FAQ entries.",
+          "title": "Zendesk knowledge base"
+        }
+      },
+      "workflowCategories": {
+        "CEO": "CEO",
+        "Data": "Data",
+        "Engineering": "Engineering",
+        "Everyone": "Everyone",
+        "Marketing": "Marketing",
+        "Operations": "Operations",
+        "Product": "Product",
+        "Sales": "Sales",
+        "Support": "Support"
+      }
     },
     "title": "Artifacts",
     "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -686,7 +686,325 @@
       "useThisTemplate": "Usa esta plantilla",
       "website": "Sitio web",
       "websitePreview": "Vista previa de la plantilla de sitio web {{title}}",
-      "workflow": "Flujo de trabajo"
+      "workflow": "Flujo de trabajo",
+      "workflowCatalog": {
+        "alert-metric-moves-slack": {
+          "description": "Supervisa tus métricas clave y avisa en Slack cuando una cambie bruscamente.",
+          "shortDescription": "Avisa en Slack si una métrica clave se mueve mucho.",
+          "title": "Alerta cuando se mueve una métrica"
+        },
+        "auto-inbox-label": {
+          "description": "Crea un flujo que se ejecuta al aplicar una etiqueta de Gmail y se ocupa del correo etiquetado.",
+          "shortDescription": "Ejecuta un flujo al aplicar una etiqueta de Gmail.",
+          "title": "Etiqueta automática de bandeja de entrada"
+        },
+        "auto-merge-github-prs": {
+          "description": "Revisa los PR etiquetados como listos para fusionar, espera a que pase CI, fusiónalos y publica el resultado en Slack.",
+          "shortDescription": "Fusiona las PR listas cuando pasa la CI.",
+          "title": "Fusionar automáticamente PR de GitHub"
+        },
+        "blog-posts-to-x": {
+          "description": "Convierte cada nuevo artículo del blog en variantes sociales en la cola de Buffer.",
+          "shortDescription": "Convierte cada artículo nuevo en publicaciones sociales.",
+          "title": "Convierte entradas de blog en publicaciones sociales"
+        },
+        "build-weekly-deck-gamma": {
+          "description": "Convierte las métricas de la semana en una presentación de Gamma lista para exponer.",
+          "shortDescription": "Convierte las métricas de la semana en un deck de Gamma.",
+          "title": "Crear la presentación semanal en Gamma"
+        },
+        "business-review-gamma": {
+          "description": "Convierte las métricas del mes en una presentación de análisis empresarial en Gamma.",
+          "shortDescription": "Convierte las métricas del mes en un deck de revisión.",
+          "title": "Crear el análisis empresarial en Gamma"
+        },
+        "catch-calendar-conflicts": {
+          "description": "Busca reservas duplicadas en tu calendario y avísate con antelación.",
+          "shortDescription": "Detecta pronto las reservas duplicadas.",
+          "title": "Detectar conflictos en Google Calendar"
+        },
+        "catch-leads-gmail": {
+          "description": "Detecta las señales de compra en el correo nuevo y registra los leads calificados.",
+          "shortDescription": "Detecta señales de compra y registra los leads.",
+          "title": "Detectar leads en Gmail"
+        },
+        "chase-overdue-asana-tasks": {
+          "description": "Encuentra tareas vencidas de Asana y recuerda a sus responsables que deben completarlas mediante Slack.",
+          "shortDescription": "Recuerda las tareas de Asana ya vencidas.",
+          "title": "Dar seguimiento a tareas vencidas de Asana"
+        },
+        "check-posthog-signup-funnel": {
+          "description": "Sigue el embudo de inscripción y publica la mayor caída en Slack.",
+          "shortDescription": "Publica dónde se cae más el embudo de registro.",
+          "title": "Comprobar el embudo de registro de PostHog"
+        },
+        "clickup-slack-standup": {
+          "description": "Reúne cada mañana las tareas de ClickUp y publica en Slack el standup del equipo.",
+          "shortDescription": "Publica el standup matinal desde ClickUp.",
+          "title": "Standup de ClickUp en Slack"
+        },
+        "compare-google-ads-last-month": {
+          "description": "Compara la inversión y el ROAS con el mes pasado y señala las anomalías en Slack.",
+          "shortDescription": "Compara inversión y ROAS con el mes pasado.",
+          "title": "Comparar Google Ads con el mes anterior"
+        },
+        "competitive-intel-monitor": {
+          "description": "Vigila precios y funciones en las webs de la competencia, guarda los hallazgos en Notion y avisa en Slack.",
+          "shortDescription": "Anota en Notion los cambios de precio de la competencia.",
+          "title": "Monitor de competencia"
+        },
+        "daily-company-brief-slack": {
+          "description": "Reúne producto, crecimiento e ingresos en un informe diario para Slack.",
+          "shortDescription": "Reúne producto, crecimiento e ingresos en un resumen.",
+          "title": "Publica un informe diario de la empresa para Slack"
+        },
+        "daily-industry-news-slack": {
+          "description": "Reúne las noticias relevantes del sector en un breve resumen diario para Slack.",
+          "shortDescription": "Recopila para Slack las noticias del sector.",
+          "title": "Publica noticias diarias del sector en Slack"
+        },
+        "daily-standup-report": {
+          "description": "Reúne cada mañana las señales de producto e ingeniería, crea un informe breve y publícalo en Slack.",
+          "shortDescription": "Publica cada mañana el resumen de producto e ingeniería.",
+          "title": "Informe diario de standup"
+        },
+        "draft-github-release-notes-notion": {
+          "description": "Convierte los PR fusionados desde la última versión en notas claras dentro de Notion.",
+          "shortDescription": "Convierte las PR fusionadas en notas de versión en Notion.",
+          "title": "Redactar notas de GitHub en Notion"
+        },
+        "draft-newsletter-mailchimp": {
+          "description": "Reúne las novedades recientes en un borrador de newsletter en Mailchimp.",
+          "shortDescription": "Reúne las novedades recientes en una newsletter.",
+          "title": "Redacta el boletín en Mailchimp"
+        },
+        "draft-replies-notion-faq": {
+          "description": "Redacta respuestas a tickets basadas en tus preguntas frecuentes de Notion.",
+          "shortDescription": "Redacta respuestas con tu FAQ de Notion.",
+          "title": "Redactar respuestas desde las preguntas frecuentes de Notion"
+        },
+        "feedback-router": {
+          "description": "Vigila un canal de Slack y lleva el feedback de producto a Notion con etiquetas y responsables.",
+          "shortDescription": "Lleva el feedback de producto de Slack a Notion.",
+          "title": "Enrutador de feedback"
+        },
+        "file-gmail-invoices-drive": {
+          "description": "Archiva en Drive los correos con facturas y registra cada una en una hoja.",
+          "shortDescription": "Archiva las facturas en Drive y regístralas.",
+          "title": "Archivar facturas de Gmail en Google Drive"
+        },
+        "file-sentry-crashes-github": {
+          "description": "Ordena los nuevos errores de Sentry por su impacto y registra los más graves como incidencias de GitHub.",
+          "shortDescription": "Crea issues de GitHub con los peores errores de Sentry.",
+          "title": "Registrar fallos de Sentry como incidencias de GitHub"
+        },
+        "flag-figma-designs-no-task": {
+          "description": "Marca los diseños de Figma que todavía no tienen una tarea de Linear vinculada.",
+          "shortDescription": "Señala los diseños de Figma sin tarea en Linear.",
+          "title": "Marcar diseños de Figma sin tarea"
+        },
+        "flagged-gmail-todoist-tasks": {
+          "description": "Convierte automáticamente los correos que marcas en tareas Todoist.",
+          "shortDescription": "Convierte los correos marcados en tareas de Todoist.",
+          "title": "Convertir correos marcados de Gmail en tareas de Todoist"
+        },
+        "github-idea-to-notion-spec": {
+          "description": "Amplía una incidencia etiquetada de GitHub y conviértela en una especificación de producto estructurada en Notion.",
+          "shortDescription": "Convierte una issue de GitHub en una spec de Notion.",
+          "title": "Convertir una idea de GitHub en una especificación de Notion"
+        },
+        "github-pr-summarizer": {
+          "description": "Reúne las pull requests fusionadas, guarda un informe estructurado en Notion y, si quieres, publícalo en Slack.",
+          "shortDescription": "Reúne las pull requests fusionadas en un informe.",
+          "title": "Resumen de PR de GitHub"
+        },
+        "gmail-followups-auto": {
+          "description": "Busca contactos que no respondieron y redacta el siguiente seguimiento.",
+          "shortDescription": "Redacta seguimientos para quien no ha respondido.",
+          "title": "Enviar seguimientos de Gmail automáticamente"
+        },
+        "gmail-reconnect-reminders": {
+          "description": "Destaca los contactos importantes a los que no has escrito últimamente.",
+          "shortDescription": "Muestra contactos a los que hace tiempo no escribes.",
+          "title": "Recibir recordatorios para retomar contactos de Gmail"
+        },
+        "highlight-key-emails-gmail": {
+          "description": "Saca a la luz los pocos correos que realmente requieren tu atención.",
+          "shortDescription": "Muestra los correos que necesitan tu atención.",
+          "title": "Resalta los correos clave en Gmail"
+        },
+        "investor-update-google-docs": {
+          "description": "Reúne métricas y destacados en una actualización para inversores en Docs.",
+          "shortDescription": "Reúne las métricas en un informe para inversores.",
+          "title": "Redacta la actualización para inversores en Google Docs"
+        },
+        "log-gong-calls-hubspot": {
+          "description": "Añade al acuerdo de HubSpot las notas y los siguientes pasos de una llamada de Gong.",
+          "shortDescription": "Lleva las notas de Gong al negocio de HubSpot.",
+          "title": "Registrar llamadas de Gong en HubSpot"
+        },
+        "meeting-notes-asana-tasks": {
+          "description": "Convierte las notas de las reuniones en tareas asignadas y con fecha de vencimiento en Asana.",
+          "shortDescription": "Convierte las notas de reunión en tareas de Asana.",
+          "title": "Convierte las notas de reuniones en tareas Asana"
+        },
+        "meeting-recaps-slack": {
+          "description": "Comparte un resumen con las decisiones y acciones después de cada reunión.",
+          "shortDescription": "Comparte decisiones y tareas tras las reuniones.",
+          "title": "Recibir resúmenes de reuniones en Slack"
+        },
+        "morning-brief": {
+          "description": "Convierte las novedades de Gmail, Calendar y Notion en un plan diario breve en Slack.",
+          "shortDescription": "Convierte correo y reuniones en un plan diario.",
+          "title": "Resumen matinal"
+        },
+        "new-gmail-contacts-hubspot": {
+          "description": "Añade como contactos de HubSpot a remitentes desconocidos y completa sus datos.",
+          "shortDescription": "Añade a HubSpot los remitentes desconocidos.",
+          "title": "Añadir nuevos contactos de Gmail a HubSpot"
+        },
+        "onboard-new-hires-asana": {
+          "description": "Crea la lista de tareas de incorporación para cada nuevo empleado en Asana.",
+          "shortDescription": "Crea una checklist de alta por cada incorporación.",
+          "title": "Incorporar a nuevos empleados en Asana"
+        },
+        "personal-weekly-digest": {
+          "description": "Resume la actividad de GitHub, Gmail y Calendar en una actualización semanal en Slack.",
+          "shortDescription": "Resume tu semana en GitHub y Gmail.",
+          "title": "Resumen semanal personal"
+        },
+        "post-daily-metrics-slack": {
+          "description": "Publica cada día en Slack las cifras de visitantes, registros y activación.",
+          "shortDescription": "Publica visitantes y registros diarios en Slack.",
+          "title": "Publicar métricas diarias en Slack"
+        },
+        "post-release-notes-slack": {
+          "description": "Redacta un registro de cambios a partir del trabajo publicado recientemente y compártelo en Slack.",
+          "shortDescription": "Redacta un changelog y publícalo en Slack.",
+          "title": "Publicar notas de la versión en Slack"
+        },
+        "prep-google-calendar-meetings": {
+          "description": "Investiga a los asistentes externos y envía un resumen previo antes de las reuniones.",
+          "shortDescription": "Envía un resumen antes de las reuniones externas.",
+          "title": "Prepara las reuniones de Google Calendar"
+        },
+        "publish-scheduled-posts-buffer": {
+          "description": "Publica el contenido programado del día y deja en cola las publicaciones sociales.",
+          "shortDescription": "Publica las redes programadas para hoy.",
+          "title": "Publicar las publicaciones programadas en Buffer"
+        },
+        "research-calendar-meetings": {
+          "description": "Investiga a las personas que vas a conocer antes de cada evento del calendario.",
+          "shortDescription": "Investiga a quien verás antes de cada reunión.",
+          "title": "Investiga tus reuniones en el calendario"
+        },
+        "research-new-signups-apollo": {
+          "description": "Investiga cada nuevo registro y publica un breve perfil.",
+          "shortDescription": "Investiga cada registro nuevo y publica su ficha.",
+          "title": "Investiga nuevas inscripciones"
+        },
+        "revenuecat-subscription-digest": {
+          "description": "Sigue las suscripciones en Sheets y avisa en Slack cuando cambien las bajas o las cancelaciones.",
+          "shortDescription": "Sigue las suscripciones y avisa de las bajas en Slack.",
+          "title": "Resumen de suscripciones de RevenueCat"
+        },
+        "run-daily-query-sheets": {
+          "description": "Ejecuta tu SQL guardado según una programación y añade los resultados a una hoja.",
+          "shortDescription": "Ejecuta SQL guardado y añade el resultado a una hoja.",
+          "title": "Ejecutar una consulta diaria en Google Sheets"
+        },
+        "salesforce-pipeline-digest": {
+          "description": "Resume cada semana en Slack los cambios de oportunidades de Salesforce y los riesgos de cierre.",
+          "shortDescription": "Resume cada semana los riesgos del pipeline.",
+          "title": "Resumen del pipeline de Salesforce"
+        },
+        "send-bugs-github-slack": {
+          "description": "Registra los informes etiquetados como errores en incidencias de GitHub y avisa al equipo en Slack.",
+          "shortDescription": "Registra los errores como issues de GitHub.",
+          "title": "Enviar errores a GitHub y Slack"
+        },
+        "sentry-issue-digest": {
+          "description": "Envía a Slack un resumen diario de las incidencias críticas y graves de Sentry.",
+          "shortDescription": "Envía un resumen diario de las incidencias críticas.",
+          "title": "Resumen de incidencias de Sentry"
+        },
+        "sort-gmail-draft-replies": {
+          "description": "Ordena tu bandeja de entrada y redacta las respuestas a los correos que las necesiten.",
+          "shortDescription": "Ordena la bandeja y redacta las respuestas.",
+          "title": "Ordena Gmail y redacta las respuestas"
+        },
+        "spot-churn-risk-stripe-zendesk": {
+          "description": "Marca cuentas en riesgo de abandono y redacta un correo de recuperación.",
+          "shortDescription": "Detecta riesgo de baja y redacta un correo.",
+          "title": "Detectar riesgo de abandono en Stripe y Zendesk"
+        },
+        "summarize-gmail-newsletters": {
+          "description": "Resume los boletines que tienes en tu bandeja de entrada en un breve resumen.",
+          "shortDescription": "Reúne tus newsletters en un solo resumen.",
+          "title": "Resumir boletines de Gmail"
+        },
+        "summarize-zendesk-tickets-daily": {
+          "description": "Resume los tickets de Zendesk del último día y publica el resultado en Slack.",
+          "shortDescription": "Publica un resumen diario de los tickets.",
+          "title": "Resumir diariamente los tickets de Zendesk"
+        },
+        "support-ticket-router": {
+          "description": "Clasifica los correos de soporte, crea registros en Notion y avisa en Slack de los tickets críticos.",
+          "shortDescription": "Clasifica los correos y marca los críticos.",
+          "title": "Enrutador de tickets de soporte"
+        },
+        "sync-asana-projects-notion": {
+          "description": "Reúne el estado de los proyectos de Asana en un único tablero de Notion.",
+          "shortDescription": "Reúne en Notion el estado de los proyectos de Asana.",
+          "title": "Sincronizar proyectos de Asana con Notion"
+        },
+        "sync-linear-roadmap-notion": {
+          "description": "Mantén una hoja de ruta de Notion sincronizada con el estado de las incidencias de Linear.",
+          "shortDescription": "Mantén la hoja de ruta de Notion al día con Linear.",
+          "title": "Sincronizar la hoja de ruta de Linear con Notion"
+        },
+        "track-feature-usage-posthog": {
+          "description": "Destaca los mayores cambios semanales en el uso de funciones según PostHog.",
+          "shortDescription": "Muestra los mayores cambios de uso de la semana.",
+          "title": "Seguir el uso de funciones con PostHog"
+        },
+        "track-keyword-ranks-ahrefs": {
+          "description": "Sigue las posiciones de tus palabras clave en Ahrefs y anota los mayores cambios en Notion.",
+          "shortDescription": "Informa de los cambios de posición de la semana.",
+          "title": "Seguir posiciones de palabras clave con Ahrefs"
+        },
+        "track-signup-sources-sheets": {
+          "description": "Atribuye cada nuevo registro a su fuente en una hoja de seguimiento.",
+          "shortDescription": "Atribuye cada registro a su origen en una hoja.",
+          "title": "Seguir las fuentes de registro en Google Sheets"
+        },
+        "vercel-deploy-digest": {
+          "description": "Vigila los despliegues de Vercel, enlázalos con los commits de GitHub y avisa en Slack de los fallos.",
+          "shortDescription": "Avisa en Slack si falla un despliegue de Vercel.",
+          "title": "Resumen de despliegues de Vercel"
+        },
+        "x-brand-monitor": {
+          "description": "Sigue las menciones de marca en X, guarda las publicaciones relevantes en Notion y avisa en Slack de las importantes.",
+          "shortDescription": "Avisa en Slack de las menciones fuertes en X.",
+          "title": "Monitor de marca en X"
+        },
+        "zendesk-knowledge-base": {
+          "description": "Encuentra las preguntas recurrentes de Zendesk, redacta entradas de FAQ y guárdalas en Notion.",
+          "shortDescription": "Convierte las preguntas repetidas en FAQ.",
+          "title": "Base de conocimiento de Zendesk"
+        }
+      },
+      "workflowCategories": {
+        "CEO": "CEO",
+        "Data": "Datos",
+        "Engineering": "Ingeniería",
+        "Everyone": "Todos",
+        "Marketing": "Marketing",
+        "Operations": "Operaciones",
+        "Product": "Producto",
+        "Sales": "Ventas",
+        "Support": "Soporte"
+      }
     },
     "title": "Artefactos",
     "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -686,7 +686,325 @@
       "useThisTemplate": "Utilisez ce modèle",
       "website": "Site web",
       "websitePreview": "Aperçu du modèle de site web {{title}}",
-      "workflow": "Workflow"
+      "workflow": "Workflow",
+      "workflowCatalog": {
+        "alert-metric-moves-slack": {
+          "description": "Surveillez vos indicateurs clés et alertez Slack lorsqu'un d'eux change brusquement.",
+          "shortDescription": "Alerte Slack quand une métrique clé bouge fort.",
+          "title": "Alerte lorsqu’une métrique bouge"
+        },
+        "auto-inbox-label": {
+          "description": "Créez un workflow qui se déclenche dès qu'un libellé Gmail est appliqué et traite le message concerné.",
+          "shortDescription": "Lance un workflow dès qu'un libellé Gmail est posé.",
+          "title": "Libellé de boîte de réception automatique"
+        },
+        "auto-merge-github-prs": {
+          "description": "Examiner les PR étiquetées prêtes à fusionner, attendre la CI, puis fusionner et publier sur Slack.",
+          "shortDescription": "Fusionne les PR prêtes une fois la CI passée.",
+          "title": "Fusion automatique des PR GitHub"
+        },
+        "blog-posts-to-x": {
+          "description": "Transformez chaque nouvel article de blog en variantes sociales dans la file Buffer.",
+          "shortDescription": "Transforme chaque nouvel article en posts sociaux.",
+          "title": "Transformer des articles de blog en publications sociales"
+        },
+        "build-weekly-deck-gamma": {
+          "description": "Transformez les métriques de la semaine en un diaporama prêt à présenter dans Gamma.",
+          "shortDescription": "Transforme les chiffres de la semaine en deck Gamma.",
+          "title": "Construire le diaporama hebdomadaire dans Gamma"
+        },
+        "business-review-gamma": {
+          "description": "Transformez les métriques du mois en un diaporama de revue d'entreprise dans Gamma.",
+          "shortDescription": "Transforme les chiffres du mois en deck de revue.",
+          "title": "Construire la revue de l'entreprise dans Gamma"
+        },
+        "catch-calendar-conflicts": {
+          "description": "Analyse votre agenda pour les doubles réservations et vous alerte à l'avance.",
+          "shortDescription": "Repère tôt les doubles réservations de l'agenda.",
+          "title": "Détecter les conflits dans Google Calendar"
+        },
+        "catch-leads-gmail": {
+          "description": "Repérer les signaux d'achat dans les nouveaux e-mails et enregistrer les prospects qualifiés.",
+          "shortDescription": "Repère les signaux d'achat et note les leads.",
+          "title": "Capturer les prospects depuis Gmail"
+        },
+        "chase-overdue-asana-tasks": {
+          "description": "Trouvez les tâches Asana en retard et relancez leurs responsables sur Slack.",
+          "shortDescription": "Relance les responsables des tâches Asana en retard.",
+          "title": "Poursuivre les tâches Asana en retard"
+        },
+        "check-posthog-signup-funnel": {
+          "description": "Suivez le tunnel d'inscription et publiez la plus grande perte sur Slack.",
+          "shortDescription": "Publie le plus gros décrochage du tunnel d'inscription.",
+          "title": "Vérifiez l'entonnoir d'inscription PostHog"
+        },
+        "clickup-slack-standup": {
+          "description": "Récupérez chaque matin les tâches ClickUp et publiez le standup de l'équipe dans Slack.",
+          "shortDescription": "Publie un standup du matin depuis ClickUp.",
+          "title": "Standup ClickUp dans Slack"
+        },
+        "compare-google-ads-last-month": {
+          "description": "Comparez les dépenses publicitaires et le ROAS au mois dernier et signalez les écarts dans Slack.",
+          "shortDescription": "Compare dépenses et ROAS au mois dernier.",
+          "title": "Comparer Google Ads au mois dernier"
+        },
+        "competitive-intel-monitor": {
+          "description": "Surveillez les prix et fonctionnalités des concurrents, consignez les trouvailles dans Notion et alertez Slack.",
+          "shortDescription": "Consigne les changements de prix des concurrents dans Notion.",
+          "title": "Veille concurrentielle"
+        },
+        "daily-company-brief-slack": {
+          "description": "Rassembler produit, croissance et revenus dans un briefing quotidien sur Slack.",
+          "shortDescription": "Réunit produit, croissance et revenus en un brief.",
+          "title": "Publier un briefing quotidien de l'entreprise sur Slack"
+        },
+        "daily-industry-news-slack": {
+          "description": "Regroupez les actualités pertinentes de l'industrie du jour dans un bref résumé sur Slack.",
+          "shortDescription": "Rassemble l'actu du secteur pour Slack.",
+          "title": "Publier quotidiennement les actualités de l'industrie sur Slack"
+        },
+        "daily-standup-report": {
+          "description": "Rassemblez chaque matin les signaux produit et ingénierie, rédigez un court rapport et publiez-le dans Slack.",
+          "shortDescription": "Publie chaque matin un brief produit et ingénierie.",
+          "title": "Rapport de standup quotidien"
+        },
+        "draft-github-release-notes-notion": {
+          "description": "Transformer les PR fusionnés depuis la dernière version en notes claires dans Notion.",
+          "shortDescription": "Transforme les PR fusionnées en notes de version Notion.",
+          "title": "Rédiger des notes de version GitHub dans Notion"
+        },
+        "draft-newsletter-mailchimp": {
+          "description": "Rassemblez les dernières actualités dans un brouillon de newsletter Mailchimp.",
+          "shortDescription": "Rassemble les actualités récentes en newsletter.",
+          "title": "Rédigez la newsletter dans Mailchimp"
+        },
+        "draft-replies-notion-faq": {
+          "description": "Rédigez les réponses aux tickets basées sur votre FAQ Notion.",
+          "shortDescription": "Rédige les réponses à partir de votre FAQ Notion.",
+          "title": "Réponses rédigées à partir de votre FAQ Notion"
+        },
+        "feedback-router": {
+          "description": "Surveillez un canal Slack et acheminez les retours produit vers Notion avec libellés et responsables.",
+          "shortDescription": "Achemine les retours produit de Slack vers Notion.",
+          "title": "Aiguillage des retours"
+        },
+        "file-gmail-invoices-drive": {
+          "description": "Classer les e-mails de factures dans Drive et consigner chacune dans une feuille.",
+          "shortDescription": "Classe les factures dans Drive et les consigne.",
+          "title": "Classer les factures Gmail sur Google Drive"
+        },
+        "file-sentry-crashes-github": {
+          "description": "Classez les nouvelles erreurs Sentry selon leur impact utilisateur et créez des issues GitHub pour les plus graves.",
+          "shortDescription": "Ouvre des issues GitHub pour les pires erreurs Sentry.",
+          "title": "Créer des issues GitHub à partir des erreurs Sentry"
+        },
+        "flag-figma-designs-no-task": {
+          "description": "Marquer les designs Figma qui n'ont pas encore de tâche Linear liée.",
+          "shortDescription": "Repère les designs Figma sans tâche Linear.",
+          "title": "Marquer les conceptions Figma sans tâche"
+        },
+        "flagged-gmail-todoist-tasks": {
+          "description": "Transformez automatiquement les e-mails que vous marquez en tâches Todoist.",
+          "shortDescription": "Transforme les e-mails suivis en tâches Todoist.",
+          "title": "Transformer les e-mails signalés de Gmail en tâches Todoist"
+        },
+        "github-idea-to-notion-spec": {
+          "description": "Développer une issue étiquetée sur GitHub en un cahier des charges structuré dans Notion.",
+          "shortDescription": "Développe une issue GitHub en spec Notion.",
+          "title": "Transformer une idée GitHub en spécification Notion"
+        },
+        "github-pr-summarizer": {
+          "description": "Rassemblez les pull requests fusionnées, enregistrez un rapport structuré dans Notion et publiez-le dans Slack si besoin.",
+          "shortDescription": "Rassemble les pull requests fusionnées en un rapport.",
+          "title": "Synthèse des PR GitHub"
+        },
+        "gmail-followups-auto": {
+          "description": "Trouver les contacts qui n'ont pas répondu et rédiger le prochain suivi.",
+          "shortDescription": "Rédige des relances pour les contacts sans réponse.",
+          "title": "Envoyer automatiquement les suivis Gmail"
+        },
+        "gmail-reconnect-reminders": {
+          "description": "Faites remonter les contacts importants que vous n'avez pas contactés par e-mail depuis un certain temps.",
+          "shortDescription": "Montre les contacts laissés sans nouvelles.",
+          "title": "Recevez des rappels pour renouer sur Gmail"
+        },
+        "highlight-key-emails-gmail": {
+          "description": "Faites remonter les quelques e-mails qui nécessitent réellement votre attention.",
+          "shortDescription": "Fait remonter les e-mails qui vous attendent.",
+          "title": "Met en évidence les emails clés dans Gmail"
+        },
+        "investor-update-google-docs": {
+          "description": "Assemble les métriques et les points forts dans une mise à jour pour les investisseurs dans Docs.",
+          "shortDescription": "Réunit les métriques en un update investisseurs.",
+          "title": "Rédiger la mise à jour pour les investisseurs dans Google Docs"
+        },
+        "log-gong-calls-hubspot": {
+          "description": "Extraire les notes et les prochaines étapes d'un appel Gong dans l'opportunité HubSpot.",
+          "shortDescription": "Verse les notes d'appel Gong dans l'affaire HubSpot.",
+          "title": "Log Gong appelle HubSpot"
+        },
+        "meeting-notes-asana-tasks": {
+          "description": "Transformez les notes de réunion en tâches assignées avec dates d'échéance dans Asana.",
+          "shortDescription": "Transforme les notes de réunion en tâches Asana.",
+          "title": "Transformez les notes de réunion en tâches Asana"
+        },
+        "meeting-recaps-slack": {
+          "description": "Partagez un récapitulatif avec les décisions et les actions à entreprendre après chaque réunion.",
+          "shortDescription": "Partage décisions et actions après les réunions.",
+          "title": "Recevez les récapitulatifs de réunion dans Slack"
+        },
+        "morning-brief": {
+          "description": "Transformez les nouveautés Gmail, Agenda et Notion en un court plan de journée dans Slack.",
+          "shortDescription": "Transforme e-mails et réunions en plan de journée.",
+          "title": "Brief du matin"
+        },
+        "new-gmail-contacts-hubspot": {
+          "description": "Ajoutez et enrichissez les expéditeurs de courriels inconnus en tant que contacts HubSpot.",
+          "shortDescription": "Ajoute les expéditeurs inconnus à HubSpot.",
+          "title": "Ajouter de nouveaux contacts Gmail à HubSpot"
+        },
+        "onboard-new-hires-asana": {
+          "description": "Créer la liste de contrôle des tâches d'intégration pour chaque nouvelle embauche dans Asana.",
+          "shortDescription": "Crée une checklist d'intégration par arrivée.",
+          "title": "Intégrer les nouvelles embauches dans Asana"
+        },
+        "personal-weekly-digest": {
+          "description": "Résumez votre activité GitHub, Gmail et Agenda dans une mise à jour hebdomadaire Slack.",
+          "shortDescription": "Résume votre semaine sur GitHub et Gmail.",
+          "title": "Synthèse hebdomadaire personnelle"
+        },
+        "post-daily-metrics-slack": {
+          "description": "Publier quotidiennement les chiffres de visiteurs, inscriptions et activations sur Slack.",
+          "shortDescription": "Publie visiteurs et inscriptions du jour dans Slack.",
+          "title": "Publier les métriques quotidiennes sur Slack"
+        },
+        "post-release-notes-slack": {
+          "description": "Rédiger un journal des modifications à partir du travail récemment livré et le publier sur Slack.",
+          "shortDescription": "Rédige un changelog et le publie dans Slack.",
+          "title": "Publier les notes de version sur Slack"
+        },
+        "prep-google-calendar-meetings": {
+          "description": "Rechercher les participants externes et envoyer un briefing avant les réunions.",
+          "shortDescription": "Envoie un brief avant les réunions externes.",
+          "title": "Préparation pour les réunions Google Calendar"
+        },
+        "publish-scheduled-posts-buffer": {
+          "description": "Publiez le contenu programmé du jour et mettez les publications sociales en file d'attente.",
+          "shortDescription": "Publie les posts sociaux programmés du jour.",
+          "title": "Publier les publications programmées dans Buffer"
+        },
+        "research-calendar-meetings": {
+          "description": "Recherchez les personnes que vous allez rencontrer avant chaque événement du calendrier.",
+          "shortDescription": "Étudie vos interlocuteurs avant chaque événement.",
+          "title": "Recherchez vos réunions du calendrier"
+        },
+        "research-new-signups-apollo": {
+          "description": "Recherchez chaque nouvelle inscription et publiez un aperçu rapide.",
+          "shortDescription": "Étudie chaque nouvelle inscription et la publie.",
+          "title": "Rechercher de nouvelles inscriptions"
+        },
+        "revenuecat-subscription-digest": {
+          "description": "Suivez les abonnements dans Sheets et alertez Slack quand les résiliations ou le churn évoluent.",
+          "shortDescription": "Suit les abonnements et alerte Slack sur le churn.",
+          "title": "Synthèse des abonnements RevenueCat"
+        },
+        "run-daily-query-sheets": {
+          "description": "Exécutez votre SQL enregistré selon un planning et ajoutez les résultats à une feuille.",
+          "shortDescription": "Exécute un SQL enregistré et l'ajoute à une feuille.",
+          "title": "Exécuter une requête quotidienne dans Google Sheets"
+        },
+        "salesforce-pipeline-digest": {
+          "description": "Résumez chaque semaine dans Slack les changements d'opportunités Salesforce et les risques de date de clôture.",
+          "shortDescription": "Résume chaque semaine les risques du pipeline.",
+          "title": "Synthèse du pipeline Salesforce"
+        },
+        "send-bugs-github-slack": {
+          "description": "Créez des issues GitHub à partir des rapports portant l’étiquette bug et alertez l’équipe sur Slack.",
+          "shortDescription": "Ouvre les rapports de bug en issues GitHub.",
+          "title": "Envoyez les bugs sur GitHub et Slack"
+        },
+        "sentry-issue-digest": {
+          "description": "Envoyez chaque jour dans Slack une synthèse des incidents Sentry critiques et graves.",
+          "shortDescription": "Envoie chaque jour les incidents Sentry critiques.",
+          "title": "Synthèse des incidents Sentry"
+        },
+        "sort-gmail-draft-replies": {
+          "description": "Triez votre boîte de réception et rédigez des réponses aux e-mails qui en ont besoin.",
+          "shortDescription": "Trie la boîte de réception et rédige les réponses.",
+          "title": "Trier Gmail et rédiger des réponses"
+        },
+        "spot-churn-risk-stripe-zendesk": {
+          "description": "Signaler les comptes à risque de perte et rédiger un e-mail de récupération.",
+          "shortDescription": "Signale un risque de churn et rédige un e-mail.",
+          "title": "Identifier le risque de désabonnement dans Stripe et Zendesk"
+        },
+        "summarize-gmail-newsletters": {
+          "description": "Résumer les newsletters dans votre boîte de réception en un court résumé.",
+          "shortDescription": "Condense vos newsletters en un seul résumé.",
+          "title": "Résumer les newsletters Gmail"
+        },
+        "summarize-zendesk-tickets-daily": {
+          "description": "Résumer les tickets Zendesk de la dernière journée et les publier sur Slack.",
+          "shortDescription": "Publie chaque jour un résumé des tickets Zendesk.",
+          "title": "Résumer les tickets Zendesk quotidiennement"
+        },
+        "support-ticket-router": {
+          "description": "Classez les e-mails de support, créez les fiches Notion et alertez Slack pour les tickets critiques.",
+          "shortDescription": "Classe les e-mails de support et signale les urgences.",
+          "title": "Aiguillage des tickets de support"
+        },
+        "sync-asana-projects-notion": {
+          "description": "Synthétiser le statut des projets Asana en un seul tableau dans Notion.",
+          "shortDescription": "Consolide l'état des projets Asana dans Notion.",
+          "title": "Synchroniser les projets Asana avec Notion"
+        },
+        "sync-linear-roadmap-notion": {
+          "description": "Maintenir une feuille de route Notion synchronisée avec l'état des tickets Linear.",
+          "shortDescription": "Garde une roadmap Notion alignée sur Linear.",
+          "title": "Synchroniser la roadmap Linear avec Notion"
+        },
+        "track-feature-usage-posthog": {
+          "description": "Mettre en évidence les plus grands changements hebdomadaires dans l'utilisation des fonctionnalités depuis PostHog.",
+          "shortDescription": "Montre les plus gros écarts d'usage de la semaine.",
+          "title": "Suivre l'utilisation des fonctionnalités avec PostHog"
+        },
+        "track-keyword-ranks-ahrefs": {
+          "description": "Suivez les positions de vos mots-clés dans Ahrefs et consignez les plus gros mouvements dans Notion.",
+          "shortDescription": "Rapporte les mouvements de positions de la semaine.",
+          "title": "Suivre les classements des mots-clés avec Ahrefs"
+        },
+        "track-signup-sources-sheets": {
+          "description": "Attribuer chaque nouvelle inscription à sa source dans une feuille de suivi.",
+          "shortDescription": "Rattache chaque inscription à sa source dans une feuille.",
+          "title": "Suivez les sources d'inscription dans Google Sheets"
+        },
+        "vercel-deploy-digest": {
+          "description": "Surveillez les déploiements Vercel, reliez-les aux commits GitHub et signalez les échecs dans Slack.",
+          "shortDescription": "Alerte Slack quand un déploiement Vercel échoue.",
+          "title": "Synthèse des déploiements Vercel"
+        },
+        "x-brand-monitor": {
+          "description": "Suivez les mentions de la marque sur X, gardez les publications utiles dans Notion et alertez Slack sur les plus fortes.",
+          "shortDescription": "Alerte Slack sur les fortes mentions de marque sur X.",
+          "title": "Veille de marque sur X"
+        },
+        "zendesk-knowledge-base": {
+          "description": "Repérez les questions récurrentes dans Zendesk, rédigez des entrées de FAQ et enregistrez-les dans Notion.",
+          "shortDescription": "Transforme les questions récurrentes en FAQ.",
+          "title": "Base de connaissances Zendesk"
+        }
+      },
+      "workflowCategories": {
+        "CEO": "CEO",
+        "Data": "Données",
+        "Engineering": "Ingénierie",
+        "Everyone": "Tout le monde",
+        "Marketing": "Marketing",
+        "Operations": "Opérations",
+        "Product": "Produit",
+        "Sales": "Ventes",
+        "Support": "Support"
+      }
     },
     "title": "Artéfacts",
     "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -669,7 +669,325 @@
       "useThisTemplate": "इस टेम्पलेट का उपयोग करें",
       "website": "वेबसाइट",
       "websitePreview": "{{title}} वेबसाइट टेम्पलेट पूर्वावलोकन",
-      "workflow": "वर्कफ़्लो"
+      "workflow": "वर्कफ़्लो",
+      "workflowCatalog": {
+        "alert-metric-moves-slack": {
+          "description": "अपने प्रमुख मेट्रिक्स देखें और जब कोई तेजी से आगे बढ़े तो Slack को सचेत करें।",
+          "shortDescription": "मुख्य मेट्रिक तेज़ी से बदलने पर Slack में बताएँ।",
+          "title": "जब कोई मीट्रिक बदलता है तो अलर्ट करें"
+        },
+        "auto-inbox-label": {
+          "description": "ऐसा वर्कफ़्लो बनाएँ जो Gmail लेबल लगते ही चले और उस ईमेल को संभाले।",
+          "shortDescription": "Gmail लेबल लगाते ही वर्कफ़्लो चलाएँ।",
+          "title": "इनबॉक्स लेबल पर स्वचालित काम"
+        },
+        "auto-merge-github-prs": {
+          "description": "विलय के लिए तैयार लेबल वाले पीआर की समीक्षा करें, CI की प्रतीक्षा करें, फिर विलय करें और Slack पर पोस्ट करें।",
+          "shortDescription": "CI पास होते ही तैयार PR मर्ज करें।",
+          "title": "ऑटो-मर्ज GitHub PRs"
+        },
+        "blog-posts-to-x": {
+          "description": "हर नए ब्लॉग पोस्ट को सोशल वर्ज़न में बदलकर Buffer की कतार में डालें।",
+          "shortDescription": "हर नए ब्लॉग पोस्ट को सोशल पोस्ट में बदलें।",
+          "title": "ब्लॉग पोस्ट को सोशल पोस्ट में बदलें"
+        },
+        "build-weekly-deck-gamma": {
+          "description": "सप्ताह के मेट्रिक्स को गामा में प्रस्तुत करने के लिए तैयार डेक में बदलें।",
+          "shortDescription": "हफ़्ते के आंकड़ों से Gamma डेक बनाएँ।",
+          "title": "गामा में साप्ताहिक डेक बनाएं"
+        },
+        "business-review-gamma": {
+          "description": "महीने के मेट्रिक्स को गामा में व्यावसायिक समीक्षा डेक में बदलें।",
+          "shortDescription": "महीने के आंकड़ों से रिव्यू डेक बनाएँ।",
+          "title": "गामा में व्यवसाय समीक्षा बनाएं"
+        },
+        "catch-calendar-conflicts": {
+          "description": "डबल-बुकिंग के लिए अपने कैलेंडर को स्कैन करें और आपको पहले ही सचेत कर दें।",
+          "shortDescription": "कैलेंडर की डबल-बुकिंग समय रहते पकड़ें।",
+          "title": "Google Calendar संघर्षों को पकड़ें"
+        },
+        "catch-leads-gmail": {
+          "description": "नए ईमेल में स्पॉट खरीदारी संकेत और योग्य लीड लॉग करें।",
+          "shortDescription": "खरीद के संकेत पहचानें और लीड दर्ज करें।",
+          "title": "Gmail से लीड पकड़ें"
+        },
+        "chase-overdue-asana-tasks": {
+          "description": "अतिदेय आसन कार्यों को खोजें और Slack पर उनके मालिकों को प्रेरित करें।",
+          "shortDescription": "देर से चल रहे Asana टास्क के मालिकों को याद दिलाएँ।",
+          "title": "अतिदेय Asana कार्यों का पीछा करें"
+        },
+        "check-posthog-signup-funnel": {
+          "description": "साइनअप फ़नल को ट्रैक करें और Slack पर सबसे बड़ा ड्रॉप-ऑफ़ पोस्ट करें।",
+          "shortDescription": "साइनअप फ़नल का सबसे बड़ा ड्रॉप-ऑफ़ बताएँ।",
+          "title": "PostHog साइनअप फ़नल की जाँच करें"
+        },
+        "clickup-slack-standup": {
+          "description": "हर सुबह ClickUp के टास्क लेकर टीम का स्टैंडअप सारांश Slack पर पोस्ट करें।",
+          "shortDescription": "ClickUp टास्क से सुबह का स्टैंडअप पोस्ट करें।",
+          "title": "ClickUp का Slack स्टैंडअप"
+        },
+        "compare-google-ads-last-month": {
+          "description": "विज्ञापन खर्च और ROAS की पिछले महीने से तुलना करें और गड़बड़ी Slack में बताएँ।",
+          "shortDescription": "विज्ञापन खर्च और ROAS की पिछले महीने से तुलना करें।",
+          "title": "Google विज्ञापनों की तुलना पिछले महीने से करें"
+        },
+        "competitive-intel-monitor": {
+          "description": "प्रतिस्पर्धियों की साइट पर कीमत और फ़ीचर बदलाव देखें, Notion में सहेजें और Slack में सूचित करें।",
+          "shortDescription": "प्रतिस्पर्धियों के कीमत बदलाव Notion में दर्ज करें।",
+          "title": "प्रतिस्पर्धी निगरानी"
+        },
+        "daily-company-brief-slack": {
+          "description": "Slack पर उत्पाद, विकास और राजस्व को दैनिक संक्षिप्त में शामिल करें।",
+          "shortDescription": "प्रोडक्ट, ग्रोथ और रेवेन्यू एक ब्रीफ़ में लाएँ।",
+          "title": "Slack पर दैनिक कंपनी संक्षिप्त पोस्ट करें"
+        },
+        "daily-industry-news-slack": {
+          "description": "दिन भर की प्रासंगिक उद्योग समाचारों को Slack संक्षिप्त में सारांशित करें।",
+          "shortDescription": "दिन की इंडस्ट्री खबरें Slack के लिए जुटाएँ।",
+          "title": "Slack पर दैनिक उद्योग समाचार पोस्ट करें"
+        },
+        "daily-standup-report": {
+          "description": "हर सुबह प्रोडक्ट और इंजीनियरिंग के आंकड़े जुटाएँ, छोटी रिपोर्ट बनाएँ और Slack पर पोस्ट करें।",
+          "shortDescription": "हर सुबह प्रोडक्ट और इंजीनियरिंग ब्रीफ़ पोस्ट करें।",
+          "title": "दैनिक स्टैंडअप रिपोर्ट"
+        },
+        "draft-github-release-notes-notion": {
+          "description": "पिछली रिलीज के बाद से मर्ज किए गए पीआर को Notion में साफ नोट्स में बदलें।",
+          "shortDescription": "मर्ज हुए PR को Notion में रिलीज़ नोट्स बनाएँ।",
+          "title": "Notion में GitHub रिलीज़ नोट का ड्राफ्ट तैयार करें"
+        },
+        "draft-newsletter-mailchimp": {
+          "description": "हाल के अपडेट जोड़कर Mailchimp में न्यूज़लेटर का ड्राफ़्ट बनाएँ।",
+          "shortDescription": "हाल के अपडेट को एक न्यूज़लेटर में जोड़ें।",
+          "title": "Mailchimp में न्यूज़लेटर का ड्राफ्ट तैयार करें"
+        },
+        "draft-replies-notion-faq": {
+          "description": "ड्राफ्ट टिकट के उत्तर आपके Notion FAQ पर आधारित हैं।",
+          "shortDescription": "Notion FAQ से टिकट के जवाब लिखें।",
+          "title": "आपके Notion FAQ से ड्राफ्ट उत्तर तैयार करें"
+        },
+        "feedback-router": {
+          "description": "किसी Slack चैनल पर नज़र रखें और प्रोडक्ट फ़ीडबैक को लेबल व ज़िम्मेदार के साथ Notion में भेजें।",
+          "shortDescription": "Slack से प्रोडक्ट फ़ीडबैक Notion में भेजें।",
+          "title": "फ़ीडबैक राउटर"
+        },
+        "file-gmail-invoices-drive": {
+          "description": "इनवॉइस ईमेल को ड्राइव में फ़ाइल करें और प्रत्येक को एक शीट में लॉग करें।",
+          "shortDescription": "इनवॉइस ईमेल Drive में रखें और दर्ज करें।",
+          "title": "Gmail चालान को Google Drive पर फ़ाइल करें"
+        },
+        "file-sentry-crashes-github": {
+          "description": "उपयोगकर्ता प्रभाव के आधार पर नई सेंट्री त्रुटियों को रैंक करें और सबसे खराब को GitHub इश्यू के रूप में दर्ज करें।",
+          "shortDescription": "सबसे गंभीर Sentry त्रुटियाँ GitHub इश्यू बनाएँ।",
+          "title": "सेंट्री क्रैश को GitHub इश्यू के रूप में फ़ाइल करें"
+        },
+        "flag-figma-designs-no-task": {
+          "description": "फिग्मा डिज़ाइनों को फ़्लैग करें जिनमें अभी तक कोई रैखिक कार्य नहीं जुड़ा है।",
+          "shortDescription": "बिना Linear टास्क वाले Figma डिज़ाइन बताएँ।",
+          "title": "बिना किसी कार्य के फिग्मा डिज़ाइन को फ़्लैग करें"
+        },
+        "flagged-gmail-todoist-tasks": {
+          "description": "आपके द्वारा फ़्लैग किए गए ईमेल को स्वचालित रूप से टोडोइस्ट कार्यों में बदल दें।",
+          "shortDescription": "चिह्नित ईमेल को Todoist टास्क बनाएँ।",
+          "title": "ध्वजांकित Gmail को टोडोइस्ट कार्यों में बदलें"
+        },
+        "github-idea-to-notion-spec": {
+          "description": "Notion में एक संरचित उत्पाद स्पेक में लेबल किए गए GitHub इश्यू का विस्तार करें।",
+          "shortDescription": "GitHub इश्यू को Notion स्पेक में बदलें।",
+          "title": "एक GitHub विचार को Notion स्पेक में बदलें"
+        },
+        "github-pr-summarizer": {
+          "description": "मर्ज हुए पुल रिक्वेस्ट जुटाएँ, Notion में व्यवस्थित रिपोर्ट सहेजें और चाहें तो Slack पर भी पोस्ट करें।",
+          "shortDescription": "मर्ज हुए पुल रिक्वेस्ट को एक रिपोर्ट में जोड़ें।",
+          "title": "GitHub PR सारांश"
+        },
+        "gmail-followups-auto": {
+          "description": "उन संपर्कों को ढूंढें जिन्होंने उत्तर नहीं दिया और अगली अनुवर्ती कार्रवाई का मसौदा तैयार करें।",
+          "shortDescription": "जवाब न देने वालों के लिए फ़ॉलो-अप लिखें।",
+          "title": "Gmail फॉलो-अप स्वचालित रूप से भेजें"
+        },
+        "gmail-reconnect-reminders": {
+          "description": "उन महत्वपूर्ण संपर्कों को सामने लाएँ जिन्हें आपने कुछ समय से ईमेल नहीं किया है।",
+          "shortDescription": "जिन्हें लंबे समय से नहीं लिखा, उन्हें दिखाएँ।",
+          "title": "Gmail पुन: कनेक्ट अनुस्मारक प्राप्त करें"
+        },
+        "highlight-key-emails-gmail": {
+          "description": "कुछ ऐसे ईमेल सामने लाएँ जिन पर वास्तव में आपका ध्यान चाहिए।",
+          "shortDescription": "जिन ईमेल पर ध्यान चाहिए, उन्हें सामने लाएँ।",
+          "title": "Gmail में प्रमुख ईमेल हाइलाइट करें"
+        },
+        "investor-update-google-docs": {
+          "description": "डॉक्स में निवेशक अपडेट में मेट्रिक्स और हाइलाइट्स को इकट्ठा करें।",
+          "shortDescription": "आंकड़े जोड़कर निवेशक अपडेट तैयार करें।",
+          "title": "Google डॉक्स में निवेशक अपडेट ड्राफ्ट करें"
+        },
+        "log-gong-calls-hubspot": {
+          "description": "HubSpot डील में गोंग कॉल से नोट्स और अगले चरण निकालें।",
+          "shortDescription": "Gong कॉल नोट्स HubSpot डील में जोड़ें।",
+          "title": "गोंग कॉल को HubSpot पर लॉग करें"
+        },
+        "meeting-notes-asana-tasks": {
+          "description": "मीटिंग नोट्स को असाइन किए गए, नियत तिथियों वाले कार्यों में Asana में बदलें।",
+          "shortDescription": "मीटिंग नोट्स को Asana टास्क में बदलें।",
+          "title": "मीटिंग नोट्स को Asana कार्यों में बदलें"
+        },
+        "meeting-recaps-slack": {
+          "description": "प्रत्येक बैठक के बाद निर्णयों और कार्रवाई मदों का सारांश साझा करें।",
+          "shortDescription": "मीटिंग के बाद फ़ैसले और काम साझा करें।",
+          "title": "Slack में मीटिंग पुनर्कथन प्राप्त करें"
+        },
+        "morning-brief": {
+          "description": "Gmail, कैलेंडर और Notion के अपडेट को Slack पर दिन की छोटी योजना में बदलें।",
+          "shortDescription": "मेल और मीटिंग से दिन की छोटी योजना बनाएँ।",
+          "title": "सुबह की ब्रीफ़"
+        },
+        "new-gmail-contacts-hubspot": {
+          "description": "अज्ञात ईमेल प्रेषकों को HubSpot संपर्कों के रूप में जोड़ें और समृद्ध करें।",
+          "shortDescription": "अनजान ईमेल भेजने वालों को HubSpot में जोड़ें।",
+          "title": "HubSpot में नए Gmail संपर्क जोड़ें"
+        },
+        "onboard-new-hires-asana": {
+          "description": "आसन में प्रत्येक नए कर्मचारी के लिए ऑनबोर्डिंग कार्य चेकलिस्ट बनाएं।",
+          "shortDescription": "हर नई भर्ती के लिए ऑनबोर्डिंग चेकलिस्ट बनाएँ।",
+          "title": "Asana में नए कर्मचारियों को शामिल करें"
+        },
+        "personal-weekly-digest": {
+          "description": "GitHub, Gmail और कैलेंडर की गतिविधि को एक साप्ताहिक Slack अपडेट में समेटें।",
+          "shortDescription": "GitHub और Gmail से अपने हफ़्ते का सार बनाएँ।",
+          "title": "व्यक्तिगत साप्ताहिक डाइजेस्ट"
+        },
+        "post-daily-metrics-slack": {
+          "description": "Slack पर दैनिक विज़िटर, साइनअप और सक्रियण संख्या पोस्ट करें।",
+          "shortDescription": "रोज़ के विज़िटर और साइनअप Slack पर पोस्ट करें।",
+          "title": "Slack पर दैनिक मेट्रिक्स पोस्ट करें"
+        },
+        "post-release-notes-slack": {
+          "description": "हाल ही में भेजे गए कार्य से एक चेंजलॉग ड्राफ्ट करें और इसे Slack पर पोस्ट करें।",
+          "shortDescription": "चेंजलॉग लिखकर Slack पर पोस्ट करें।",
+          "title": "Slack पर रिलीज़ नोट्स पोस्ट करें"
+        },
+        "prep-google-calendar-meetings": {
+          "description": "बाहरी उपस्थित लोगों पर शोध करें और बैठकों से पहले तैयारी का विवरण भेजें।",
+          "shortDescription": "बाहरी मीटिंग से पहले तैयारी ब्रीफ़ भेजें।",
+          "title": "Google Calendar बैठकों के लिए तैयारी"
+        },
+        "publish-scheduled-posts-buffer": {
+          "description": "दिन का शेड्यूल किया गया कंटेंट प्रकाशित करें और सोशल पोस्ट कतार में लगाएँ।",
+          "shortDescription": "आज शेड्यूल किए सोशल पोस्ट प्रकाशित करें।",
+          "title": "बफ़र पर निर्धारित पोस्ट प्रकाशित करें"
+        },
+        "research-calendar-meetings": {
+          "description": "प्रत्येक कैलेंडर ईवेंट से पहले उन लोगों पर शोध करें जिनसे आप मिल रहे हैं।",
+          "shortDescription": "हर मीटिंग से पहले लोगों के बारे में जानें।",
+          "title": "अपनी कैलेंडर बैठकों पर शोध करें"
+        },
+        "research-new-signups-apollo": {
+          "description": "प्रत्येक नए साइनअप पर शोध करें और एक त्वरित स्नैपशॉट पोस्ट करें।",
+          "shortDescription": "हर नए साइनअप पर शोध कर ब्योरा पोस्ट करें।",
+          "title": "नए साइनअप पर शोध करें"
+        },
+        "revenuecat-subscription-digest": {
+          "description": "Sheets में सब्सक्रिप्शन ट्रैक करें और चर्न या कैंसिलेशन का पैटर्न बदलने पर Slack में सूचित करें।",
+          "shortDescription": "सब्सक्रिप्शन ट्रैक करें, चर्न पर Slack में बताएँ।",
+          "title": "RevenueCat सब्सक्रिप्शन डाइजेस्ट"
+        },
+        "run-daily-query-sheets": {
+          "description": "अपने सहेजे गए SQL को एक शेड्यूल पर चलाएं और परिणामों को एक शीट में जोड़ें।",
+          "shortDescription": "सहेजा SQL चलाकर नतीजे शीट में जोड़ें।",
+          "title": "Google शीट्स में दैनिक क्वेरी चलाएँ"
+        },
+        "salesforce-pipeline-digest": {
+          "description": "हर हफ़्ते Salesforce अवसरों के बदलाव और क्लोज़ डेट के जोखिम Slack में बताएँ।",
+          "shortDescription": "हर हफ़्ते Salesforce पाइपलाइन के जोखिम बताएँ।",
+          "title": "Salesforce पाइपलाइन डाइजेस्ट"
+        },
+        "send-bugs-github-slack": {
+          "description": "GitHub इश्यू के रूप में बग-टैग की गई रिपोर्ट दर्ज करें और Slack पर टीम को सचेत करें।",
+          "shortDescription": "बग रिपोर्ट GitHub इश्यू के रूप में दर्ज करें।",
+          "title": "GitHub और Slack पर बग भेजें"
+        },
+        "sentry-issue-digest": {
+          "description": "गंभीर और उच्च प्राथमिकता वाले Sentry इश्यू का रोज़ाना सारांश Slack पर भेजें।",
+          "shortDescription": "गंभीर Sentry इश्यू का रोज़ाना सारांश भेजें।",
+          "title": "Sentry इश्यू डाइजेस्ट"
+        },
+        "sort-gmail-draft-replies": {
+          "description": "अपने इनबॉक्स को क्रमबद्ध करें और उन ईमेल के उत्तर ड्राफ्ट करें जिन्हें उनकी आवश्यकता है।",
+          "shortDescription": "इनबॉक्स छाँटें और ज़रूरी जवाब लिखें।",
+          "title": "Gmail को क्रमबद्ध करें और उत्तरों का मसौदा तैयार करें"
+        },
+        "spot-churn-risk-stripe-zendesk": {
+          "description": "मंथन के जोखिम वाले खातों को चिह्नित करें और एक पुनर्प्राप्ति ईमेल का मसौदा तैयार करें।",
+          "shortDescription": "चर्न जोखिम बताएँ और वापसी ईमेल लिखें।",
+          "title": "स्ट्राइप और ज़ेंडेस्क में मंथन जोखिम को पहचानें"
+        },
+        "summarize-gmail-newsletters": {
+          "description": "अपने इनबॉक्स में मौजूद न्यूज़लेटर्स को एक संक्षिप्त सारांश में समेटें।",
+          "shortDescription": "अपने न्यूज़लेटर एक सारांश में समेटें।",
+          "title": "Gmail न्यूज़लेटर्स का सारांश प्रस्तुत करें"
+        },
+        "summarize-zendesk-tickets-daily": {
+          "description": "ज़ेंडेस्क टिकटों के अंतिम दिन का सारांश बनाएं और इसे Slack पर पोस्ट करें।",
+          "shortDescription": "Zendesk टिकट का रोज़ाना सारांश पोस्ट करें।",
+          "title": "प्रतिदिन ज़ेंडेस्क टिकटों का सारांश बनाएं"
+        },
+        "support-ticket-router": {
+          "description": "सपोर्ट ईमेल वर्गीकृत करें, Notion में रिकॉर्ड बनाएँ और गंभीर टिकट पर Slack में सूचित करें।",
+          "shortDescription": "सपोर्ट ईमेल छाँटें और गंभीर मामले चिह्नित करें।",
+          "title": "सपोर्ट टिकट राउटर"
+        },
+        "sync-asana-projects-notion": {
+          "description": "आसन परियोजना की स्थिति को Notion में एक ही बोर्ड में रोल अप करें।",
+          "shortDescription": "Asana प्रोजेक्ट की स्थिति Notion में समेटें।",
+          "title": "आसन परियोजनाओं को Notion में सिंक करें"
+        },
+        "sync-linear-roadmap-notion": {
+          "description": "Notion रोडमैप को अपनी रैखिक समस्या स्थिति के साथ समन्वयित रखें।",
+          "shortDescription": "Notion रोडमैप को Linear के साथ मिलाकर रखें।",
+          "title": "Linear रोडमैप को Notion में सिंक करें"
+        },
+        "track-feature-usage-posthog": {
+          "description": "PostHog से फीचर उपयोग में सबसे बड़ा साप्ताहिक बदलाव सामने आया।",
+          "shortDescription": "इस हफ़्ते उपयोग में सबसे बड़े बदलाव दिखाएँ।",
+          "title": "PostHog के साथ फीचर उपयोग को ट्रैक करें"
+        },
+        "track-keyword-ranks-ahrefs": {
+          "description": "Ahrefs में कीवर्ड रैंकिंग ट्रैक करें और सबसे बड़े बदलाव Notion में दर्ज करें।",
+          "shortDescription": "इस हफ़्ते की कीवर्ड रैंक हलचल बताएँ।",
+          "title": "Ahrefs के साथ कीवर्ड रैंक ट्रैक करें"
+        },
+        "track-signup-sources-sheets": {
+          "description": "ट्रैकिंग शीट में प्रत्येक नए साइनअप को उसके स्रोत से जोड़ें।",
+          "shortDescription": "हर साइनअप का स्रोत शीट में दर्ज करें।",
+          "title": "Google शीट्स में साइनअप स्रोत ट्रैक करें"
+        },
+        "vercel-deploy-digest": {
+          "description": "Vercel डिप्लॉयमेंट पर नज़र रखें, उन्हें GitHub कमिट से जोड़ें और विफलता पर Slack में सूचित करें।",
+          "shortDescription": "Vercel डिप्लॉय विफल होने पर Slack में बताएँ।",
+          "title": "Vercel डिप्लॉय डाइजेस्ट"
+        },
+        "x-brand-monitor": {
+          "description": "X पर ब्रांड के ज़िक्र ट्रैक करें, अहम पोस्ट Notion में सहेजें और बड़े ज़िक्र पर Slack में सूचित करें।",
+          "shortDescription": "X पर बड़े ब्रांड ज़िक्र की सूचना Slack में दें।",
+          "title": "X पर ब्रांड निगरानी"
+        },
+        "zendesk-knowledge-base": {
+          "description": "Zendesk में बार-बार आने वाले सवाल खोजें, FAQ प्रविष्टियाँ लिखें और Notion में सहेजें।",
+          "shortDescription": "बार-बार आने वाले सवालों को FAQ बनाएँ।",
+          "title": "Zendesk नॉलेज बेस"
+        }
+      },
+      "workflowCategories": {
+        "CEO": "CEO",
+        "Data": "डेटा",
+        "Engineering": "इंजीनियरिंग",
+        "Everyone": "सभी",
+        "Marketing": "मार्केटिंग",
+        "Operations": "ऑपरेशंस",
+        "Product": "प्रोडक्ट",
+        "Sales": "सेल्स",
+        "Support": "सपोर्ट"
+      }
     },
     "title": "आर्टिफ़ैक्ट",
     "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -669,7 +669,325 @@
       "useThisTemplate": "Gunakan template ini",
       "website": "Website",
       "websitePreview": "pratinjau template website {{title}}",
-      "workflow": "Alur kerja"
+      "workflow": "Alur kerja",
+      "workflowCatalog": {
+        "alert-metric-moves-slack": {
+          "description": "Pantau metrik utama Anda dan beri peringatan ke Slack saat salah satunya berubah tajam.",
+          "shortDescription": "Beri tahu Slack saat metrik kunci bergerak tajam.",
+          "title": "Beri peringatan saat metrik berubah"
+        },
+        "auto-inbox-label": {
+          "description": "Buat alur kerja yang berjalan saat label Gmail dipasang dan menangani email berlabel itu.",
+          "shortDescription": "Jalankan alur kerja saat Anda memasang label Gmail.",
+          "title": "Label inbox otomatis"
+        },
+        "auto-merge-github-prs": {
+          "description": "Tinjau PR berlabel siap-merge, tunggu CI, lalu merge dan kirim ke Slack.",
+          "shortDescription": "Merge PR yang siap begitu CI lolos.",
+          "title": "Auto-merge PR GitHub"
+        },
+        "blog-posts-to-x": {
+          "description": "Ubah tiap artikel blog baru menjadi versi sosial di antrean Buffer.",
+          "shortDescription": "Ubah tiap artikel blog baru jadi post sosial.",
+          "title": "Ubah posting blog menjadi posting sosial"
+        },
+        "build-weekly-deck-gamma": {
+          "description": "Ubah metrik minggu ini menjadi deck siap presentasi di Gamma.",
+          "shortDescription": "Ubah metrik minggu ini jadi deck Gamma.",
+          "title": "Buat deck mingguan di Gamma"
+        },
+        "business-review-gamma": {
+          "description": "Ubah metrik bulan ini menjadi deck tinjauan bisnis di Gamma.",
+          "shortDescription": "Ubah metrik bulan ini jadi deck review.",
+          "title": "Buat tinjauan bisnis di Gamma"
+        },
+        "catch-calendar-conflicts": {
+          "description": "Pindai kalender Anda untuk jadwal ganda dan beri tahu lebih awal.",
+          "shortDescription": "Temukan jadwal ganda di kalender lebih awal.",
+          "title": "Deteksi konflik Google Calendar"
+        },
+        "catch-leads-gmail": {
+          "description": "Temukan sinyal pembelian di email baru dan catat lead yang memenuhi syarat.",
+          "shortDescription": "Kenali sinyal beli dan catat lead yang layak.",
+          "title": "Tangkap lead dari Gmail"
+        },
+        "chase-overdue-asana-tasks": {
+          "description": "Temukan tugas Asana yang terlambat dan ingatkan pemiliknya di Slack.",
+          "shortDescription": "Ingatkan pemilik tugas Asana yang lewat tenggat.",
+          "title": "Tindaklanjuti tugas Asana yang terlambat"
+        },
+        "check-posthog-signup-funnel": {
+          "description": "Pantau alur pendaftaran dan kirim penurunan terbesar ke Slack.",
+          "shortDescription": "Posting titik drop-off terbesar di funnel signup.",
+          "title": "Periksa alur pendaftaran PostHog"
+        },
+        "clickup-slack-standup": {
+          "description": "Ambil tugas ClickUp tiap pagi dan posting ringkasan standup tim ke Slack.",
+          "shortDescription": "Posting standup pagi dari tugas ClickUp.",
+          "title": "Standup ClickUp di Slack"
+        },
+        "compare-google-ads-last-month": {
+          "description": "Bandingkan belanja iklan dan ROAS dengan bulan lalu, lalu tandai anomalinya di Slack.",
+          "shortDescription": "Bandingkan belanja iklan dan ROAS dengan bulan lalu.",
+          "title": "Bandingkan Google Ads vs bulan lalu"
+        },
+        "competitive-intel-monitor": {
+          "description": "Pantau perubahan harga dan fitur di situs kompetitor, simpan temuannya di Notion, dan beri tahu Slack.",
+          "shortDescription": "Catat perubahan harga kompetitor di Notion.",
+          "title": "Pemantau kompetitor"
+        },
+        "daily-company-brief-slack": {
+          "description": "Tarik produk, pertumbuhan, dan pendapatan ke ringkasan harian di Slack.",
+          "shortDescription": "Satukan produk, pertumbuhan, dan pendapatan jadi ringkasan.",
+          "title": "Kirim ringkasan harian perusahaan ke Slack"
+        },
+        "daily-industry-news-slack": {
+          "description": "Kumpulkan berita industri relevan hari ini menjadi ringkasan Slack.",
+          "shortDescription": "Rangkum berita industri hari itu untuk Slack.",
+          "title": "Kirim berita industri harian ke Slack"
+        },
+        "daily-standup-report": {
+          "description": "Kumpulkan sinyal produk dan engineering tiap pagi, buat laporan singkat, lalu posting ke Slack.",
+          "shortDescription": "Posting ringkasan produk dan engineering tiap pagi.",
+          "title": "Laporan standup harian"
+        },
+        "draft-github-release-notes-notion": {
+          "description": "Ubah PR yang digabung sejak rilis terakhir menjadi catatan yang rapi di Notion.",
+          "shortDescription": "Ubah PR yang di-merge jadi catatan rilis di Notion.",
+          "title": "Susun catatan rilis GitHub di Notion"
+        },
+        "draft-newsletter-mailchimp": {
+          "description": "Rangkum update terbaru menjadi draf newsletter di Mailchimp.",
+          "shortDescription": "Rangkum update terbaru jadi satu newsletter.",
+          "title": "Buat draf newsletter di Mailchimp"
+        },
+        "draft-replies-notion-faq": {
+          "description": "Buat draf balasan tiket berdasarkan FAQ Notion Anda.",
+          "shortDescription": "Susun balasan tiket dari FAQ Notion Anda.",
+          "title": "Buat draf balasan dari FAQ Notion Anda"
+        },
+        "feedback-router": {
+          "description": "Pantau satu kanal Slack dan salurkan feedback produk ke Notion lengkap dengan label dan penanggung jawab.",
+          "shortDescription": "Salurkan feedback produk dari Slack ke Notion.",
+          "title": "Penyalur feedback"
+        },
+        "file-gmail-invoices-drive": {
+          "description": "Simpan email invoice ke Drive dan catat semuanya di Sheet.",
+          "shortDescription": "Simpan email invoice ke Drive dan catat semuanya.",
+          "title": "Simpan invoice Gmail ke Google Drive"
+        },
+        "file-sentry-crashes-github": {
+          "description": "Urutkan error baru di Sentry berdasarkan dampak ke pengguna dan ubah yang terburuk menjadi issue GitHub.",
+          "shortDescription": "Catat error Sentry terparah sebagai isu GitHub.",
+          "title": "Ubah crash Sentry menjadi issue GitHub"
+        },
+        "flag-figma-designs-no-task": {
+          "description": "Tandai desain Figma yang belum memiliki tugas Linear terhubung.",
+          "shortDescription": "Tandai desain Figma yang belum punya tugas Linear.",
+          "title": "Tandai desain Figma tanpa tugas"
+        },
+        "flagged-gmail-todoist-tasks": {
+          "description": "Ubah email yang Anda tandai menjadi tugas Todoist secara otomatis.",
+          "shortDescription": "Ubah email bertanda jadi tugas Todoist.",
+          "title": "Ubah email Gmail yang ditandai menjadi tugas Todoist"
+        },
+        "github-idea-to-notion-spec": {
+          "description": "Ubah issue GitHub berlabel menjadi spesifikasi produk terstruktur di Notion.",
+          "shortDescription": "Kembangkan isu GitHub jadi spesifikasi di Notion.",
+          "title": "Ubah ide GitHub menjadi spesifikasi Notion"
+        },
+        "github-pr-summarizer": {
+          "description": "Kumpulkan pull request yang sudah di-merge, simpan laporannya di Notion, dan posting ke Slack bila perlu.",
+          "shortDescription": "Kumpulkan pull request yang di-merge jadi laporan.",
+          "title": "Ringkasan PR GitHub"
+        },
+        "gmail-followups-auto": {
+          "description": "Temukan kontak yang belum membalas dan susun tindak lanjut berikutnya.",
+          "shortDescription": "Susun follow-up untuk kontak yang belum membalas.",
+          "title": "Kirim follow-up Gmail otomatis"
+        },
+        "gmail-reconnect-reminders": {
+          "description": "Tampilkan kontak penting yang sudah lama belum Anda email.",
+          "shortDescription": "Tampilkan kontak yang lama tak Anda hubungi.",
+          "title": "Dapatkan pengingat untuk menyambung kembali di Gmail"
+        },
+        "highlight-key-emails-gmail": {
+          "description": "Tampilkan beberapa email yang benar-benar butuh perhatian Anda.",
+          "shortDescription": "Angkat email yang butuh perhatian Anda.",
+          "title": "Sorot email penting di Gmail"
+        },
+        "investor-update-google-docs": {
+          "description": "Kumpulkan metrik dan sorotan menjadi update investor di Docs.",
+          "shortDescription": "Rangkai metrik jadi update untuk investor.",
+          "title": "Susun update investor di Google Docs"
+        },
+        "log-gong-calls-hubspot": {
+          "description": "Ambil catatan dan langkah berikutnya dari panggilan Gong ke deal HubSpot.",
+          "shortDescription": "Tarik catatan panggilan Gong ke deal HubSpot.",
+          "title": "Catat panggilan Gong ke HubSpot"
+        },
+        "meeting-notes-asana-tasks": {
+          "description": "Ubah catatan rapat menjadi tugas Asana yang ditugaskan dan diberi tenggat.",
+          "shortDescription": "Ubah catatan rapat jadi tugas di Asana.",
+          "title": "Ubah catatan rapat menjadi tugas Asana"
+        },
+        "meeting-recaps-slack": {
+          "description": "Bagikan rangkuman berisi keputusan dan item aksi setelah setiap rapat.",
+          "shortDescription": "Bagikan keputusan dan tindak lanjut usai rapat.",
+          "title": "Dapatkan rangkuman rapat di Slack"
+        },
+        "morning-brief": {
+          "description": "Ubah update Gmail, Calendar, dan Notion jadi rencana harian singkat di Slack.",
+          "shortDescription": "Ubah email dan rapat jadi rencana harian singkat.",
+          "title": "Ringkasan pagi"
+        },
+        "new-gmail-contacts-hubspot": {
+          "description": "Tambahkan dan lengkapi pengirim email yang belum dikenal sebagai kontak HubSpot.",
+          "shortDescription": "Tambahkan pengirim email tak dikenal ke HubSpot.",
+          "title": "Tambahkan kontak Gmail baru ke HubSpot"
+        },
+        "onboard-new-hires-asana": {
+          "description": "Buat checklist tugas onboarding untuk setiap karyawan baru di Asana.",
+          "shortDescription": "Buat checklist onboarding untuk tiap karyawan baru.",
+          "title": "Onboard karyawan baru di Asana"
+        },
+        "personal-weekly-digest": {
+          "description": "Rangkum aktivitas GitHub, Gmail, dan Calendar jadi satu update mingguan di Slack.",
+          "shortDescription": "Rangkum pekan Anda dari GitHub dan Gmail.",
+          "title": "Ringkasan mingguan pribadi"
+        },
+        "post-daily-metrics-slack": {
+          "description": "Posting jumlah pengunjung, signup, dan aktivasi harian ke Slack.",
+          "shortDescription": "Posting pengunjung dan signup harian ke Slack.",
+          "title": "Posting metrik harian ke Slack"
+        },
+        "post-release-notes-slack": {
+          "description": "Susun changelog dari pekerjaan yang baru dirilis dan posting ke Slack.",
+          "shortDescription": "Susun changelog lalu posting ke Slack.",
+          "title": "Posting catatan rilis ke Slack"
+        },
+        "prep-google-calendar-meetings": {
+          "description": "Teliti peserta eksternal dan kirim brief persiapan sebelum meeting.",
+          "shortDescription": "Kirim ringkasan persiapan sebelum rapat eksternal.",
+          "title": "Siapkan meeting Google Calendar"
+        },
+        "publish-scheduled-posts-buffer": {
+          "description": "Terbitkan konten terjadwal hari itu dan antrekan post sosialnya.",
+          "shortDescription": "Terbitkan post sosial yang dijadwalkan hari ini.",
+          "title": "Publikasikan posting terjadwal ke Buffer"
+        },
+        "research-calendar-meetings": {
+          "description": "Teliti orang yang akan Anda temui sebelum setiap event kalender.",
+          "shortDescription": "Teliti orang yang akan Anda temui sebelum acara.",
+          "title": "Teliti meeting kalender Anda"
+        },
+        "research-new-signups-apollo": {
+          "description": "Teliti setiap pendaftaran baru dan kirim snapshot singkat.",
+          "shortDescription": "Teliti tiap signup baru dan posting ringkasannya.",
+          "title": "Teliti pendaftaran baru"
+        },
+        "revenuecat-subscription-digest": {
+          "description": "Lacak langganan di Sheets dan beri tahu Slack saat pola churn atau pembatalan berubah.",
+          "shortDescription": "Lacak langganan dan beri tahu Slack soal churn.",
+          "title": "Ringkasan langganan RevenueCat"
+        },
+        "run-daily-query-sheets": {
+          "description": "Jalankan SQL tersimpan Anda sesuai jadwal dan tambahkan hasilnya ke Sheet.",
+          "shortDescription": "Jalankan SQL tersimpan dan tambahkan hasilnya ke Sheet.",
+          "title": "Jalankan query harian ke Google Sheets"
+        },
+        "salesforce-pipeline-digest": {
+          "description": "Rangkum tiap minggu perubahan opportunity Salesforce dan risiko tanggal closing ke Slack.",
+          "shortDescription": "Rangkum risiko pipeline Salesforce tiap minggu.",
+          "title": "Ringkasan pipeline Salesforce"
+        },
+        "send-bugs-github-slack": {
+          "description": "Arsipkan laporan bertanda bug sebagai issue GitHub dan beri tahu tim di Slack.",
+          "shortDescription": "Catat laporan bug sebagai isu GitHub.",
+          "title": "Kirim bug ke GitHub dan Slack"
+        },
+        "sentry-issue-digest": {
+          "description": "Kirim ringkasan harian isu Sentry yang kritis dan berat ke Slack.",
+          "shortDescription": "Kirim ringkasan harian isu Sentry yang kritis.",
+          "title": "Ringkasan isu Sentry"
+        },
+        "sort-gmail-draft-replies": {
+          "description": "Sortir inbox Anda dan buat draf balasan untuk email yang membutuhkannya.",
+          "shortDescription": "Sortir inbox dan susun balasan yang perlu.",
+          "title": "Sortir Gmail dan buat draf balasan"
+        },
+        "spot-churn-risk-stripe-zendesk": {
+          "description": "Tandai akun yang berisiko churn dan buat draf email pemulihan.",
+          "shortDescription": "Tandai risiko churn dan susun email pemulihan.",
+          "title": "Deteksi risiko churn di Stripe dan Zendesk"
+        },
+        "summarize-gmail-newsletters": {
+          "description": "Ringkas newsletter di inbox Anda menjadi satu ringkasan singkat.",
+          "shortDescription": "Padatkan newsletter Anda jadi satu ringkasan.",
+          "title": "Ringkas newsletter Gmail"
+        },
+        "summarize-zendesk-tickets-daily": {
+          "description": "Ringkas tiket Zendesk 24 jam terakhir dan posting ke Slack.",
+          "shortDescription": "Posting ringkasan harian tiket Zendesk.",
+          "title": "Ringkas tiket Zendesk setiap hari"
+        },
+        "support-ticket-router": {
+          "description": "Klasifikasikan email support, buat catatannya di Notion, dan beri tahu Slack untuk tiket kritis.",
+          "shortDescription": "Klasifikasikan email support dan tandai yang kritis.",
+          "title": "Penyalur tiket support"
+        },
+        "sync-asana-projects-notion": {
+          "description": "Gabungkan status proyek Asana ke satu board di Notion.",
+          "shortDescription": "Rangkum status proyek Asana ke Notion.",
+          "title": "Sinkronkan proyek Asana ke Notion"
+        },
+        "sync-linear-roadmap-notion": {
+          "description": "Jaga roadmap Notion tetap sinkron dengan status isu Linear Anda.",
+          "shortDescription": "Jaga roadmap Notion tetap seiring dengan Linear.",
+          "title": "Sinkronkan roadmap Linear ke Notion"
+        },
+        "track-feature-usage-posthog": {
+          "description": "Tampilkan pergeseran mingguan terbesar dalam penggunaan fitur dari PostHog.",
+          "shortDescription": "Tampilkan perubahan penggunaan terbesar minggu ini.",
+          "title": "Lacak penggunaan fitur dengan PostHog"
+        },
+        "track-keyword-ranks-ahrefs": {
+          "description": "Lacak peringkat kata kunci di Ahrefs dan catat perubahan terbesarnya di Notion.",
+          "shortDescription": "Laporkan pergerakan peringkat kata kunci minggu ini.",
+          "title": "Lacak peringkat kata kunci dengan Ahrefs"
+        },
+        "track-signup-sources-sheets": {
+          "description": "Atribusikan setiap pendaftaran baru ke sumbernya di Sheet pelacakan.",
+          "shortDescription": "Catat asal tiap signup di sebuah Sheet.",
+          "title": "Lacak sumber pendaftaran di Google Sheets"
+        },
+        "vercel-deploy-digest": {
+          "description": "Pantau deploy Vercel, hubungkan dengan commit GitHub, dan beri tahu Slack saat gagal.",
+          "shortDescription": "Beri tahu Slack saat deploy Vercel gagal.",
+          "title": "Ringkasan deploy Vercel"
+        },
+        "x-brand-monitor": {
+          "description": "Lacak sebutan brand di X, simpan post yang relevan di Notion, dan beri tahu Slack untuk sebutan penting.",
+          "shortDescription": "Beri tahu Slack saat brand banyak disebut di X.",
+          "title": "Pemantau brand di X"
+        },
+        "zendesk-knowledge-base": {
+          "description": "Temukan pertanyaan berulang di Zendesk, buat draf entri FAQ, dan simpan ke Notion.",
+          "shortDescription": "Ubah pertanyaan berulang jadi entri FAQ.",
+          "title": "Basis pengetahuan Zendesk"
+        }
+      },
+      "workflowCategories": {
+        "CEO": "CEO",
+        "Data": "Data",
+        "Engineering": "Engineering",
+        "Everyone": "Semua",
+        "Marketing": "Marketing",
+        "Operations": "Operasional",
+        "Product": "Produk",
+        "Sales": "Sales",
+        "Support": "Support"
+      }
     },
     "title": "Artefak",
     "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -686,7 +686,325 @@
       "useThisTemplate": "Usa questo modello",
       "website": "Sito web",
       "websitePreview": "{{title}} anteprima del modello di sito web",
-      "workflow": "Flusso di lavoro"
+      "workflow": "Flusso di lavoro",
+      "workflowCatalog": {
+        "alert-metric-moves-slack": {
+          "description": "Tieni d'occhio i tuoi parametri chiave e avvisa Slack quando si verifica un movimento brusco.",
+          "shortDescription": "Avvisa Slack se una metrica chiave si muove molto.",
+          "title": "Avvisa quando una metrica si sposta"
+        },
+        "auto-inbox-label": {
+          "description": "Crea un flusso che parte quando applichi un'etichetta Gmail e gestisce il messaggio etichettato.",
+          "shortDescription": "Avvia un flusso quando applichi un'etichetta Gmail.",
+          "title": "Etichetta automatica della posta"
+        },
+        "auto-merge-github-prs": {
+          "description": "Esamina i PR etichettati come pronti per l'unione, attendi il CI, quindi unisci e pubblica su Slack.",
+          "shortDescription": "Unisce le PR pronte quando la CI è verde.",
+          "title": "Unisci automaticamente GitHub PR"
+        },
+        "blog-posts-to-x": {
+          "description": "Trasforma ogni nuovo articolo del blog in varianti social in coda su Buffer.",
+          "shortDescription": "Trasforma ogni nuovo articolo in post social.",
+          "title": "Trasforma i post del blog in post social"
+        },
+        "build-weekly-deck-gamma": {
+          "description": "Trasforma le metriche della settimana in una presentazione pronta in Gamma.",
+          "shortDescription": "Trasforma i dati della settimana in un deck Gamma.",
+          "title": "Crea la presentazione settimanale in Gamma"
+        },
+        "business-review-gamma": {
+          "description": "Trasforma le metriche del mese in un resoconto aziendale in Gamma.",
+          "shortDescription": "Trasforma i dati del mese in un deck di review.",
+          "title": "Costruisci la revisione aziendale in Gamma"
+        },
+        "catch-calendar-conflicts": {
+          "description": "Scansiona il tuo calendario per eventuali doppie prenotazioni e avvisati in anticipo.",
+          "shortDescription": "Scopre in anticipo le doppie prenotazioni.",
+          "title": "Rileva Google conflitti di calendario"
+        },
+        "catch-leads-gmail": {
+          "description": "Individua i segnali di acquisto nelle nuove email e registra i lead qualificati.",
+          "shortDescription": "Individua i segnali d'acquisto e registra i lead.",
+          "title": "Cattura contatti da Gmail"
+        },
+        "chase-overdue-asana-tasks": {
+          "description": "Trova le attività Asana scadute e invita i loro proprietari su Slack.",
+          "shortDescription": "Sollecita i responsabili delle attività Asana scadute.",
+          "title": "Insegui i compiti Asana scaduti"
+        },
+        "check-posthog-signup-funnel": {
+          "description": "Tieni traccia della canalizzazione di registrazione e pubblica il calo più grande su Slack.",
+          "shortDescription": "Pubblica il punto di maggiore abbandono nel funnel.",
+          "title": "Controlla la canalizzazione di registrazione di PostHog"
+        },
+        "clickup-slack-standup": {
+          "description": "Raccogli ogni mattina le attività ClickUp e pubblica su Slack lo standup del team.",
+          "shortDescription": "Pubblica lo standup del mattino dalle attività ClickUp.",
+          "title": "Standup ClickUp su Slack"
+        },
+        "compare-google-ads-last-month": {
+          "description": "Confronta spesa pubblicitaria e ROAS con il mese scorso e segnala le anomalie su Slack.",
+          "shortDescription": "Confronta spesa e ROAS con il mese scorso.",
+          "title": "Confronta gli annunci Google con quelli del mese scorso"
+        },
+        "competitive-intel-monitor": {
+          "description": "Monitora prezzi e funzionalità dei concorrenti, salva quanto trovi su Notion e avvisa Slack.",
+          "shortDescription": "Registra su Notion i cambi di prezzo dei concorrenti.",
+          "title": "Monitoraggio della concorrenza"
+        },
+        "daily-company-brief-slack": {
+          "description": "Inserisci prodotto, crescita ed entrate in un brief quotidiano su Slack.",
+          "shortDescription": "Unisce prodotto, crescita e ricavi in un brief.",
+          "title": "Pubblica un brief aziendale quotidiano su Slack"
+        },
+        "daily-industry-news-slack": {
+          "description": "Raccogli le notizie di settore rilevanti del giorno in un Slack brief.",
+          "shortDescription": "Raccoglie per Slack le notizie del settore.",
+          "title": "Pubblica notizie quotidiane del settore su Slack"
+        },
+        "daily-standup-report": {
+          "description": "Raccogli ogni mattina i segnali di prodotto e ingegneria, crea un breve report e pubblicalo su Slack.",
+          "shortDescription": "Pubblica ogni mattina un brief di prodotto e sviluppo.",
+          "title": "Report giornaliero di standup"
+        },
+        "draft-github-release-notes-notion": {
+          "description": "Trasforma i PR uniti dall'ultima versione in note pulite in Notion.",
+          "shortDescription": "Trasforma le PR unite in note di rilascio su Notion.",
+          "title": "Bozza delle note sulla versione di GitHub in Notion"
+        },
+        "draft-newsletter-mailchimp": {
+          "description": "Raccogli gli ultimi aggiornamenti in una bozza di newsletter su Mailchimp.",
+          "shortDescription": "Raccoglie gli aggiornamenti recenti in una newsletter.",
+          "title": "Redigere la newsletter in Mailchimp"
+        },
+        "draft-replies-notion-faq": {
+          "description": "Bozze di risposte ai ticket basate sulle Notion Domande frequenti.",
+          "shortDescription": "Scrive le risposte partendo dalla tua FAQ su Notion.",
+          "title": "Bozze di risposte dalle tue Notion Domande frequenti"
+        },
+        "feedback-router": {
+          "description": "Osserva un canale Slack e porta i feedback di prodotto su Notion con etichette e responsabili.",
+          "shortDescription": "Porta i feedback di prodotto da Slack a Notion.",
+          "title": "Smistamento dei feedback"
+        },
+        "file-gmail-invoices-drive": {
+          "description": "Archivia le email di fatturazione su Drive e registra ciascuna di esse in un foglio.",
+          "shortDescription": "Archivia le fatture su Drive e le registra.",
+          "title": "Archivia le fatture Gmail su Google Drive"
+        },
+        "file-sentry-crashes-github": {
+          "description": "Classifica i nuovi errori Sentry in base all'impatto sull'utente e archivia i peggiori come issue GitHub.",
+          "shortDescription": "Apre issue GitHub per gli errori Sentry peggiori.",
+          "title": "Il file Sentry si blocca a causa di issue GitHub"
+        },
+        "flag-figma-designs-no-task": {
+          "description": "Segnala i progetti Figma che non hanno ancora un'attività lineare collegata.",
+          "shortDescription": "Segnala i design Figma senza attività su Linear.",
+          "title": "Segnala i disegni Figma senza alcuna attività"
+        },
+        "flagged-gmail-todoist-tasks": {
+          "description": "Trasforma automaticamente le email che contrassegni in attività di Todoist.",
+          "shortDescription": "Trasforma le email segnate in attività Todoist.",
+          "title": "Trasforma Gmail contrassegnato nelle attività di Todoist"
+        },
+        "github-idea-to-notion-spec": {
+          "description": "Espandi un problema etichettato GitHub in una specifica di prodotto strutturata in Notion.",
+          "shortDescription": "Espande una issue GitHub in una spec su Notion.",
+          "title": "Trasforma un'idea GitHub in una specifica Notion"
+        },
+        "github-pr-summarizer": {
+          "description": "Raccogli le pull request unite, salva un report strutturato su Notion e se vuoi pubblicalo su Slack.",
+          "shortDescription": "Raccoglie le pull request unite in un report.",
+          "title": "Riepilogo delle PR di GitHub"
+        },
+        "gmail-followups-auto": {
+          "description": "Trova i contatti che non hanno risposto e redige il successivo follow-up.",
+          "shortDescription": "Scrive solleciti per i contatti che non hanno risposto.",
+          "title": "Invia Gmail follow-up automaticamente"
+        },
+        "gmail-reconnect-reminders": {
+          "description": "Mostra contatti importanti a cui non invii email da un po'.",
+          "shortDescription": "Mostra i contatti che non senti da tempo.",
+          "title": "Ricevi Gmail promemoria di riconnessione"
+        },
+        "highlight-key-emails-gmail": {
+          "description": "Fai emergere le poche e-mail che effettivamente richiedono la tua attenzione.",
+          "shortDescription": "Mette in evidenza le email che ti aspettano.",
+          "title": "Evidenzia le email chiave in Gmail"
+        },
+        "investor-update-google-docs": {
+          "description": "Raccogli metriche e punti salienti in un aggiornamento per gli investitori su Google Docs.",
+          "shortDescription": "Unisce le metriche in un update per gli investitori.",
+          "title": "Redigere l'aggiornamento per gli investitori in Google Docs"
+        },
+        "log-gong-calls-hubspot": {
+          "description": "Inserisci note e passaggi successivi da una chiamata Gong all'accordo HubSpot.",
+          "shortDescription": "Porta le note delle call Gong nella trattativa HubSpot.",
+          "title": "Registra le chiamate Gong su HubSpot"
+        },
+        "meeting-notes-asana-tasks": {
+          "description": "Trasforma gli appunti della riunione in attività assegnate e con scadenza in Asana.",
+          "shortDescription": "Trasforma le note delle riunioni in attività Asana.",
+          "title": "Trasforma gli appunti della riunione in attività Asana"
+        },
+        "meeting-recaps-slack": {
+          "description": "Condividi un riepilogo con decisioni e azioni dopo ogni riunione.",
+          "shortDescription": "Condivide decisioni e azioni dopo le riunioni.",
+          "title": "Ricevi i riepiloghi delle riunioni in Slack"
+        },
+        "morning-brief": {
+          "description": "Trasforma gli aggiornamenti di Gmail, Calendar e Notion in un breve piano quotidiano su Slack.",
+          "shortDescription": "Trasforma email e riunioni in un breve piano del giorno.",
+          "title": "Brief del mattino"
+        },
+        "new-gmail-contacts-hubspot": {
+          "description": "Aggiungi e arricchisci mittenti e-mail sconosciuti come contatti HubSpot.",
+          "shortDescription": "Aggiunge a HubSpot i mittenti sconosciuti.",
+          "title": "Aggiungi nuovi Gmail contatti a HubSpot"
+        },
+        "onboard-new-hires-asana": {
+          "description": "Crea l'elenco di controllo delle attività di onboarding per ogni nuovo assunto in Asana.",
+          "shortDescription": "Crea una checklist di inserimento per ogni assunzione.",
+          "title": "Integrazione dei nuovi assunti ad Asana"
+        },
+        "personal-weekly-digest": {
+          "description": "Riassumi l'attività di GitHub, Gmail e Calendar in un aggiornamento settimanale su Slack.",
+          "shortDescription": "Riassume la tua settimana su GitHub e Gmail.",
+          "title": "Riepilogo settimanale personale"
+        },
+        "post-daily-metrics-slack": {
+          "description": "Pubblica visitatori giornalieri, iscrizioni e numeri di attivazione su Slack.",
+          "shortDescription": "Pubblica visitatori e iscrizioni del giorno su Slack.",
+          "title": "Pubblica metriche giornaliere su Slack"
+        },
+        "post-release-notes-slack": {
+          "description": "Crea un registro delle modifiche dal lavoro inviato di recente e pubblicalo su Slack.",
+          "shortDescription": "Scrive un changelog e lo pubblica su Slack.",
+          "title": "Pubblica note di rilascio su Slack"
+        },
+        "prep-google-calendar-meetings": {
+          "description": "Effettua ricerche sui partecipanti esterni e invia un brief di preparazione prima delle riunioni.",
+          "shortDescription": "Invia un brief prima delle riunioni esterne.",
+          "title": "Preparati per le riunioni del calendario Google"
+        },
+        "publish-scheduled-posts-buffer": {
+          "description": "Pubblica i contenuti programmati per la giornata e metti in coda i post social.",
+          "shortDescription": "Pubblica i post social programmati per oggi.",
+          "title": "Pubblica post programmati su Buffer"
+        },
+        "research-calendar-meetings": {
+          "description": "Ricerca le persone che incontrerai prima di ogni evento del calendario.",
+          "shortDescription": "Studia le persone che incontri prima di ogni evento.",
+          "title": "Ricerca le riunioni del tuo calendario"
+        },
+        "research-new-signups-apollo": {
+          "description": "Ricerca ogni nuova registrazione e pubblica una rapida istantanea.",
+          "shortDescription": "Studia ogni nuova iscrizione e ne pubblica il profilo.",
+          "title": "Ricerca nuove iscrizioni"
+        },
+        "revenuecat-subscription-digest": {
+          "description": "Tieni traccia degli abbonamenti in Sheets e avvisa Slack quando cambiano churn o disdette.",
+          "shortDescription": "Segue gli abbonamenti e avvisa Slack sul churn.",
+          "title": "Riepilogo abbonamenti RevenueCat"
+        },
+        "run-daily-query-sheets": {
+          "description": "Esegui il tuo SQL salvato in base a una pianificazione e aggiungi i risultati a un foglio.",
+          "shortDescription": "Esegue SQL salvato e aggiunge i dati a un foglio.",
+          "title": "Esegui una query giornaliera in Google Sheets"
+        },
+        "salesforce-pipeline-digest": {
+          "description": "Riepiloga ogni settimana su Slack i cambiamenti delle opportunità Salesforce e i rischi sulle date di chiusura.",
+          "shortDescription": "Riepiloga ogni settimana i rischi della pipeline.",
+          "title": "Riepilogo della pipeline Salesforce"
+        },
+        "send-bugs-github-slack": {
+          "description": "Archivia le segnalazioni contrassegnate da bug come issue GitHub e avvisa il team su Slack.",
+          "shortDescription": "Apre le segnalazioni di bug come issue GitHub.",
+          "title": "Invia bug a GitHub e Slack"
+        },
+        "sentry-issue-digest": {
+          "description": "Invia su Slack un riepilogo giornaliero dei problemi Sentry critici e gravi.",
+          "shortDescription": "Invia ogni giorno i problemi Sentry critici.",
+          "title": "Riepilogo dei problemi Sentry"
+        },
+        "sort-gmail-draft-replies": {
+          "description": "Ordina la tua casella di posta e crea bozze di risposta alle email che ne hanno bisogno.",
+          "shortDescription": "Ordina la posta e prepara le risposte.",
+          "title": "Ordina Gmail e bozza delle risposte"
+        },
+        "spot-churn-risk-stripe-zendesk": {
+          "description": "Contrassegna gli account a rischio di abbandono e redige un'e-mail di recupero.",
+          "shortDescription": "Segnala il rischio churn e scrive un'email.",
+          "title": "Individua il rischio di abbandono in Stripe e Zendesk"
+        },
+        "summarize-gmail-newsletters": {
+          "description": "Riassumi le newsletter nella tua casella di posta in un breve riepilogo.",
+          "shortDescription": "Condensa le tue newsletter in un unico riassunto.",
+          "title": "Riepiloga le Gmail newsletter"
+        },
+        "summarize-zendesk-tickets-daily": {
+          "description": "Riepiloga l'ultimo giorno dei ticket Zendesk e pubblicalo su Slack.",
+          "shortDescription": "Pubblica ogni giorno un riassunto dei ticket.",
+          "title": "Riepiloga i biglietti Zendesk ogni giorno"
+        },
+        "support-ticket-router": {
+          "description": "Classifica le email di supporto, crea le schede su Notion e avvisa Slack per i ticket critici.",
+          "shortDescription": "Classifica le email di supporto e segnala le urgenze.",
+          "title": "Smistamento dei ticket di supporto"
+        },
+        "sync-asana-projects-notion": {
+          "description": "Riunisci lo stato del progetto Asana in un'unica scheda in Notion.",
+          "shortDescription": "Riunisce su Notion lo stato dei progetti Asana.",
+          "title": "Sincronizza i progetti Asana su Notion"
+        },
+        "sync-linear-roadmap-notion": {
+          "description": "Mantieni una roadmap Notion sincronizzata con lo stato del problema Linear.",
+          "shortDescription": "Tiene la roadmap Notion allineata a Linear.",
+          "title": "Sincronizza la roadmap lineare su Notion"
+        },
+        "track-feature-usage-posthog": {
+          "description": "Scopri i maggiori cambiamenti settimanali nell'utilizzo delle funzionalità di PostHog.",
+          "shortDescription": "Mostra i maggiori cambi di utilizzo della settimana.",
+          "title": "Tieni traccia dell'utilizzo delle funzionalità con PostHog"
+        },
+        "track-keyword-ranks-ahrefs": {
+          "description": "Segui il posizionamento delle parole chiave su Ahrefs e riporta su Notion i movimenti maggiori.",
+          "shortDescription": "Riporta i movimenti di posizione della settimana.",
+          "title": "Tieni traccia del posizionamento delle parole chiave con Ahrefs"
+        },
+        "track-signup-sources-sheets": {
+          "description": "Attribuisci ogni nuova registrazione alla sua fonte in un foglio di monitoraggio.",
+          "shortDescription": "Attribuisce ogni iscrizione alla sua fonte in un foglio.",
+          "title": "Monitora le origini delle registrazioni in Google Sheets"
+        },
+        "vercel-deploy-digest": {
+          "description": "Monitora i deploy di Vercel, collegali ai commit GitHub e segnala gli errori su Slack.",
+          "shortDescription": "Avvisa Slack quando un deploy Vercel fallisce.",
+          "title": "Riepilogo dei deploy Vercel"
+        },
+        "x-brand-monitor": {
+          "description": "Segui le menzioni del brand su X, salva i post rilevanti su Notion e avvisa Slack su quelle importanti.",
+          "shortDescription": "Avvisa Slack sulle menzioni forti del brand su X.",
+          "title": "Monitoraggio del brand su X"
+        },
+        "zendesk-knowledge-base": {
+          "description": "Trova le domande ricorrenti su Zendesk, scrivi le voci della FAQ e salvale su Notion.",
+          "shortDescription": "Trasforma le domande ricorrenti in voci di FAQ.",
+          "title": "Knowledge base Zendesk"
+        }
+      },
+      "workflowCategories": {
+        "CEO": "CEO",
+        "Data": "Dati",
+        "Engineering": "Ingegneria",
+        "Everyone": "Tutti",
+        "Marketing": "Marketing",
+        "Operations": "Operazioni",
+        "Product": "Prodotto",
+        "Sales": "Vendite",
+        "Support": "Supporto"
+      }
     },
     "title": "Artefatti",
     "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -669,7 +669,325 @@
       "useThisTemplate": "このテンプレートを使用してください",
       "website": "ウェブサイト",
       "websitePreview": "{{title}} Web サイト テンプレートのプレビュー",
-      "workflow": "ワークフロー"
+      "workflow": "ワークフロー",
+      "workflowCatalog": {
+        "alert-metric-moves-slack": {
+          "description": "主要なメトリクスを監視し、急激に変化した場合は Slack に警告します。",
+          "shortDescription": "主要指標が大きく動いたら Slack に通知します。",
+          "title": "メトリクスが移動したときにアラートを送信する"
+        },
+        "auto-inbox-label": {
+          "description": "Gmail のラベルが付いたときに実行し、そのメールを処理するワークフローを作成します。",
+          "shortDescription": "Gmail のラベルを付けるとワークフローが動きます。",
+          "title": "受信トレイのラベル自動処理"
+        },
+        "auto-merge-github-prs": {
+          "description": "「マージ準備完了」というラベルが付いた PR を確認し、CI を待ってからマージして Slack にポストします。",
+          "shortDescription": "CI が通った PR を自動でマージします。",
+          "title": "GitHub PR の自動マージ"
+        },
+        "blog-posts-to-x": {
+          "description": "新しいブログ記事をソーシャル向けの文面にして Buffer のキューに入れます。",
+          "shortDescription": "新しいブログ記事をソーシャル投稿にします。",
+          "title": "ブログ投稿をソーシャル投稿に変える"
+        },
+        "build-weekly-deck-gamma": {
+          "description": "Gamma で、その週の指標をすぐに提示できるデッキに変換します。",
+          "shortDescription": "今週の指標を Gamma のデッキにします。",
+          "title": "Gamma で毎週のデッキを作成する"
+        },
+        "business-review-gamma": {
+          "description": "Gamma で月の指標をビジネス レビュー資料に変換します。",
+          "shortDescription": "今月の指標をレビュー用デッキにします。",
+          "title": "Gamma でビジネス レビューを作成する"
+        },
+        "catch-calendar-conflicts": {
+          "description": "カレンダーをスキャンしてダブルブッキングがないか確認し、早めに通知します。",
+          "shortDescription": "カレンダーの二重予約を早めに見つけます。",
+          "title": "Google Calendar の競合を捕捉する"
+        },
+        "catch-leads-gmail": {
+          "description": "新しいメール内の購入シグナルを特定し、見込み客を記録します。",
+          "shortDescription": "購買の兆しを見つけて有望なリードを記録します。",
+          "title": "Gmail からのリードを獲得する"
+        },
+        "chase-overdue-asana-tasks": {
+          "description": "期限を過ぎた Asana タスクを見つけて、その所有者に Slack を指示します。",
+          "shortDescription": "期限切れの Asana タスクの担当者に声をかけます。",
+          "title": "期限を過ぎた Asana タスクを追跡する"
+        },
+        "check-posthog-signup-funnel": {
+          "description": "サインアップ ファネルを追跡し、最大の減少を Slack にポストします。",
+          "shortDescription": "登録フローで最も離脱が多い箇所を知らせます。",
+          "title": "PostHog サインアップ ファネルを確認する"
+        },
+        "clickup-slack-standup": {
+          "description": "毎朝 ClickUp のタスクを集めて、チームのスタンドアップ要約を Slack に投稿します。",
+          "shortDescription": "ClickUp のタスクで朝のスタンドアップを投稿します。",
+          "title": "ClickUp の Slack スタンドアップ"
+        },
+        "compare-google-ads-last-month": {
+          "description": "広告費と ROAS を先月と比較し、異常があれば Slack に通知します。",
+          "shortDescription": "広告費と ROAS を先月と比べます。",
+          "title": "Google 広告と先月の比較"
+        },
+        "competitive-intel-monitor": {
+          "description": "競合サイトの価格や機能の変化を監視し、内容を Notion に保存して Slack に通知します。",
+          "shortDescription": "競合の価格変更を Notion に記録します。",
+          "title": "競合モニタリング"
+        },
+        "daily-company-brief-slack": {
+          "description": "製品、成長、収益を Slack の日次概要にまとめます。",
+          "shortDescription": "プロダクト・成長・売上を一つの要約にまとめます。",
+          "title": "毎日の会社概要を Slack に投稿します"
+        },
+        "daily-industry-news-slack": {
+          "description": "その日の関連業界ニュースを Slack 概要にまとめます。",
+          "shortDescription": "その日の業界ニュースを Slack にまとめます。",
+          "title": "毎日の業界ニュースを Slack に投稿します"
+        },
+        "daily-standup-report": {
+          "description": "毎朝プロダクトとエンジニアリングの指標を集めて短いレポートを作成し、Slack に投稿します。",
+          "shortDescription": "毎朝プロダクトと開発の要点を投稿します。",
+          "title": "デイリースタンドアップレポート"
+        },
+        "draft-github-release-notes-notion": {
+          "description": "前回のリリース以降にマージされた PR を Notion のクリーン ノートに変換します。",
+          "shortDescription": "マージ済みの PR を Notion のリリースノートにします。",
+          "title": "Notion で GitHub リリース ノートの草案を作成する"
+        },
+        "draft-newsletter-mailchimp": {
+          "description": "最近の更新をまとめて Mailchimp にニュースレターの下書きを作成します。",
+          "shortDescription": "最近の更新をニュースレターにまとめます。",
+          "title": "Mailchimp でニュースレターの下書きを作成します"
+        },
+        "draft-replies-notion-faq": {
+          "description": "Notion FAQ に基づいたドラフト チケットの返信。",
+          "shortDescription": "Notion の FAQ から返信を下書きします。",
+          "title": "Notion FAQ からの返信の下書き"
+        },
+        "feedback-router": {
+          "description": "Slack チャンネルを監視し、プロダクトへのフィードバックにラベルと担当者を付けて Notion に振り分けます。",
+          "shortDescription": "Slack のプロダクト意見を Notion に振り分けます。",
+          "title": "フィードバックの振り分け"
+        },
+        "file-gmail-invoices-drive": {
+          "description": "請求書メールをドライブにファイルし、それぞれをシートに記録します。",
+          "shortDescription": "請求書メールを Drive に保存して記録します。",
+          "title": "Gmail 請求書を Google Drive にファイルします"
+        },
+        "file-sentry-crashes-github": {
+          "description": "新しい Sentry エラーをユーザーへの影響別にランク付けし、最悪のものを GitHub Issueとして記録します。",
+          "shortDescription": "深刻な Sentry エラーを GitHub の課題にします。",
+          "title": "SentryのクラッシュをGitHub Issueとして登録"
+        },
+        "flag-figma-designs-no-task": {
+          "description": "Linear タスクがまだリンクされていない Figma デザインにフラグを立てます。",
+          "shortDescription": "Linear のタスクがない Figma デザインを洗い出します。",
+          "title": "タスクのない Figma デザインにフラグを立てる"
+        },
+        "flagged-gmail-todoist-tasks": {
+          "description": "フラグを付けたメールは自動的に Todoist タスクに変換されます。",
+          "shortDescription": "スター付きのメールを Todoist のタスクにします。",
+          "title": "フラグが設定された Gmail を Todoist タスクに変換する"
+        },
+        "github-idea-to-notion-spec": {
+          "description": "ラベル付き GitHub のIssueを Notion の構造化された製品仕様に展開します。",
+          "shortDescription": "GitHub の課題を Notion の仕様書に広げます。",
+          "title": "GitHub のアイデアを Notion 仕様に変える"
+        },
+        "github-pr-summarizer": {
+          "description": "マージされたプルリクエストを集めて Notion にレポートとして保存し、必要に応じて Slack にも投稿します。",
+          "shortDescription": "マージ済みの PR をレポートにまとめます。",
+          "title": "GitHub PR の要約"
+        },
+        "gmail-followups-auto": {
+          "description": "返信しなかった連絡先を見つけて、次のフォローアップの下書きを作成します。",
+          "shortDescription": "返信のない相手へのフォローを下書きします。",
+          "title": "Gmail のフォローアップを自動的に送信する"
+        },
+        "gmail-reconnect-reminders": {
+          "description": "しばらくメールを送っていない重要な連絡先を表示します。",
+          "shortDescription": "しばらく連絡していない相手を知らせます。",
+          "title": "Gmail 再接続リマインダーを取得する"
+        },
+        "highlight-key-emails-gmail": {
+          "description": "実際に注意が必要なメールをいくつか洗い出します。",
+          "shortDescription": "対応が必要なメールを拾い上げます。",
+          "title": "Gmail で重要なメールを強調表示する"
+        },
+        "investor-update-google-docs": {
+          "description": "指標とハイライトをドキュメント内の投資家向け最新情報にまとめます。",
+          "shortDescription": "指標をまとめて投資家向けの報告にします。",
+          "title": "Google ドキュメントで投資家向け最新情報の草案を作成する"
+        },
+        "log-gong-calls-hubspot": {
+          "description": "HubSpot 取引への Gong コールからメモと次のステップを引き出します。",
+          "shortDescription": "Gong の通話メモを HubSpot の商談に取り込みます。",
+          "title": "Gong 呼び出しを HubSpot に記録します"
+        },
+        "meeting-notes-asana-tasks": {
+          "description": "Asana では、会議メモを期限付きの割り当てられたタスクに変換します。",
+          "shortDescription": "議事録を Asana のタスクにします。",
+          "title": "会議メモを Asana タスクに変える"
+        },
+        "meeting-recaps-slack": {
+          "description": "各会議の後に、決定事項と実行項目の要約を共有します。",
+          "shortDescription": "会議の決定事項とやることを共有します。",
+          "title": "Slack で会議の概要を取得します"
+        },
+        "morning-brief": {
+          "description": "Gmail、カレンダー、Notion の更新を短い一日の計画にして Slack に送ります。",
+          "shortDescription": "メールと予定を短い一日の計画にします。",
+          "title": "モーニングブリーフ"
+        },
+        "new-gmail-contacts-hubspot": {
+          "description": "不明なメール送信者を HubSpot 連絡先として追加して強化します。",
+          "shortDescription": "未登録の送信者を HubSpot に追加します。",
+          "title": "新しい Gmail 連絡先を HubSpot に追加します"
+        },
+        "onboard-new-hires-asana": {
+          "description": "Asana で各新入社員のオンボーディング タスク チェックリストを作成します。",
+          "shortDescription": "新しい仲間ごとに受け入れ用のチェックリストを作ります。",
+          "title": "Asana での新入社員のオンボーディング"
+        },
+        "personal-weekly-digest": {
+          "description": "GitHub、Gmail、カレンダーの動きを週次でまとめて Slack に送ります。",
+          "shortDescription": "GitHub と Gmail から一週間を振り返ります。",
+          "title": "個人の週次ダイジェスト"
+        },
+        "post-daily-metrics-slack": {
+          "description": "毎日の訪問者、サインアップ、アクティベーション番号を Slack に投稿します。",
+          "shortDescription": "日々の訪問者と登録数を Slack に投稿します。",
+          "title": "毎日のメトリクスを Slack に投稿します"
+        },
+        "post-release-notes-slack": {
+          "description": "最近出荷された作業から変更ログを作成し、Slack に投稿します。",
+          "shortDescription": "変更点をまとめて Slack に投稿します。",
+          "title": "リリース ノートを Slack に投稿します"
+        },
+        "prep-google-calendar-meetings": {
+          "description": "外部出席者を調査し、会議の前に準備概要を送信します。",
+          "shortDescription": "社外ミーティングの前に準備メモを送ります。",
+          "title": "Google Calendar 会議の準備をする"
+        },
+        "publish-scheduled-posts-buffer": {
+          "description": "その日に予約したコンテンツを公開し、ソーシャル投稿をキューに入れます。",
+          "shortDescription": "その日に予約したソーシャル投稿を公開します。",
+          "title": "スケジュールされた投稿をバッファに公開する"
+        },
+        "research-calendar-meetings": {
+          "description": "カレンダーの各イベントの前に、会う人について調べてください。",
+          "shortDescription": "予定の前に会う相手を調べます。",
+          "title": "カレンダー上の会議を調査する"
+        },
+        "research-new-signups-apollo": {
+          "description": "新しいサインアップをそれぞれ調査し、簡単なスナップショットを投稿します。",
+          "shortDescription": "新規登録者を調べて概要を投稿します。",
+          "title": "新しいサインアップを調査する"
+        },
+        "revenuecat-subscription-digest": {
+          "description": "サブスクリプションをシートで追跡し、解約や離脱の傾向が変わったら Slack に通知します。",
+          "shortDescription": "サブスクを追跡し解約の兆しを Slack に通知します。",
+          "title": "RevenueCat サブスクリプションダイジェスト"
+        },
+        "run-daily-query-sheets": {
+          "description": "保存した SQL をスケジュールに従って実行し、結果をシートに追加します。",
+          "shortDescription": "保存した SQL を実行して結果をシートに追記します。",
+          "title": "Google Sheets に対して毎日クエリを実行します。"
+        },
+        "salesforce-pipeline-digest": {
+          "description": "毎週 Salesforce の商談の変化とクローズ日のリスクを Slack にまとめます。",
+          "shortDescription": "毎週 Salesforce の商談リスクをまとめます。",
+          "title": "Salesforce パイプラインダイジェスト"
+        },
+        "send-bugs-github-slack": {
+          "description": "バグタグを付けたレポートを GitHub Issueとしてファイルし、Slack でチームに警告します。",
+          "shortDescription": "バグ報告を GitHub の課題として登録します。",
+          "title": "バグを GitHub および Slack に送信します。"
+        },
+        "sentry-issue-digest": {
+          "description": "重大度の高い Sentry の課題を毎日まとめて Slack に送ります。",
+          "shortDescription": "重大な Sentry の課題を毎日まとめて送ります。",
+          "title": "Sentry 課題ダイジェスト"
+        },
+        "sort-gmail-draft-replies": {
+          "description": "受信トレイを分類し、必要なメールへの返信の下書きを作成します。",
+          "shortDescription": "受信トレイを整理して返信を下書きします。",
+          "title": "Gmail と返信の下書きを並べ替える"
+        },
+        "spot-churn-risk-stripe-zendesk": {
+          "description": "解約のリスクがあるアカウントにフラグを立てて、回復メールの下書きを作成します。",
+          "shortDescription": "解約リスクを見つけて挽回メールを下書きします。",
+          "title": "Stripe および Zendesk のスポット チャーン リスク"
+        },
+        "summarize-gmail-newsletters": {
+          "description": "受信トレイ内のニュースレターを 1 つの短い要約に要約します。",
+          "shortDescription": "ニュースレターを一つの要約にまとめます。",
+          "title": "Gmail ニュースレターの要約"
+        },
+        "summarize-zendesk-tickets-daily": {
+          "description": "Zendesk チケットの最終日を要約し、Slack に投稿します。",
+          "shortDescription": "Zendesk のチケットを毎日まとめて投稿します。",
+          "title": "Zendesk チケットを毎日要約する"
+        },
+        "support-ticket-router": {
+          "description": "サポートメールを分類して Notion に記録し、重大なチケットは Slack に通知します。",
+          "shortDescription": "問い合わせを分類し重要なものを目立たせます。",
+          "title": "サポートチケットの振り分け"
+        },
+        "sync-asana-projects-notion": {
+          "description": "Asana プロジェクトのステータスを Notion の単一ボードにロールアップします。",
+          "shortDescription": "Asana のプロジェクト状況を Notion にまとめます。",
+          "title": "Asana プロジェクトを Notion に同期します"
+        },
+        "sync-linear-roadmap-notion": {
+          "description": "Notion ロードマップと Linear の問題ステータスの同期を維持します。",
+          "shortDescription": "Notion のロードマップを Linear と同期します。",
+          "title": "Linear ロードマップを Notion に同期します"
+        },
+        "track-feature-usage-posthog": {
+          "description": "PostHog からの機能使用量の週ごとの最大の変化を明らかにします。",
+          "shortDescription": "今週いちばん動いた利用状況を知らせます。",
+          "title": "PostHog を使用して機能の使用状況を追跡する"
+        },
+        "track-keyword-ranks-ahrefs": {
+          "description": "Ahrefs でキーワード順位を追跡し、変動の大きいものを Notion にまとめます。",
+          "shortDescription": "今週の検索順位の変動をまとめます。",
+          "title": "Ahrefs でキーワード ランクを追跡する"
+        },
+        "track-signup-sources-sheets": {
+          "description": "追跡シート内の各新規サインアップをそのソースに帰属させます。",
+          "shortDescription": "登録の流入元をシートに記録します。",
+          "title": "Google Sheets でサインアップ ソースを追跡する"
+        },
+        "vercel-deploy-digest": {
+          "description": "Vercel のデプロイを監視して GitHub のコミットと紐づけ、失敗したら Slack に通知します。",
+          "shortDescription": "Vercel のデプロイ失敗を Slack に通知します。",
+          "title": "Vercel デプロイダイジェスト"
+        },
+        "x-brand-monitor": {
+          "description": "X でのブランド言及を追跡し、関連する投稿を Notion に保存して重要な言及を Slack に通知します。",
+          "shortDescription": "X で目立つブランド言及を Slack に通知します。",
+          "title": "X ブランドモニタリング"
+        },
+        "zendesk-knowledge-base": {
+          "description": "Zendesk で繰り返される質問を見つけて FAQ の下書きを作成し、Notion に保存します。",
+          "shortDescription": "繰り返される質問を FAQ の項目にします。",
+          "title": "Zendesk ナレッジベース"
+        }
+      },
+      "workflowCategories": {
+        "CEO": "CEO",
+        "Data": "データ",
+        "Engineering": "エンジニアリング",
+        "Everyone": "すべて",
+        "Marketing": "マーケティング",
+        "Operations": "オペレーション",
+        "Product": "プロダクト",
+        "Sales": "セールス",
+        "Support": "サポート"
+      }
     },
     "title": "アーティファクト",
     "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -669,7 +669,325 @@
       "useThisTemplate": "이 템플릿 사용",
       "website": "웹사이트",
       "websitePreview": "{{title}} 웹사이트 템플릿 미리보기",
-      "workflow": "워크플로"
+      "workflow": "워크플로",
+      "workflowCatalog": {
+        "alert-metric-moves-slack": {
+          "description": "핵심 지표를 모니터링하고 급격한 변동 시 Slack에 알림을 보냅니다.",
+          "shortDescription": "핵심 지표가 크게 움직이면 Slack에 알립니다.",
+          "title": "지표 변동 시 알림"
+        },
+        "auto-inbox-label": {
+          "description": "Gmail 라벨이 지정되면 실행되어 해당 메일을 처리하는 워크플로를 만듭니다.",
+          "shortDescription": "Gmail 라벨을 붙이면 워크플로를 실행합니다.",
+          "title": "받은편지함 라벨 자동 처리"
+        },
+        "auto-merge-github-prs": {
+          "description": "준비 완료 라벨이 붙은 PR을 검토하고 CI를 기다린 후 병합하고 Slack에 게시합니다.",
+          "shortDescription": "CI가 통과한 PR을 자동으로 머지합니다.",
+          "title": "GitHub PR 자동 병합"
+        },
+        "blog-posts-to-x": {
+          "description": "새 블로그 글을 소셜용 문구로 바꿔 Buffer 대기열에 넣습니다.",
+          "shortDescription": "새 블로그 글을 소셜 게시물로 만듭니다.",
+          "title": "블로그 게시물을 소셜 게시물로 전환"
+        },
+        "build-weekly-deck-gamma": {
+          "description": "이번 주 지표를 Gamma에서 발표용 데크로 만듭니다.",
+          "shortDescription": "이번 주 지표를 Gamma 덱으로 만듭니다.",
+          "title": "Gamma에서 주간 데크 만들기"
+        },
+        "business-review-gamma": {
+          "description": "이번 달 지표를 Gamma에서 비즈니스 리뷰 데크로 만듭니다.",
+          "shortDescription": "이번 달 지표를 리뷰 덱으로 만듭니다.",
+          "title": "Gamma에서 비즈니스 리뷰 만들기"
+        },
+        "catch-calendar-conflicts": {
+          "description": "캘린더에서 중복 예약을 찾아 미리 알림을 보냅니다.",
+          "shortDescription": "캘린더의 중복 예약을 미리 찾아냅니다.",
+          "title": "Google 캘린더 충돌 감지"
+        },
+        "catch-leads-gmail": {
+          "description": "새 이메일에서 구매 신호를 찾아 적격 리드를 기록합니다.",
+          "shortDescription": "구매 신호를 찾아 유효 리드를 기록합니다.",
+          "title": "Gmail에서 리드 포착"
+        },
+        "chase-overdue-asana-tasks": {
+          "description": "기한이 지난 Asana 작업을 찾아 소유자에게 Slack으로 알림을 보냅니다.",
+          "shortDescription": "기한이 지난 Asana 작업의 담당자에게 알립니다.",
+          "title": "기한 지난 Asana 작업 챙기기"
+        },
+        "check-posthog-signup-funnel": {
+          "description": "가입 퍼널을 추적하고 가장 큰 이탈 지점을 Slack에 게시합니다.",
+          "shortDescription": "가입 퍼널에서 이탈이 가장 큰 지점을 알려줍니다.",
+          "title": "PostHog 가입 퍼널 확인"
+        },
+        "clickup-slack-standup": {
+          "description": "매일 아침 ClickUp 작업을 모아 팀 스탠드업 요약을 Slack에 게시합니다.",
+          "shortDescription": "ClickUp 작업으로 아침 스탠드업을 게시합니다.",
+          "title": "ClickUp Slack 스탠드업"
+        },
+        "compare-google-ads-last-month": {
+          "description": "광고비와 ROAS를 지난달과 비교하고 이상 신호를 Slack에 알립니다.",
+          "shortDescription": "광고비와 ROAS를 지난달과 비교합니다.",
+          "title": "Google Ads와 지난달 비교"
+        },
+        "competitive-intel-monitor": {
+          "description": "경쟁사 사이트의 가격과 기능 변화를 모니터링해 Notion에 기록하고 Slack에 알립니다.",
+          "shortDescription": "경쟁사 가격 변화를 Notion에 기록합니다.",
+          "title": "경쟁사 동향 모니터"
+        },
+        "daily-company-brief-slack": {
+          "description": "제품, 성장, 수익 데이터를 모아 Slack에 일일 브리핑을 게시합니다.",
+          "shortDescription": "제품·성장·매출을 한 편의 브리핑으로 모읍니다.",
+          "title": "Slack에 일일 회사 브리핑 게시"
+        },
+        "daily-industry-news-slack": {
+          "description": "당일 관련 산업 뉴스를 모아 Slack 브리핑으로 게시합니다.",
+          "shortDescription": "그날의 업계 소식을 Slack에 정리합니다.",
+          "title": "Slack에 일일 산업 뉴스 게시"
+        },
+        "daily-standup-report": {
+          "description": "매일 아침 제품과 엔지니어링 지표를 모아 짧은 리포트를 만들고 Slack에 게시합니다.",
+          "shortDescription": "아침마다 제품·엔지니어링 브리핑을 게시합니다.",
+          "title": "일일 스탠드업 리포트"
+        },
+        "draft-github-release-notes-notion": {
+          "description": "마지막 릴리스 이후 병합된 PR을 깔끔한 노트로 Notion에 작성합니다.",
+          "shortDescription": "머지된 PR을 Notion 릴리스 노트로 만듭니다.",
+          "title": "Notion에서 GitHub 릴리스 노트 초안 작성"
+        },
+        "draft-newsletter-mailchimp": {
+          "description": "최근 소식을 모아 Mailchimp에 뉴스레터 초안을 만듭니다.",
+          "shortDescription": "최근 소식을 모아 뉴스레터를 만듭니다.",
+          "title": "Mailchimp에서 뉴스레터 초안 작성"
+        },
+        "draft-replies-notion-faq": {
+          "description": "Notion FAQ를 기반으로 티켓 답변 초안을 작성합니다.",
+          "shortDescription": "Notion FAQ로 문의 답변 초안을 씁니다.",
+          "title": "Notion FAQ에서 답변 초안 작성"
+        },
+        "feedback-router": {
+          "description": "Slack 채널을 지켜보다가 제품 피드백에 라벨과 담당자를 붙여 Notion으로 보냅니다.",
+          "shortDescription": "Slack의 제품 피드백을 Notion으로 보냅니다.",
+          "title": "피드백 라우터"
+        },
+        "file-gmail-invoices-drive": {
+          "description": "인보이스 이메일을 Drive에 저장하고 각 항목을 시트에 기록합니다.",
+          "shortDescription": "인보이스 메일을 Drive에 저장하고 기록합니다.",
+          "title": "Gmail 인보이스를 Google Drive에 저장"
+        },
+        "file-sentry-crashes-github": {
+          "description": "새 Sentry 오류를 사용자 영향도별로 순위 매기고 심각한 오류를 GitHub 이슈로 등록합니다.",
+          "shortDescription": "심각한 Sentry 오류를 GitHub 이슈로 등록합니다.",
+          "title": "Sentry 충돌을 GitHub 이슈로 등록"
+        },
+        "flag-figma-designs-no-task": {
+          "description": "아직 연결된 Linear 작업이 없는 Figma 디자인을 표시합니다.",
+          "shortDescription": "Linear 작업이 없는 Figma 디자인을 찾아냅니다.",
+          "title": "작업 없는 Figma 디자인 표시"
+        },
+        "flagged-gmail-todoist-tasks": {
+          "description": "표시한 이메일을 자동으로 Todoist 작업으로 전환합니다.",
+          "shortDescription": "별표한 메일을 Todoist 작업으로 만듭니다.",
+          "title": "표시한 Gmail을 Todoist 작업으로 전환"
+        },
+        "github-idea-to-notion-spec": {
+          "description": "라벨이 붙은 GitHub 이슈를 구조화된 제품 사양으로 확장합니다.",
+          "shortDescription": "GitHub 이슈를 Notion 기획서로 확장합니다.",
+          "title": "GitHub 아이디어를 Notion 명세로 전환하기"
+        },
+        "github-pr-summarizer": {
+          "description": "머지된 풀 리퀘스트를 모아 Notion에 정리된 리포트로 저장하고 필요하면 Slack에도 게시합니다.",
+          "shortDescription": "머지된 풀 리퀘스트를 리포트로 모읍니다.",
+          "title": "GitHub PR 요약"
+        },
+        "gmail-followups-auto": {
+          "description": "응답하지 않은 연락처를 찾아 다음 후속 조치를 초안 작성합니다.",
+          "shortDescription": "답장이 없는 상대에게 후속 메일 초안을 씁니다.",
+          "title": "Gmail 후속 조치를 자동으로 보내기"
+        },
+        "gmail-reconnect-reminders": {
+          "description": "오랫동안 이메일을 보내지 않은 중요한 연락처를 표시합니다.",
+          "shortDescription": "한동안 연락하지 않은 사람을 알려줍니다.",
+          "title": "Gmail 재연결 알림 받기"
+        },
+        "highlight-key-emails-gmail": {
+          "description": "실제로 주의를 기울여야 하는 몇 개의 이메일을 표시합니다.",
+          "shortDescription": "지금 확인해야 할 메일을 골라줍니다.",
+          "title": "Gmail에서 주요 이메일 강조하기"
+        },
+        "investor-update-google-docs": {
+          "description": "지표와 하이라이트를 모아 Docs에 투자자 업데이트를 작성합니다.",
+          "shortDescription": "지표를 모아 투자자 업데이트를 만듭니다.",
+          "title": "Google Docs에서 투자자 업데이트 초안 작성하기"
+        },
+        "log-gong-calls-hubspot": {
+          "description": "Gong 통화에서 노트와 다음 단계를 HubSpot 거래에 가져옵니다.",
+          "shortDescription": "Gong 통화 메모를 HubSpot 거래에 기록합니다.",
+          "title": "Gong 통화를 HubSpot에 기록하기"
+        },
+        "meeting-notes-asana-tasks": {
+          "description": "회의 노트를 할당된 기한 있는 Asana 작업으로 전환합니다.",
+          "shortDescription": "회의록을 Asana 작업으로 만듭니다.",
+          "title": "회의 노트를 Asana 작업으로 전환하기"
+        },
+        "meeting-recaps-slack": {
+          "description": "각 회의 후 결정 사항과 액션 아이템이 포함된 요약을 공유합니다.",
+          "shortDescription": "회의 후 결정과 할 일을 공유합니다.",
+          "title": "Slack에서 회의 요약 받기"
+        },
+        "morning-brief": {
+          "description": "Gmail, 캘린더, Notion 업데이트를 짧은 하루 계획으로 만들어 Slack에 보냅니다.",
+          "shortDescription": "메일과 일정을 짧은 하루 계획으로 만듭니다.",
+          "title": "모닝 브리핑"
+        },
+        "new-gmail-contacts-hubspot": {
+          "description": "알 수 없는 이메일 발신자를 HubSpot 연락처로 추가하고 보강합니다.",
+          "shortDescription": "처음 보는 발신자를 HubSpot에 추가합니다.",
+          "title": "새 Gmail 연락처를 HubSpot에 추가하기"
+        },
+        "onboard-new-hires-asana": {
+          "description": "각 신입 사원을 위한 온보딩 작업 체크리스트를 Asana에 생성합니다.",
+          "shortDescription": "신규 입사자별 온보딩 체크리스트를 만듭니다.",
+          "title": "Asana에서 신입 사원 온보딩하기"
+        },
+        "personal-weekly-digest": {
+          "description": "GitHub, Gmail, 캘린더 활동을 한 주 단위로 정리해 Slack에 보냅니다.",
+          "shortDescription": "GitHub과 Gmail로 한 주를 정리합니다.",
+          "title": "개인 주간 다이제스트"
+        },
+        "post-daily-metrics-slack": {
+          "description": "일일 방문자, 가입자 및 활성화 수치를 Slack에 게시합니다.",
+          "shortDescription": "일일 방문자와 가입자를 Slack에 게시합니다.",
+          "title": "일일 지표를 Slack에 게시하기"
+        },
+        "post-release-notes-slack": {
+          "description": "최근 배포된 작업에서 변경 로그 초안을 작성해 Slack에 게시합니다.",
+          "shortDescription": "변경 사항을 정리해 Slack에 게시합니다.",
+          "title": "릴리스 노트를 Slack에 게시"
+        },
+        "prep-google-calendar-meetings": {
+          "description": "외부 참석자를 조사하고 회의 전에 준비 요약을 전송합니다.",
+          "shortDescription": "외부 미팅 전에 사전 브리핑을 보냅니다.",
+          "title": "Google 캘린더 회의 준비"
+        },
+        "publish-scheduled-posts-buffer": {
+          "description": "그날 예약된 콘텐츠를 게시하고 소셜 게시물을 대기열에 넣습니다.",
+          "shortDescription": "그날 예약된 소셜 게시물을 발행합니다.",
+          "title": "Buffer에 예정된 게시물 게시"
+        },
+        "research-calendar-meetings": {
+          "description": "각 캘린더 이벤트 전에 만나는 사람을 조사합니다.",
+          "shortDescription": "미팅 전에 만날 사람을 조사합니다.",
+          "title": "캘린더 회의 조사"
+        },
+        "research-new-signups-apollo": {
+          "description": "새 가입자를 조사하고 빠른 스냅샷을 게시합니다.",
+          "shortDescription": "새 가입자를 조사해 요약을 게시합니다.",
+          "title": "신규 가입자 조사"
+        },
+        "revenuecat-subscription-digest": {
+          "description": "구독 현황을 시트로 추적하고 이탈이나 해지 패턴이 바뀌면 Slack에 알립니다.",
+          "shortDescription": "구독을 추적하고 이탈 신호를 Slack에 알립니다.",
+          "title": "RevenueCat 구독 다이제스트"
+        },
+        "run-daily-query-sheets": {
+          "description": "저장된 SQL을 예약 실행하고 결과를 시트에 추가합니다.",
+          "shortDescription": "저장된 SQL을 실행해 시트에 결과를 추가합니다.",
+          "title": "일일 쿼리를 Google Sheets에 실행"
+        },
+        "salesforce-pipeline-digest": {
+          "description": "매주 Salesforce 기회 변동과 마감일 리스크를 Slack에 정리합니다.",
+          "shortDescription": "매주 Salesforce 파이프라인 리스크를 정리합니다.",
+          "title": "Salesforce 파이프라인 다이제스트"
+        },
+        "send-bugs-github-slack": {
+          "description": "버그 태그가 붙은 보고서를 GitHub 이슈로 등록하고 팀에 Slack 알림을 보냅니다.",
+          "shortDescription": "버그 제보를 GitHub 이슈로 등록합니다.",
+          "title": "버그를 GitHub와 Slack에 전송"
+        },
+        "sentry-issue-digest": {
+          "description": "심각도가 높은 Sentry 이슈를 매일 정리해 Slack으로 보냅니다.",
+          "shortDescription": "심각한 Sentry 이슈를 매일 정리해 보냅니다.",
+          "title": "Sentry 이슈 다이제스트"
+        },
+        "sort-gmail-draft-replies": {
+          "description": "받은편지함을 정리하고 답장이 필요한 이메일에 답장 초안을 작성합니다.",
+          "shortDescription": "받은편지함을 정리하고 답장 초안을 씁니다.",
+          "title": "Gmail 정리 및 답장 초안 작성"
+        },
+        "spot-churn-risk-stripe-zendesk": {
+          "description": "이탈 위험 계정을 표시하고 복구 이메일을 초안 작성합니다.",
+          "shortDescription": "이탈 위험을 찾아 회복 메일을 준비합니다.",
+          "title": "Stripe와 Zendesk에서 이탈 위험 감지"
+        },
+        "summarize-gmail-newsletters": {
+          "description": "받은편지함 뉴스레터를 한 줄 요약으로 정리합니다.",
+          "shortDescription": "뉴스레터를 하나의 요약으로 정리합니다.",
+          "title": "Gmail 뉴스레터 요약"
+        },
+        "summarize-zendesk-tickets-daily": {
+          "description": "지난 하루 Zendesk 티켓을 요약해 Slack에 게시합니다.",
+          "shortDescription": "Zendesk 티켓을 매일 요약해 게시합니다.",
+          "title": "Zendesk 티켓 일일 요약"
+        },
+        "support-ticket-router": {
+          "description": "고객 문의 메일을 분류해 Notion에 기록하고 긴급 건은 Slack에 알립니다.",
+          "shortDescription": "문의 메일을 분류하고 긴급 건을 표시합니다.",
+          "title": "고객 문의 라우터"
+        },
+        "sync-asana-projects-notion": {
+          "description": "Asana 프로젝트 상태를 Notion의 단일 보드로 집계",
+          "shortDescription": "Asana 프로젝트 현황을 Notion에 모읍니다.",
+          "title": "Asana 프로젝트를 Notion과 동기화"
+        },
+        "sync-linear-roadmap-notion": {
+          "description": "Notion 로드맵을 Linear 이슈 상태와 동기화하세요.",
+          "shortDescription": "Notion 로드맵을 Linear와 동기화합니다.",
+          "title": "Linear 로드맵을 Notion과 동기화"
+        },
+        "track-feature-usage-posthog": {
+          "description": "PostHog에서 주간 기능 사용량의 가장 큰 변화를 표시합니다.",
+          "shortDescription": "이번 주 사용량 변화가 큰 기능을 알려줍니다.",
+          "title": "PostHog로 기능 사용량 추적"
+        },
+        "track-keyword-ranks-ahrefs": {
+          "description": "Ahrefs에서 키워드 순위를 추적하고 변동이 큰 키워드를 Notion에 정리합니다.",
+          "shortDescription": "이번 주 키워드 순위 변동을 정리합니다.",
+          "title": "Ahrefs로 키워드 순위 추적"
+        },
+        "track-signup-sources-sheets": {
+          "description": "각 신규 가입을 추적 시트의 출처에 연결합니다.",
+          "shortDescription": "가입 경로를 시트에 정리합니다.",
+          "title": "Google 시트에서 가입 출처 추적"
+        },
+        "vercel-deploy-digest": {
+          "description": "Vercel 배포를 모니터링해 GitHub 커밋과 연결하고 실패하면 Slack에 알립니다.",
+          "shortDescription": "Vercel 배포가 실패하면 Slack에 알립니다.",
+          "title": "Vercel 배포 다이제스트"
+        },
+        "x-brand-monitor": {
+          "description": "X에서 브랜드 언급을 추적해 관련 게시물을 Notion에 저장하고 중요한 언급은 Slack에 알립니다.",
+          "shortDescription": "X에서 눈에 띄는 브랜드 언급을 Slack에 알립니다.",
+          "title": "X 브랜드 모니터"
+        },
+        "zendesk-knowledge-base": {
+          "description": "Zendesk에서 반복되는 질문을 찾아 FAQ 초안을 만들고 Notion에 저장합니다.",
+          "shortDescription": "반복되는 질문을 FAQ 항목으로 만듭니다.",
+          "title": "Zendesk 지식베이스"
+        }
+      },
+      "workflowCategories": {
+        "CEO": "CEO",
+        "Data": "데이터",
+        "Engineering": "엔지니어링",
+        "Everyone": "모두",
+        "Marketing": "마케팅",
+        "Operations": "운영",
+        "Product": "제품",
+        "Sales": "영업",
+        "Support": "지원"
+      }
     },
     "title": "아티팩트",
     "toasts": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -686,7 +686,325 @@
       "useThisTemplate": "Usar este modelo",
       "website": "Site",
       "websitePreview": "Visualização do modelo de site {{title}}",
-      "workflow": "Fluxo de trabalho"
+      "workflow": "Fluxo de trabalho",
+      "workflowCatalog": {
+        "alert-metric-moves-slack": {
+          "description": "Monitore suas métricas-chave e avise o Slack quando uma mudar drasticamente.",
+          "shortDescription": "Avisa no Slack quando uma métrica-chave dispara.",
+          "title": "Alerta quando uma métrica muda"
+        },
+        "auto-inbox-label": {
+          "description": "Crie um fluxo que roda quando um marcador do Gmail é aplicado e cuida da mensagem marcada.",
+          "shortDescription": "Roda um fluxo quando você aplica um marcador do Gmail.",
+          "title": "Marcador automático da caixa de entrada"
+        },
+        "auto-merge-github-prs": {
+          "description": "Revise PRs rotulados como prontos para mesclar, aguarde o CI, depois mescle e publique no Slack.",
+          "shortDescription": "Mescla os PRs prontos quando a CI passa.",
+          "title": "Mesclar PRs do GitHub automaticamente"
+        },
+        "blog-posts-to-x": {
+          "description": "Transforme cada novo post do blog em variações sociais na fila do Buffer.",
+          "shortDescription": "Transforma cada novo post do blog em posts sociais.",
+          "title": "Transformar posts de blog em posts sociais"
+        },
+        "build-weekly-deck-gamma": {
+          "description": "Transforme as métricas da semana em um deck pronto para apresentação no Gamma.",
+          "shortDescription": "Transforma as métricas da semana em um deck no Gamma.",
+          "title": "Criar o deck semanal no Gamma"
+        },
+        "business-review-gamma": {
+          "description": "Transforme as métricas do mês em uma apresentação de revisão de negócios no Gamma.",
+          "shortDescription": "Transforma as métricas do mês em um deck de review.",
+          "title": "Construir a revisão de negócios no Gamma"
+        },
+        "catch-calendar-conflicts": {
+          "description": "Verifique seu calendário em busca de reservas duplas e alerte você com antecedência.",
+          "shortDescription": "Descobre cedo as reservas duplicadas na agenda.",
+          "title": "Identificar conflitos no Google Calendar"
+        },
+        "catch-leads-gmail": {
+          "description": "Identifique sinais de compra em novos e-mails e registre os leads qualificados.",
+          "shortDescription": "Percebe sinais de compra e registra os leads.",
+          "title": "Capturar leads do Gmail"
+        },
+        "chase-overdue-asana-tasks": {
+          "description": "Encontre tarefas do Asana em atraso e lembre seus responsáveis no Slack.",
+          "shortDescription": "Cobra os responsáveis por tarefas atrasadas no Asana.",
+          "title": "Cobrar tarefas do Asana em atraso"
+        },
+        "check-posthog-signup-funnel": {
+          "description": "Acompanhe o funil de inscrição e envie a maior queda para o Slack.",
+          "shortDescription": "Publica onde o funil de cadastro mais perde gente.",
+          "title": "Verificar o funil de inscrição do PostHog"
+        },
+        "clickup-slack-standup": {
+          "description": "Reúna as tarefas do ClickUp toda manhã e publique o standup do time no Slack.",
+          "shortDescription": "Publica o standup da manhã a partir do ClickUp.",
+          "title": "Standup do ClickUp no Slack"
+        },
+        "compare-google-ads-last-month": {
+          "description": "Compare investimento e ROAS com o mês passado e aponte as anomalias no Slack.",
+          "shortDescription": "Compara investimento e ROAS com o mês passado.",
+          "title": "Comparar Google Ads com o mês passado"
+        },
+        "competitive-intel-monitor": {
+          "description": "Acompanhe preços e recursos nos sites dos concorrentes, registre no Notion e avise no Slack.",
+          "shortDescription": "Registra no Notion as mudanças de preço dos concorrentes.",
+          "title": "Monitor da concorrência"
+        },
+        "daily-company-brief-slack": {
+          "description": "Reúna dados de produto, crescimento e receita em um resumo diário no Slack.",
+          "shortDescription": "Junta produto, crescimento e receita em um resumo.",
+          "title": "Publicar um resumo diário da empresa no Slack"
+        },
+        "daily-industry-news-slack": {
+          "description": "Reúna as notícias relevantes do dia da indústria em um resumo no Slack.",
+          "shortDescription": "Reúne as notícias do setor para o Slack.",
+          "title": "Publicar notícias diárias da indústria no Slack"
+        },
+        "daily-standup-report": {
+          "description": "Reúna todas as manhãs os sinais de produto e engenharia, monte um relatório curto e publique no Slack.",
+          "shortDescription": "Publica de manhã um resumo de produto e engenharia.",
+          "title": "Relatório diário de standup"
+        },
+        "draft-github-release-notes-notion": {
+          "description": "Transforme os PRs mesclados desde o último lançamento em notas limpas no Notion.",
+          "shortDescription": "Transforma PRs mesclados em notas de versão no Notion.",
+          "title": "Rascunhar notas de lançamento do GitHub no Notion"
+        },
+        "draft-newsletter-mailchimp": {
+          "description": "Reúna as novidades recentes em um rascunho de newsletter no Mailchimp.",
+          "shortDescription": "Reúne as novidades recentes em uma newsletter.",
+          "title": "Rascunhar a newsletter no Mailchimp"
+        },
+        "draft-replies-notion-faq": {
+          "description": "Redija respostas para tickets com base na sua FAQ do Notion.",
+          "shortDescription": "Escreve respostas a partir do seu FAQ no Notion.",
+          "title": "Redigir respostas da sua FAQ do Notion"
+        },
+        "feedback-router": {
+          "description": "Acompanhe um canal do Slack e leve o feedback de produto para o Notion com marcadores e responsáveis.",
+          "shortDescription": "Leva o feedback de produto do Slack para o Notion.",
+          "title": "Roteador de feedback"
+        },
+        "file-gmail-invoices-drive": {
+          "description": "Arquive e-mails de faturas no Drive e registre cada um em uma planilha.",
+          "shortDescription": "Arquiva e-mails de fatura no Drive e registra cada um.",
+          "title": "Arquivar faturas do Gmail no Google Drive"
+        },
+        "file-sentry-crashes-github": {
+          "description": "Classifique novos erros do Sentry por impacto no usuário e registre os piores como problemas do GitHub.",
+          "shortDescription": "Abre issues no GitHub para os piores erros do Sentry.",
+          "title": "Registrar falhas do Sentry como problemas do GitHub"
+        },
+        "flag-figma-designs-no-task": {
+          "description": "Sinalizar designs do Figma que ainda não têm uma tarefa vinculada ao Linear.",
+          "shortDescription": "Aponta designs do Figma sem tarefa no Linear.",
+          "title": "Sinalizar designs do Figma sem uma tarefa"
+        },
+        "flagged-gmail-todoist-tasks": {
+          "description": "Transforme os e-mails que você sinaliza em tarefas do Todoist automaticamente.",
+          "shortDescription": "Transforma e-mails sinalizados em tarefas no Todoist.",
+          "title": "Transformar e-mails sinalizados do Gmail em tarefas do Todoist"
+        },
+        "github-idea-to-notion-spec": {
+          "description": "Expanda um problema rotulado do GitHub em uma especificação de produto estruturada no Notion.",
+          "shortDescription": "Expande uma issue do GitHub em uma spec no Notion.",
+          "title": "Transformar uma ideia do GitHub em uma especificação do Notion"
+        },
+        "github-pr-summarizer": {
+          "description": "Reúna os pull requests mesclados, salve um relatório estruturado no Notion e, se quiser, publique no Slack.",
+          "shortDescription": "Reúne os pull requests mesclados em um relatório.",
+          "title": "Resumo de PRs do GitHub"
+        },
+        "gmail-followups-auto": {
+          "description": "Encontre contatos que não responderam e elabore o próximo follow-up.",
+          "shortDescription": "Escreve follow-ups para quem não respondeu.",
+          "title": "Enviar follow-ups do Gmail automaticamente"
+        },
+        "gmail-reconnect-reminders": {
+          "description": "Destaque contatos importantes com quem você não enviou e-mail há um tempo.",
+          "shortDescription": "Mostra contatos com quem você não fala há tempo.",
+          "title": "Receber lembretes de reconexão do Gmail"
+        },
+        "highlight-key-emails-gmail": {
+          "description": "Destaque os poucos e-mails que realmente precisam da sua atenção.",
+          "shortDescription": "Destaca os e-mails que precisam de você.",
+          "title": "Destacar e-mails importantes no Gmail"
+        },
+        "investor-update-google-docs": {
+          "description": "Monte métricas e destaques em uma atualização para investidores no Docs.",
+          "shortDescription": "Reúne as métricas em um update para investidores.",
+          "title": "Redigir a atualização para investidores no Google Docs"
+        },
+        "log-gong-calls-hubspot": {
+          "description": "Puxe notas e próximos passos de uma chamada do Gong para o negócio no HubSpot.",
+          "shortDescription": "Leva as notas das calls do Gong para o negócio no HubSpot.",
+          "title": "Registrar chamadas do Gong no HubSpot"
+        },
+        "meeting-notes-asana-tasks": {
+          "description": "Transforme notas de reunião em tarefas atribuídas e com prazo no Asana.",
+          "shortDescription": "Transforma notas de reunião em tarefas no Asana.",
+          "title": "Transformar notas de reunião em tarefas do Asana"
+        },
+        "meeting-recaps-slack": {
+          "description": "Compartilhe um resumo com decisões e itens de ação após cada reunião.",
+          "shortDescription": "Compartilha decisões e próximos passos após reuniões.",
+          "title": "Receber resumos de reuniões no Slack"
+        },
+        "morning-brief": {
+          "description": "Transforme as novidades do Gmail, Agenda e Notion em um plano diário curto no Slack.",
+          "shortDescription": "Transforma e-mails e reuniões em um plano do dia.",
+          "title": "Resumo da manhã"
+        },
+        "new-gmail-contacts-hubspot": {
+          "description": "Adicione e enriqueça remetentes de e-mail desconhecidos como contatos do HubSpot.",
+          "shortDescription": "Adiciona ao HubSpot remetentes desconhecidos.",
+          "title": "Adicionar novos contatos do Gmail ao HubSpot"
+        },
+        "onboard-new-hires-asana": {
+          "description": "Crie a lista de verificação de tarefas de integração para cada novo contratado no Asana.",
+          "shortDescription": "Cria um checklist de integração por nova contratação.",
+          "title": "Integrar novos contratados no Asana"
+        },
+        "personal-weekly-digest": {
+          "description": "Resuma a atividade do GitHub, Gmail e Agenda em uma atualização semanal no Slack.",
+          "shortDescription": "Resume sua semana no GitHub e no Gmail.",
+          "title": "Resumo semanal pessoal"
+        },
+        "post-daily-metrics-slack": {
+          "description": "Publicar visitantes diários, inscrições e números de ativação no Slack.",
+          "shortDescription": "Publica visitantes e cadastros do dia no Slack.",
+          "title": "Publicar métricas diárias no Slack"
+        },
+        "post-release-notes-slack": {
+          "description": "Rascunhe um changelog do trabalho recentemente enviado e publique no Slack.",
+          "shortDescription": "Escreve um changelog e publica no Slack.",
+          "title": "Publicar notas de lançamento no Slack"
+        },
+        "prep-google-calendar-meetings": {
+          "description": "Pesquise participantes externos e envie um resumo antes das reuniões.",
+          "shortDescription": "Envia um resumo antes das reuniões externas.",
+          "title": "Preparar reuniões do Google Calendar"
+        },
+        "publish-scheduled-posts-buffer": {
+          "description": "Publique o conteúdo agendado do dia e coloque os posts sociais na fila.",
+          "shortDescription": "Publica os posts sociais agendados para hoje.",
+          "title": "Publicar posts agendados no Buffer"
+        },
+        "research-calendar-meetings": {
+          "description": "Pesquise as pessoas que você vai encontrar antes de cada evento no calendário.",
+          "shortDescription": "Pesquisa quem você vai encontrar antes de cada evento.",
+          "title": "Pesquise suas reuniões no calendário"
+        },
+        "research-new-signups-apollo": {
+          "description": "Pesquise cada nova inscrição e publique um rápido resumo.",
+          "shortDescription": "Pesquisa cada novo cadastro e publica um panorama.",
+          "title": "Pesquisar novas inscrições"
+        },
+        "revenuecat-subscription-digest": {
+          "description": "Acompanhe as assinaturas em uma planilha e avise no Slack quando o churn ou os cancelamentos mudarem.",
+          "shortDescription": "Acompanha assinaturas e avisa no Slack sobre churn.",
+          "title": "Resumo de assinaturas do RevenueCat"
+        },
+        "run-daily-query-sheets": {
+          "description": "Execute sua SQL salva em um cronograma e anexe os resultados a uma planilha.",
+          "shortDescription": "Roda um SQL salvo e adiciona o resultado à planilha.",
+          "title": "Executar uma consulta diária no Google Sheets"
+        },
+        "salesforce-pipeline-digest": {
+          "description": "Resuma toda semana no Slack as mudanças nas oportunidades do Salesforce e os riscos de data de fechamento.",
+          "shortDescription": "Resume toda semana os riscos do pipeline.",
+          "title": "Resumo do pipeline do Salesforce"
+        },
+        "send-bugs-github-slack": {
+          "description": "Registre relatórios marcados como bugs como problemas no GitHub e avise a equipe no Slack.",
+          "shortDescription": "Registra relatos de bug como issues no GitHub.",
+          "title": "Enviar bugs para GitHub e Slack"
+        },
+        "sentry-issue-digest": {
+          "description": "Envie ao Slack um resumo diário dos problemas críticos e graves do Sentry.",
+          "shortDescription": "Envia diariamente os problemas críticos do Sentry.",
+          "title": "Resumo de problemas do Sentry"
+        },
+        "sort-gmail-draft-replies": {
+          "description": "Classifique sua caixa de entrada e rascunhe respostas para os e-mails que precisam delas.",
+          "shortDescription": "Organiza a caixa de entrada e rascunha as respostas.",
+          "title": "Classificar Gmail e rascunhar respostas"
+        },
+        "spot-churn-risk-stripe-zendesk": {
+          "description": "Marque contas em risco de churn e redija um e-mail de recuperação.",
+          "shortDescription": "Aponta risco de churn e escreve um e-mail.",
+          "title": "Identificar risco de churn no Stripe e Zendesk"
+        },
+        "summarize-gmail-newsletters": {
+          "description": "Resuma as newsletters na sua caixa de entrada em um breve resumo.",
+          "shortDescription": "Condensa suas newsletters em um só resumo.",
+          "title": "Resumir newsletters do Gmail"
+        },
+        "summarize-zendesk-tickets-daily": {
+          "description": "Resuma o último dia de tickets do Zendesk e publique no Slack.",
+          "shortDescription": "Publica um resumo diário dos tickets do Zendesk.",
+          "title": "Resumir tickets do Zendesk diariamente"
+        },
+        "support-ticket-router": {
+          "description": "Classifique os e-mails de suporte, crie registros no Notion e avise no Slack sobre tickets críticos.",
+          "shortDescription": "Classifica e-mails de suporte e marca os críticos.",
+          "title": "Roteador de tickets de suporte"
+        },
+        "sync-asana-projects-notion": {
+          "description": "Consolide o status dos projetos do Asana em um único quadro no Notion.",
+          "shortDescription": "Consolida o status dos projetos do Asana no Notion.",
+          "title": "Sincronizar projetos do Asana com o Notion"
+        },
+        "sync-linear-roadmap-notion": {
+          "description": "Mantenha um roadmap no Notion em sincronia com o status dos seus problemas do Linear.",
+          "shortDescription": "Mantém o roadmap do Notion em dia com o Linear.",
+          "title": "Sincronizar o roadmap do Linear com o Notion"
+        },
+        "track-feature-usage-posthog": {
+          "description": "Identifique as maiores mudanças semanais no uso de recursos a partir do PostHog.",
+          "shortDescription": "Mostra as maiores mudanças de uso da semana.",
+          "title": "Rastrear uso de recursos com PostHog"
+        },
+        "track-keyword-ranks-ahrefs": {
+          "description": "Acompanhe as posições das palavras-chave no Ahrefs e registre as maiores variações no Notion.",
+          "shortDescription": "Relata as variações de posição da semana.",
+          "title": "Rastrear posições de palavras-chave com Ahrefs"
+        },
+        "track-signup-sources-sheets": {
+          "description": "Atribua cada nova inscrição à sua fonte em uma planilha de rastreamento.",
+          "shortDescription": "Atribui cada cadastro à sua origem na planilha.",
+          "title": "Rastrear fontes de inscrição no Google Sheets"
+        },
+        "vercel-deploy-digest": {
+          "description": "Acompanhe os deploys da Vercel, ligue-os aos commits do GitHub e avise no Slack quando falharem.",
+          "shortDescription": "Avisa no Slack quando um deploy da Vercel falha.",
+          "title": "Resumo de deploys da Vercel"
+        },
+        "x-brand-monitor": {
+          "description": "Acompanhe menções à marca no X, salve os posts relevantes no Notion e avise no Slack sobre os mais fortes.",
+          "shortDescription": "Avisa no Slack sobre menções fortes à marca no X.",
+          "title": "Monitor de marca no X"
+        },
+        "zendesk-knowledge-base": {
+          "description": "Encontre as perguntas recorrentes no Zendesk, escreva entradas de FAQ e salve no Notion.",
+          "shortDescription": "Transforma perguntas recorrentes em itens de FAQ.",
+          "title": "Base de conhecimento do Zendesk"
+        }
+      },
+      "workflowCategories": {
+        "CEO": "CEO",
+        "Data": "Dados",
+        "Engineering": "Engenharia",
+        "Everyone": "Todos",
+        "Marketing": "Marketing",
+        "Operations": "Operações",
+        "Product": "Produto",
+        "Sales": "Vendas",
+        "Support": "Suporte"
+      }
     },
     "title": "Artefatos",
     "toasts": {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -3156,6 +3156,38 @@ describe("chat composer templates", () => {
     });
   });
 
+  it("localizes the workflow catalog in the picker", async () => {
+    const workflowTemplate = WORKFLOW_TEMPLATE_ITEMS[0]!;
+    context.mocks.data.userPreferences({ locale: "pt-BR" });
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Modelo");
+      }),
+    );
+    await waitFor(() => {
+      expect(tabByText("Fluxo de trabalho")).toBeInTheDocument();
+    });
+    click(tabByText("Fluxo de trabalho"));
+
+    // The catalog ships English copy; the card and the persona pills read the
+    // reader's language instead.
+    await waitFor(() => {
+      expect(
+        screen.getByText("Marcador automático da caixa de entrada"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText(workflowTemplate.title)).toBeNull();
+    expect(screen.queryByText(workflowTemplate.description)).toBeNull();
+    expect(screen.getByText("Engenharia")).toBeInTheDocument();
+  });
+
   it("selects and sends a website template", async () => {
     const user = userEvent.setup({ delay: null });
     const websiteTemplate = WEBSITE_TEMPLATE_ITEMS[0]!;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-start-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-start-cards.test.tsx
@@ -31,6 +31,10 @@ const PT_BR_TITLES = [
   "Criar um vídeo",
   "Criar um avatar",
 ] as const;
+// The catalog's own English wording, which only en-US readers should see.
+const EN_WORKFLOW_TITLES = WORKFLOW_TEMPLATE_ITEMS.map((item) => {
+  return item.title;
+});
 const PT_BR_PLACEHOLDER =
   "Peça para automatizar fluxos de trabalho, gerenciar tarefas...";
 
@@ -69,14 +73,12 @@ describe("chat start cards", () => {
     ).resolves.toBeInTheDocument();
 
     expect(startCards()).toHaveLength(3);
-    const workflowTitles = WORKFLOW_TEMPLATE_ITEMS.map((item) => {
-      return item.title;
-    });
     // At most one of the three kinds is the workflow card, so at least two
     // titles always come from the localized catalog.
     expect(renderedTitles(EN_TITLES).length).toBeGreaterThanOrEqual(2);
     expect(
-      renderedTitles(EN_TITLES).length + renderedTitles(workflowTitles).length,
+      renderedTitles(EN_TITLES).length +
+        renderedTitles(EN_WORKFLOW_TITLES).length,
     ).toBe(3);
     expect(screen.getAllByText("Create")).toHaveLength(3);
     expect(templateButtons()).toHaveLength(3);
@@ -134,6 +136,8 @@ describe("chat start cards", () => {
 
     expect(renderedTitles(PT_BR_TITLES).length).toBeGreaterThanOrEqual(2);
     expect(renderedTitles(EN_TITLES)).toStrictEqual([]);
+    // The workflow card names a catalog template, which is localized too.
+    expect(renderedTitles(EN_WORKFLOW_TITLES)).toStrictEqual([]);
     expect(screen.getAllByText("Modelos")).toHaveLength(3);
     expect(screen.queryByText("Templates")).toBeNull();
   });

--- a/turbo/apps/platform/src/views/zero-page/workflow-template-copy.ts
+++ b/turbo/apps/platform/src/views/zero-page/workflow-template-copy.ts
@@ -1,0 +1,59 @@
+import type { WorkflowTemplateItem } from "@okouai/core/workflow-template-items";
+import { i18n } from "../../i18n/index.ts";
+import enUSCommon from "../../i18n/locales/en-US/common.json";
+
+// The catalog lives in core, which ships one English string per field. Every
+// surface that shows a template to the user reads its copy from here instead,
+// keyed by the catalog slug. en-US carries the catalog's own wording, so a
+// template added before its translations land keeps its English copy.
+const TEMPLATE_COPY = enUSCommon.artifacts.templates.workflowCatalog;
+const CATEGORY_COPY = enUSCommon.artifacts.templates.workflowCategories;
+
+type TemplateSlug = keyof typeof TEMPLATE_COPY;
+type TemplateCategory = keyof typeof CATEGORY_COPY;
+
+const TEMPLATE_ID_PREFIX = "workflow-template:";
+
+function isTemplateSlug(value: string): value is TemplateSlug {
+  return Object.hasOwn(TEMPLATE_COPY, value);
+}
+
+function isTemplateCategory(value: string): value is TemplateCategory {
+  return Object.hasOwn(CATEGORY_COPY, value);
+}
+
+/**
+ * The template with its user-visible copy in the reader's language. The
+ * connectors and the prompt guidance are unchanged: the guidance is context for
+ * the agent, which answers in the user's language on its own.
+ */
+export function localizedWorkflowTemplate(
+  item: WorkflowTemplateItem,
+): WorkflowTemplateItem {
+  const slug = item.id.slice(TEMPLATE_ID_PREFIX.length);
+  if (!isTemplateSlug(slug)) {
+    return item;
+  }
+  return {
+    ...item,
+    title: i18n.t(($) => {
+      return $.artifacts.templates.workflowCatalog[slug].title;
+    }),
+    description: i18n.t(($) => {
+      return $.artifacts.templates.workflowCatalog[slug].description;
+    }),
+    shortDescription: i18n.t(($) => {
+      return $.artifacts.templates.workflowCatalog[slug].shortDescription;
+    }),
+  };
+}
+
+/** The persona group's name in the reader's language. */
+export function localizedWorkflowTemplateCategory(category: string): string {
+  if (!isTemplateCategory(category)) {
+    return category;
+  }
+  return i18n.t(($) => {
+    return $.artifacts.templates.workflowCategories[category];
+  });
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -237,6 +237,10 @@ import {
 } from "./avatar-template-picker.tsx";
 import { ComposerVideoOptionsChip } from "./composer-video-options.tsx";
 import {
+  localizedWorkflowTemplate,
+  localizedWorkflowTemplateCategory,
+} from "./workflow-template-copy.ts";
+import {
   DEFAULT_IMAGE_MODEL,
   IMAGE_MODEL_CONFIGS,
   IMAGE_MODEL_VARIANT_GROUPS,
@@ -821,7 +825,10 @@ function selectedTemplateTitle(
     );
   }
   if (value?.type === "workflow") {
-    return selectedWorkflowTemplateItem(value)?.title;
+    const workflowItem = selectedWorkflowTemplateItem(value);
+    return workflowItem
+      ? localizedWorkflowTemplate(workflowItem).title
+      : undefined;
   }
   if (value?.type === "website") {
     return selectedWebsiteTemplateItem(value)?.title;
@@ -946,10 +953,15 @@ function workflowTemplateMatchesSearch(
   if (!normalizedQuery) {
     return true;
   }
+  // Both wordings are searchable: the reader types in their own language, and
+  // connector names stay English in every locale.
+  const copy = localizedWorkflowTemplate(item);
   const searchable = [
     item.title,
     item.id,
     item.description,
+    copy.title,
+    copy.description,
     item.connectorSlugs.join(" "),
   ].join(" ");
   return searchable.toLowerCase().includes(normalizedQuery);
@@ -1427,6 +1439,7 @@ function WorkflowTemplateCard({
   onSelect: (item: WorkflowTemplateItem) => void;
 }) {
   const { t } = useTranslation();
+  const copy = localizedWorkflowTemplate(item);
   return (
     <div
       className={cn(
@@ -1436,9 +1449,9 @@ function WorkflowTemplateCard({
         selected && TEMPLATE_TILE_RING_SELECTED,
       )}
     >
-      <p className="text-sm font-semibold text-foreground">{item.title}</p>
+      <p className="text-sm font-semibold text-foreground">{copy.title}</p>
       <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
-        {item.description}
+        {copy.description}
       </p>
       <div className="mt-auto flex items-center gap-2 pt-3.5">
         <WorkflowTemplateConnectorIcons
@@ -1452,7 +1465,7 @@ function WorkflowTemplateCard({
               return $.artifacts.templates.selectWorkflow;
             },
             {
-              title: item.title,
+              title: copy.title,
             },
           )}
           aria-pressed={selected}
@@ -1540,7 +1553,7 @@ function WorkflowTemplatePillRow({
               ? t(($) => {
                   return $.artifacts.templates.all;
                 })
-              : pill}
+              : localizedWorkflowTemplateCategory(pill)}
           </button>
         );
       })}
@@ -5507,7 +5520,7 @@ function selectedComposerTemplateAttachment(
   if (workflowItem) {
     return {
       type: "workflow",
-      title: workflowItem.title,
+      title: localizedWorkflowTemplate(workflowItem).title,
       category: "workflow",
     };
   }

--- a/turbo/apps/platform/src/views/zero-page/zero-start-cards.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-start-cards.tsx
@@ -13,6 +13,7 @@ import {
   type StartCardKind,
 } from "../../signals/zero-page/zero-start-cards.ts";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
+import { localizedWorkflowTemplate } from "./workflow-template-copy.ts";
 
 // Every kind draws into the same square slot so the row reads as one family.
 // The card is only ~292px wide, so the tile stays small enough to leave the
@@ -439,11 +440,14 @@ export function StartCards({
     template: WorkflowTemplateItem | undefined,
   ): StartCardContent => {
     if (kind === "workflow") {
+      const localized = template
+        ? localizedWorkflowTemplate(template)
+        : undefined;
       return {
-        title: template?.title ?? "",
+        title: localized?.title ?? "",
         // The catalog's own `description` is written for the template picker
         // and runs past the two lines this card has.
-        description: template?.shortDescription ?? "",
+        description: localized?.shortDescription ?? "",
         prompt: template?.promptGuidance ?? "",
       };
     }


### PR DESCRIPTION
## Problem

On a non-English locale, the chat landing row mixes translated cards with an untranslated one: the workflow card shows the catalog's English title and short description (e.g. "Catch Google Calendar conflicts" / "Catch double-bookings in your calendar early." next to "영상 만들기" and "일러스트 만들기").

The cause is that `WORKFLOW_TEMPLATE_ITEMS` lives in `@okouai/core` and ships one English string per field. Every surface that renders it was reading those strings verbatim:

- the chat landing workflow start card (`zero-start-cards.tsx`)
- the template picker's workflow cards and their `Select workflow template …` labels
- the persona pill row (`Everyone`, `Engineering`, …)
- the selected-template chip in the composer

## Change

- Add `artifacts.templates.workflowCatalog.<slug>.{title,description,shortDescription}` and `artifacts.templates.workflowCategories.<category>` to the common namespace for all ten locales. `en-US` carries the catalog's own wording, so English is unchanged.
- Read the copy through one helper, `localizedWorkflowTemplate()` / `localizedWorkflowTemplateCategory()`, used by the start card, the picker cards, the pills, and the chip. A template without an entry keeps its English copy.
- Search matches the English and the localized wording, so a reader can type in either language.
- `promptGuidance` and connectors are untouched: the guidance is context for the agent, not user-visible copy.
- Preserve the new dynamic keys in `i18next.config.ts`.

Translations reuse the existing onboarding wording where the same template already had it (46 titles, 41 descriptions), so the picker and the onboarding cards read the same in every locale.

## Fallbacks

- `workflow-template-copy.ts:localizedWorkflowTemplate` / `localizedWorkflowTemplateCategory` — a catalog slug or persona name with no entry in `artifacts.templates.workflowCatalog` / `workflowCategories` keeps the catalog's own English copy instead of rendering a raw key path. The catalog lives in `@okouai/core` and its id type is `workflow-template:${string}`, so a template added there without i18n keys is a reachable state that no type or schema prevents. Surface: client-only presentational default, no cross-version rollout window (nothing is persisted or negotiated across deploys). Remove when the catalog ids become a literal union that can type the copy map as `Record<Slug, Copy>`, which makes the missing-entry state unrepresentable.

## Tests

- `chat-start-cards`: the pt-BR case now also asserts no English catalog title renders.
- `chat-composer-template-picker`: new case asserting the workflow tab shows the localized title and persona pill and neither English string.

Local `pnpm` checks could not run in this environment (the npm registry is not reachable from the sandbox), so lint, types, and tests run on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)