### PR TITLE
feat: point runs at the deck reverse-engineering guide

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1581,6 +1581,42 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
   });
 
+  it("names the deck guide in the agent tools prompt only once presentation templates are on", async () => {
+    const api = createRunsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    // The guide is not a mounted skill, so the prompt is the only thing that
+    // tells a run where to find it. Off, it must stay out of every run.
+    const gatedOff = await api.createRun(actor, {
+      agentId,
+      prompt: "turn this deck into a template",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const gatedOffClaim = await api.claimRunnerJob(gatedOff.runId);
+    expect(gatedOffClaim.appendSystemPrompt ?? "").toContain("# Agent Tools");
+    expect(gatedOffClaim.appendSystemPrompt ?? "").not.toContain(
+      "vm0-ai/Template-artifact",
+    );
+
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.PresentationTemplates]: true,
+    });
+
+    const gatedOn = await api.createRun(actor, {
+      agentId,
+      prompt: "turn this deck into a template",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const gatedOnClaim = await api.claimRunnerJob(gatedOn.runId);
+    const appendSystemPrompt = gatedOnClaim.appendSystemPrompt ?? "";
+    expect(appendSystemPrompt).toContain("vm0-ai/Template-artifact");
+    expect(appendSystemPrompt).toContain("reverse-template");
+    expect(appendSystemPrompt).toContain("feat/reverse-template-skill");
+  });
+
   it("emits api dispatch timing for exact-empty direct dispatch runs", async () => {
     const api = createRunsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -12,7 +12,12 @@ import type { ModelProviderCredentialScope } from "@okouai/api-contracts/contrac
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { permissionGrantsToFirewallPolicies } from "@okouai/connectors/firewall-metadata/policy";
 import type { FirewallPolicies } from "@okouai/connectors/firewall-types";
-import type { FeatureSwitchContext } from "@okouai/core/feature-switch";
+import {
+  isFeatureEnabled,
+  type FeatureSwitchContext,
+} from "@okouai/core/feature-switch";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { presentationTemplateSkillInstruction } from "@okouai/core/presentation-template-skill";
 import {
   agentDisplayNameForPublicBrand,
   appUrlForPublicBrand,
@@ -349,6 +354,7 @@ function buildIntegrationToolsPrompt(
 function buildAgentToolsPrompt(args: {
   readonly triggerSource: TriggerSource;
   readonly cloudBrowserEnabled: boolean | undefined;
+  readonly presentationTemplatesEnabled: boolean;
 }): string {
   const okouCliCommand = `npx --yes --package="\${CLI_PKG_URL}" okou`;
   return [
@@ -359,6 +365,9 @@ function buildAgentToolsPrompt(args: {
     "- Locate local agent-session files, search web chat messages, or inspect external services via connectors: `okou search --help`.",
     '- Workflow and automation requests use the `workflow-setup` skill first, then follow its guidance. This covers creating, editing, inspecting, running, scheduling, enabling, disabling, copying, or deleting a workflow or automation, and any recurring or event-driven request (for example "every morning", "when a new email arrives", "whenever X happens", "monitor", "remind me", "keep this in sync") even when the user does not say the word "workflow".',
     "- Manage recurring workflow automations: `okou workflow automation --help`. Do NOT use /loop, cron tools (CronCreate, CronList, CronDelete), or ScheduleWakeup — they are not available.",
+    ...(args.presentationTemplatesEnabled
+      ? [`- ${presentationTemplateSkillInstruction()}`]
+      : []),
     "- Browser access: `agent-browser` provides rendered-page inspection and interaction. For one known public URL when you only need page content, prefer `okou scrape <url> --format markdown`; use `agent-browser` when you need browser state, authentication, JavaScript, screenshots, or interaction.",
     ...(args.cloudBrowserEnabled === true
       ? [
@@ -463,6 +472,7 @@ function buildAppendSystemPrompt(args: {
   readonly userInfo: UserInfo;
   readonly triggerSource: TriggerSource;
   readonly cloudBrowserEnabled: boolean | undefined;
+  readonly presentationTemplatesEnabled: boolean;
 }): string {
   const identity = buildAgentIdentityPrompt(args.agent, args.publicBrand);
   return [
@@ -470,6 +480,7 @@ function buildAppendSystemPrompt(args: {
     buildAgentToolsPrompt({
       triggerSource: args.triggerSource,
       cloudBrowserEnabled: args.cloudBrowserEnabled,
+      presentationTemplatesEnabled: args.presentationTemplatesEnabled,
     }),
     buildCurrentUserPrompt(args.userInfo),
   ]
@@ -657,6 +668,7 @@ function createRunBody(args: {
   readonly publicBrand: PublicBrand | undefined;
   readonly appendSystemPrompt: string | undefined;
   readonly cloudBrowserEnabled: boolean | undefined;
+  readonly presentationTemplatesEnabled: boolean;
 }) {
   const triggerSource = args.triggerSource ?? "web";
   const baseAppendSystemPrompt = buildAppendSystemPrompt({
@@ -665,6 +677,7 @@ function createRunBody(args: {
     userInfo: args.userInfo,
     triggerSource,
     cloudBrowserEnabled: args.cloudBrowserEnabled,
+    presentationTemplatesEnabled: args.presentationTemplatesEnabled,
   });
   return {
     prompt: args.body.prompt,
@@ -837,6 +850,7 @@ function buildZeroCreateAgentRunArgs(args: {
   readonly timing: ApiDispatchTimingCollector;
   readonly threadSessionResolution?: ChatThreadSessionResolution;
   readonly cloudBrowserEnabled: boolean | undefined;
+  readonly featureSwitchContext: FeatureSwitchContext;
 }): CreateAgentRunArgs {
   const command = args.command;
   const agentModelProviderId = optionalAgentSetting(args.agent.modelProviderId);
@@ -853,6 +867,10 @@ function buildZeroCreateAgentRunArgs(args: {
       publicBrand: command.publicBrand,
       appendSystemPrompt: command.appendSystemPrompt,
       cloudBrowserEnabled: args.cloudBrowserEnabled,
+      presentationTemplatesEnabled: isFeatureEnabled(
+        FeatureSwitchKey.PresentationTemplates,
+        args.featureSwitchContext,
+      ),
     }),
     apiStartTime: command.apiStartTime,
     modelProviderId: command.modelProviderId ?? agentModelProviderId,

--- a/turbo/apps/platform/src/signals/zero-page/presentation-template-import.ts
+++ b/turbo/apps/platform/src/signals/zero-page/presentation-template-import.ts
@@ -1,5 +1,6 @@
 import { command, computed } from "ccstate";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { presentationTemplateSkillInstruction } from "@okouai/core/presentation-template-skill";
 
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import type { ComposerSignals } from "./composer-signals.ts";
@@ -13,12 +14,18 @@ export const PRESENTATION_TEMPLATE_IMPORT_ACCEPT = ".pptx,.pdf";
 /**
  * The message the deck is sent with.
  *
- * Kept as a plain sentence on purpose: importing a template is not a special
+ * Opens as a plain sentence on purpose: importing a template is not a special
  * protocol, it is a chat message with a file attached, and the user should be
- * able to read what was said on their behalf in the thread they land in.
+ * able to read what was asked on their behalf in the thread they land in. The
+ * pointer to the guide follows, because the guide is not a mounted skill the
+ * run would otherwise find.
  */
-const PRESENTATION_TEMPLATE_IMPORT_PROMPT =
-  "Analyse this deck and save its visual language as a reusable presentation template.";
+function presentationTemplateImportPrompt(): string {
+  return [
+    "Analyse this deck and save its visual language as a reusable presentation template.",
+    presentationTemplateSkillInstruction(),
+  ].join("\n\n");
+}
 
 export const presentationTemplateImportEnabled$ = computed((get) => {
   return get(featureSwitch$)[FeatureSwitchKey.PresentationTemplates] ?? false;
@@ -52,7 +59,7 @@ export const importPresentationTemplateDeck$ = command(
     if (!attached) {
       return false;
     }
-    set(signals.draft.setDraftInput$, PRESENTATION_TEMPLATE_IMPORT_PROMPT);
+    set(signals.draft.setDraftInput$, presentationTemplateImportPrompt());
 
     const action = await get(signals.submission.primaryAction$);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -3371,6 +3371,10 @@ describe("chat composer templates", () => {
     });
     await waitFor(() => {
       expect(sentPrompt).toContain("reusable presentation template");
+      // The guide is not a mounted skill, so the message has to carry the
+      // pointer; without it the thread opens with nothing to follow.
+      expect(sentPrompt).toContain("vm0-ai/Template-artifact");
+      expect(sentPrompt).toContain("reverse-template");
       expect(sentMessage?.parts).toContainEqual(
         expect.objectContaining({
           type: "file",

--- a/turbo/packages/core/src/presentation-template-skill.ts
+++ b/turbo/packages/core/src/presentation-template-skill.ts
@@ -1,0 +1,32 @@
+/**
+ * Where the deck-reverse-engineering guide lives.
+ *
+ * Not in `vm0-ai/vm0-skills`, and so not mounted by the skills sync, because
+ * the guide is still being revised against real decks and its scripts change
+ * with each run. Pointing at the working branch keeps that iteration out of
+ * the every-minute sync and out of every unrelated run's skill mounts.
+ *
+ * The consequence is that this only resolves for a run whose GitHub access
+ * covers a vm0 private repository, which is why every use of it is behind the
+ * `PresentationTemplates` switch. Moving the guide into `vm0-skills` later
+ * turns this constant into a plain skill name and removes the clone step;
+ * that move is tracked in vm0-ai/vm0#28374, which is what stops this branch
+ * pin from outliving the switch.
+ */
+const PRESENTATION_TEMPLATE_SKILL_REPO = "vm0-ai/Template-artifact";
+const PRESENTATION_TEMPLATE_SKILL_BRANCH = "feat/reverse-template-skill";
+const PRESENTATION_TEMPLATE_SKILL_PATH = "reverse-template";
+
+/**
+ * Tell a run how to reach the guide.
+ *
+ * One sentence pair, used both by the import message the template picker sends
+ * and by the standing agent-tools prompt, so a deck dropped in the chat box
+ * reaches the same instructions as one picked through the dialog.
+ */
+export function presentationTemplateSkillInstruction(): string {
+  return [
+    `Turning an uploaded deck (.pptx or .pdf) into a reusable presentation template follows the ${PRESENTATION_TEMPLATE_SKILL_PATH} guide, which is not mounted as a skill.`,
+    `Clone it first with \`gh repo clone ${PRESENTATION_TEMPLATE_SKILL_REPO} <dir> -- --depth 1 -b ${PRESENTATION_TEMPLATE_SKILL_BRANCH}\`, read \`<dir>/${PRESENTATION_TEMPLATE_SKILL_PATH}/SKILL.md\`, and follow it exactly, including its page-rendering and publish steps.`,
+  ].join(" ");
+}


### PR DESCRIPTION
Part of #28252. Stacked on #28344, which introduces the import message this extends.

> [!WARNING]
> **Local validation could not run.** The sandbox lost `node_modules` mid-session and `registry.npmjs.org` has been returning `424` since (retried nine times over ~15 minutes), so `pnpm install` fails and format, lint, check-types, knip, and tests are all unavailable. CI is the first validation for this PR. Details and what was verified by hand are at the bottom.

## The gap

The import flow had no instructions attached to it. The message #28344 sends is a plain sentence, and the guide that knows how to render pages, extract a visual language, and publish the result is not mounted as a skill — so nothing told a run how to do the work, and nothing ever called `publish`. An extraction could finish and still leave the user with nothing.

## Where the guide lives, and why it stays there

`vm0-ai/Template-artifact`, branch `feat/reverse-template-skill`, path `reverse-template/`. It is still being revised against real decks and its scripts change with each run; syncing it into `vm0-skills` would put that iteration into the every-minute cron and into every unrelated run's skill mounts.

So its location is one hardcoded constant in `@okouai/core/presentation-template-skill`.

**That repository is private.** Neither the skills sync (anonymous `codeload` fetch) nor an ordinary user's run can reach it — it resolves only for a run whose GitHub access covers a vm0 private repository. That is precisely why every use of it sits behind the `PresentationTemplates` switch, and it is the reason to move the guide into `vm0-skills` once it settles. At that point the constant becomes a plain skill name and the clone step disappears.

## Two ways in, one instruction

- **Template picker** — choosing a deck appends the pointer to the message it sends, so the thread the user lands in already knows what to follow.
- **Chat box** — the standing agent-tools prompt carries the same line when the switch is on, next to the `workflow-setup` line, so a deck dropped straight into the composer reaches the same guide.

Both call `presentationTemplateSkillInstruction()`, so the two entry points cannot drift.

The switch is off, so the prompt is byte-identical today.

## Also, in `Template-artifact#18`

The guide itself was missing both ends of the flow, fixed there rather than here:

- **Input** — the deck is an attachment on the message that opened the thread, already on local disk; the ingest step has nothing to download.
- **Delivery** — a new step 4 calls `okou presentation-template publish` with the deck, the ordered pages, and the package. Previously the guide stopped at a package directory, which is not a template.

## What I verified without a toolchain

- `ZeroRunAfterPreCreate` declares `featureSwitchContext` (`zero-runs-create.service.ts:934`), and `attemptInput` spreads `input`, so `buildZeroCreateAgentRunArgs` already receives it — the new field is a declaration, not new plumbing.
- `FeatureSwitchKey` was not previously imported in that file, so the added import does not collide.
- The three location constants are module-private, since only the instruction builder reads them, so knip should not see unused exports.

None of that substitutes for running the checks. If CI finds formatting or type issues, they are mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
