### PR TITLE
fix(runner): reconcile stale drain override cleanup

### DIFF
--- a/crates/runner/src/cmd/service/drain_override.rs
+++ b/crates/runner/src/cmd/service/drain_override.rs
@@ -18,6 +18,23 @@ pub(super) enum DrainRestartOverrideWrite {
     Replaced,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum DrainRestartOverrideRemoval {
+    OverrideRemoved,
+    DirectoryRemoved,
+    AlreadyAbsent,
+}
+
+impl DrainRestartOverrideRemoval {
+    pub(super) const fn override_removed(self) -> bool {
+        matches!(self, Self::OverrideRemoved)
+    }
+
+    const fn reload_required(self) -> bool {
+        !matches!(self, Self::AlreadyAbsent)
+    }
+}
+
 pub(super) fn write_drain_restart_override(
     unit: &RunnerServiceUnit,
 ) -> RunnerResult<DrainRestartOverrideWrite> {
@@ -26,6 +43,12 @@ pub(super) fn write_drain_restart_override(
 
 /// Returns whether cleanup found state that warrants reloading systemd.
 pub(super) fn remove_drain_restart_override(unit: &RunnerServiceUnit) -> RunnerResult<bool> {
+    remove_drain_restart_override_outcome(unit).map(DrainRestartOverrideRemoval::reload_required)
+}
+
+pub(super) fn remove_drain_restart_override_outcome(
+    unit: &RunnerServiceUnit,
+) -> RunnerResult<DrainRestartOverrideRemoval> {
     remove_drain_restart_override_at(Path::new(RUNTIME_SYSTEMD_SYSTEM_DIR), unit)
 }
 
@@ -68,11 +91,14 @@ fn write_drain_restart_override_at(
     Ok(outcome)
 }
 
-fn remove_drain_restart_override_at(root: &Path, unit: &RunnerServiceUnit) -> RunnerResult<bool> {
+fn remove_drain_restart_override_at(
+    root: &Path,
+    unit: &RunnerServiceUnit,
+) -> RunnerResult<DrainRestartOverrideRemoval> {
     let path = drain_restart_override_path_at(root, unit);
     cleanup_unit_staging_files(&path)?;
 
-    let mut changed = match std::fs::remove_file(&path) {
+    let override_removed = match std::fs::remove_file(&path) {
         Ok(()) => true,
         Err(e) if e.kind() == ErrorKind::NotFound => false,
         Err(e) => {
@@ -84,19 +110,26 @@ fn remove_drain_restart_override_at(root: &Path, unit: &RunnerServiceUnit) -> Ru
     };
 
     let dir = drain_restart_override_dir_at(root, unit);
-    match std::fs::remove_dir(&dir) {
-        Ok(()) => changed = true,
-        Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::DirectoryNotEmpty) => {}
+    let directory_removed = match std::fs::remove_dir(&dir) {
+        Ok(()) => true,
+        Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::DirectoryNotEmpty) => false,
         Err(e) => {
             warn!(
                 directory = %dir.display(),
                 error = %e,
                 "failed to remove empty drain restart override directory"
             );
+            false
         }
-    }
+    };
 
-    Ok(changed)
+    Ok(if override_removed {
+        DrainRestartOverrideRemoval::OverrideRemoved
+    } else if directory_removed {
+        DrainRestartOverrideRemoval::DirectoryRemoved
+    } else {
+        DrainRestartOverrideRemoval::AlreadyAbsent
+    })
 }
 
 #[cfg(test)]
@@ -170,7 +203,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let unit = service_unit();
 
-        assert!(!remove_drain_restart_override_at(dir.path(), &unit).unwrap());
+        let outcome = remove_drain_restart_override_at(dir.path(), &unit).unwrap();
+
+        assert_eq!(outcome, DrainRestartOverrideRemoval::AlreadyAbsent);
+        assert!(!outcome.reload_required());
     }
 
     #[test]
@@ -180,7 +216,10 @@ mod tests {
         let drop_in_dir = drain_restart_override_dir_at(dir.path(), &unit);
         std::fs::create_dir(&drop_in_dir).unwrap();
 
-        assert!(remove_drain_restart_override_at(dir.path(), &unit).unwrap());
+        let outcome = remove_drain_restart_override_at(dir.path(), &unit).unwrap();
+
+        assert_eq!(outcome, DrainRestartOverrideRemoval::DirectoryRemoved);
+        assert!(outcome.reload_required());
 
         assert!(!drop_in_dir.exists());
     }
@@ -192,7 +231,10 @@ mod tests {
         let drop_in_dir = drain_restart_override_dir_at(dir.path(), &unit);
 
         write_drain_restart_override_at(dir.path(), &unit).unwrap();
-        assert!(remove_drain_restart_override_at(dir.path(), &unit).unwrap());
+        assert_eq!(
+            remove_drain_restart_override_at(dir.path(), &unit).unwrap(),
+            DrainRestartOverrideRemoval::OverrideRemoved
+        );
 
         assert!(!drop_in_dir.exists());
     }
@@ -206,7 +248,10 @@ mod tests {
 
         write_drain_restart_override_at(dir.path(), &unit).unwrap();
         std::fs::write(&other, "[Service]\nEnvironment=EXTRA=1\n").unwrap();
-        assert!(remove_drain_restart_override_at(dir.path(), &unit).unwrap());
+        assert_eq!(
+            remove_drain_restart_override_at(dir.path(), &unit).unwrap(),
+            DrainRestartOverrideRemoval::OverrideRemoved
+        );
 
         assert!(drop_in_dir.exists());
         assert!(other.exists());
@@ -224,7 +269,10 @@ mod tests {
         let path = drain_restart_override_path_at(dir.path(), &unit);
         std::fs::write(&path, DRAIN_DROP_IN_CONTENT).unwrap();
 
-        assert!(remove_drain_restart_override_at(dir.path(), &unit).unwrap());
+        assert_eq!(
+            remove_drain_restart_override_at(dir.path(), &unit).unwrap(),
+            DrainRestartOverrideRemoval::OverrideRemoved
+        );
 
         assert!(!path.exists());
         assert!(

--- a/crates/runner/src/cmd/service/drain_override_cleanup.rs
+++ b/crates/runner/src/cmd/service/drain_override_cleanup.rs
@@ -2,7 +2,10 @@ use std::time::Duration;
 
 use crate::error::{RunnerError, RunnerResult};
 
-use super::drain_override::{remove_drain_restart_override, write_drain_restart_override};
+use super::drain_override::{
+    DrainRestartOverrideRemoval, remove_drain_restart_override_outcome,
+    write_drain_restart_override,
+};
 use super::reload::{
     SystemdReloadRequirement, coordinate_systemd_reload, coordinate_systemd_reload_bounded,
 };
@@ -18,7 +21,10 @@ pub(super) enum DrainOverrideReloadPolicy {
 }
 
 trait DrainOverrideCleanupOps {
-    fn remove_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<bool>;
+    fn remove_override(
+        &mut self,
+        unit: &RunnerServiceUnit,
+    ) -> RunnerResult<DrainRestartOverrideRemoval>;
     fn restore_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()>;
     fn reload<'a>(
         &'a mut self,
@@ -31,8 +37,11 @@ trait DrainOverrideCleanupOps {
 struct RealDrainOverrideCleanupOps;
 
 impl DrainOverrideCleanupOps for RealDrainOverrideCleanupOps {
-    fn remove_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<bool> {
-        remove_drain_restart_override(unit)
+    fn remove_override(
+        &mut self,
+        unit: &RunnerServiceUnit,
+    ) -> RunnerResult<DrainRestartOverrideRemoval> {
+        remove_drain_restart_override_outcome(unit)
     }
 
     fn restore_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()> {
@@ -114,7 +123,9 @@ async fn reconcile_drain_restart_override_removal_with_ops(
     ops: &mut impl DrainOverrideCleanupOps,
 ) -> RunnerResult<()> {
     let remove_result = ops.remove_override(unit);
-    let removed = matches!(&remove_result, Ok(true));
+    let removed = remove_result
+        .as_ref()
+        .is_ok_and(|outcome| outcome.override_removed());
 
     let reload_result = ops
         .reload(
@@ -172,14 +183,17 @@ mod tests {
     }
 
     struct FakeDrainOverrideCleanupOps {
-        remove_result: Option<RunnerResult<bool>>,
+        remove_result: Option<RunnerResult<DrainRestartOverrideRemoval>>,
         restore_result: Option<RunnerResult<()>>,
         reload_results: VecDeque<RunnerResult<()>>,
         events: Vec<Event>,
     }
 
     impl DrainOverrideCleanupOps for FakeDrainOverrideCleanupOps {
-        fn remove_override(&mut self, _unit: &RunnerServiceUnit) -> RunnerResult<bool> {
+        fn remove_override(
+            &mut self,
+            _unit: &RunnerServiceUnit,
+        ) -> RunnerResult<DrainRestartOverrideRemoval> {
             self.events.push(Event::Remove);
             self.remove_result.take().unwrap()
         }
@@ -211,7 +225,7 @@ mod tests {
     }
 
     fn fake_ops(
-        remove_result: RunnerResult<bool>,
+        remove_result: RunnerResult<DrainRestartOverrideRemoval>,
         reload_results: impl IntoIterator<Item = RunnerResult<()>>,
     ) -> FakeDrainOverrideCleanupOps {
         FakeDrainOverrideCleanupOps {
@@ -232,7 +246,7 @@ mod tests {
     #[tokio::test]
     async fn absent_override_is_reconciled_through_both_reload_policies() {
         for policy in [DrainOverrideReloadPolicy::Unbounded, bounded_policy()] {
-            let mut ops = fake_ops(Ok(false), []);
+            let mut ops = fake_ops(Ok(DrainRestartOverrideRemoval::AlreadyAbsent), []);
 
             reconcile_drain_restart_override_removal_with_ops(&service_unit(), policy, &mut ops)
                 .await
@@ -253,7 +267,38 @@ mod tests {
 
     #[tokio::test]
     async fn failed_retry_does_not_restore_override_absent_before_this_attempt() {
-        let mut ops = fake_ops(Ok(false), [Err(fake_error("reload failed"))]);
+        let mut ops = fake_ops(
+            Ok(DrainRestartOverrideRemoval::AlreadyAbsent),
+            [Err(fake_error("reload failed"))],
+        );
+
+        let error = reconcile_drain_restart_override_removal_with_ops(
+            &service_unit(),
+            DrainOverrideReloadPolicy::Unbounded,
+            &mut ops,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "internal error: reload failed");
+        assert_eq!(
+            ops.events,
+            [
+                Event::Remove,
+                Event::Reload(
+                    DrainOverrideReloadPolicy::Unbounded,
+                    SystemdReloadRequirement::dirty().with_drain_override(false),
+                ),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_directory_cleanup_reload_does_not_restore_override() {
+        let mut ops = fake_ops(
+            Ok(DrainRestartOverrideRemoval::DirectoryRemoved),
+            [Err(fake_error("reload failed"))],
+        );
 
         let error = reconcile_drain_restart_override_removal_with_ops(
             &service_unit(),
@@ -279,7 +324,10 @@ mod tests {
     #[tokio::test]
     async fn failed_removal_reload_restores_with_same_policy() {
         let policy = bounded_policy();
-        let mut ops = fake_ops(Ok(true), [Err(fake_error("reload failed")), Ok(())]);
+        let mut ops = fake_ops(
+            Ok(DrainRestartOverrideRemoval::OverrideRemoved),
+            [Err(fake_error("reload failed")), Ok(())],
+        );
 
         let error =
             reconcile_drain_restart_override_removal_with_ops(&service_unit(), policy, &mut ops)
@@ -326,7 +374,10 @@ mod tests {
 
     #[tokio::test]
     async fn reload_and_restoration_failures_keep_both_errors() {
-        let mut ops = fake_ops(Ok(true), [Err(fake_error("reload failed"))]);
+        let mut ops = fake_ops(
+            Ok(DrainRestartOverrideRemoval::OverrideRemoved),
+            [Err(fake_error("reload failed"))],
+        );
         ops.restore_result = Some(Err(fake_error("restore failed")));
 
         let error = reconcile_drain_restart_override_removal_with_ops(

--- a/crates/runner/src/cmd/service/drain_override_cleanup.rs
+++ b/crates/runner/src/cmd/service/drain_override_cleanup.rs
@@ -1,0 +1,343 @@
+use std::time::Duration;
+
+use crate::error::{RunnerError, RunnerResult};
+
+use super::drain_override::{remove_drain_restart_override, write_drain_restart_override};
+use super::reload::{
+    SystemdReloadRequirement, coordinate_systemd_reload, coordinate_systemd_reload_bounded,
+};
+use super::{RunnerServiceUnit, ServiceFuture};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum DrainOverrideReloadPolicy {
+    Unbounded,
+    Bounded {
+        lock_timeout: Duration,
+        command_timeout: Duration,
+    },
+}
+
+trait DrainOverrideCleanupOps {
+    fn remove_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<bool>;
+    fn restore_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()>;
+    fn reload<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+        requirement: SystemdReloadRequirement,
+        policy: DrainOverrideReloadPolicy,
+    ) -> ServiceFuture<'a, ()>;
+}
+
+struct RealDrainOverrideCleanupOps;
+
+impl DrainOverrideCleanupOps for RealDrainOverrideCleanupOps {
+    fn remove_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<bool> {
+        remove_drain_restart_override(unit)
+    }
+
+    fn restore_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()> {
+        write_drain_restart_override(unit).map(|_| ())
+    }
+
+    fn reload<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+        requirement: SystemdReloadRequirement,
+        policy: DrainOverrideReloadPolicy,
+    ) -> ServiceFuture<'a, ()> {
+        Box::pin(async move {
+            match policy {
+                DrainOverrideReloadPolicy::Unbounded => {
+                    coordinate_systemd_reload(unit, requirement).await?;
+                }
+                DrainOverrideReloadPolicy::Bounded {
+                    lock_timeout,
+                    command_timeout,
+                } => {
+                    coordinate_systemd_reload_bounded(
+                        unit,
+                        requirement,
+                        lock_timeout,
+                        command_timeout,
+                    )
+                    .await?;
+                }
+            }
+            Ok(())
+        })
+    }
+}
+
+fn cleanup_reload_error(
+    unit: &RunnerServiceUnit,
+    reload_error: RunnerError,
+    restore_error: RunnerError,
+) -> RunnerError {
+    RunnerError::Internal(format!(
+        "failed to reload systemd after removing drain restart override for {}: {reload_error}; additionally failed to restore drain restart override: {restore_error}",
+        unit.unit_name()
+    ))
+}
+
+async fn restore_after_failed_cleanup(
+    unit: &RunnerServiceUnit,
+    policy: DrainOverrideReloadPolicy,
+    ops: &mut impl DrainOverrideCleanupOps,
+) -> RunnerResult<()> {
+    if let Err(error) = ops.restore_override(unit) {
+        return Err(RunnerError::Internal(format!(
+            "failed to restore drain restart override for {} after cleanup reload failure: {error}",
+            unit.unit_name()
+        )));
+    }
+
+    if let Err(error) = ops
+        .reload(
+            unit,
+            SystemdReloadRequirement::dirty().with_drain_override(true),
+            policy,
+        )
+        .await
+    {
+        return Err(RunnerError::Internal(format!(
+            "failed to reload systemd after restoring drain restart override for {}: {error}",
+            unit.unit_name()
+        )));
+    }
+
+    Ok(())
+}
+
+async fn reconcile_drain_restart_override_removal_with_ops(
+    unit: &RunnerServiceUnit,
+    policy: DrainOverrideReloadPolicy,
+    ops: &mut impl DrainOverrideCleanupOps,
+) -> RunnerResult<()> {
+    let remove_result = ops.remove_override(unit);
+    let removed = matches!(&remove_result, Ok(true));
+
+    let reload_result = ops
+        .reload(
+            unit,
+            SystemdReloadRequirement::dirty().with_drain_override(false),
+            policy,
+        )
+        .await;
+
+    if let Err(reload_error) = reload_result {
+        let reload_error = if removed {
+            match restore_after_failed_cleanup(unit, policy, ops).await {
+                Ok(()) => reload_error,
+                Err(restore_error) => cleanup_reload_error(unit, reload_error, restore_error),
+            }
+        } else {
+            reload_error
+        };
+
+        return match remove_result {
+            Ok(_) => Err(reload_error),
+            Err(remove_error) => Err(RunnerError::Internal(format!(
+                "failed to remove drain restart override for {}: {remove_error}; additionally failed to reload systemd: {reload_error}",
+                unit.unit_name()
+            ))),
+        };
+    }
+
+    remove_result.map(|_| ())
+}
+
+pub(super) async fn reconcile_drain_restart_override_removal(
+    unit: &RunnerServiceUnit,
+    policy: DrainOverrideReloadPolicy,
+) -> RunnerResult<()> {
+    reconcile_drain_restart_override_removal_with_ops(
+        unit,
+        policy,
+        &mut RealDrainOverrideCleanupOps,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use super::*;
+
+    #[derive(Debug, Eq, PartialEq)]
+    enum Event {
+        Remove,
+        Restore,
+        Reload(DrainOverrideReloadPolicy, SystemdReloadRequirement),
+    }
+
+    struct FakeDrainOverrideCleanupOps {
+        remove_result: Option<RunnerResult<bool>>,
+        restore_result: Option<RunnerResult<()>>,
+        reload_results: VecDeque<RunnerResult<()>>,
+        events: Vec<Event>,
+    }
+
+    impl DrainOverrideCleanupOps for FakeDrainOverrideCleanupOps {
+        fn remove_override(&mut self, _unit: &RunnerServiceUnit) -> RunnerResult<bool> {
+            self.events.push(Event::Remove);
+            self.remove_result.take().unwrap()
+        }
+
+        fn restore_override(&mut self, _unit: &RunnerServiceUnit) -> RunnerResult<()> {
+            self.events.push(Event::Restore);
+            self.restore_result.take().unwrap_or(Ok(()))
+        }
+
+        fn reload<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+            requirement: SystemdReloadRequirement,
+            policy: DrainOverrideReloadPolicy,
+        ) -> ServiceFuture<'a, ()> {
+            self.events.push(Event::Reload(policy, requirement));
+            Box::pin(std::future::ready(
+                self.reload_results.pop_front().unwrap_or(Ok(())),
+            ))
+        }
+    }
+
+    fn service_unit() -> RunnerServiceUnit {
+        RunnerServiceUnit::from_suffix("test").unwrap()
+    }
+
+    fn fake_error(message: &str) -> RunnerError {
+        RunnerError::Internal(message.to_string())
+    }
+
+    fn fake_ops(
+        remove_result: RunnerResult<bool>,
+        reload_results: impl IntoIterator<Item = RunnerResult<()>>,
+    ) -> FakeDrainOverrideCleanupOps {
+        FakeDrainOverrideCleanupOps {
+            remove_result: Some(remove_result),
+            restore_result: None,
+            reload_results: reload_results.into_iter().collect(),
+            events: Vec::new(),
+        }
+    }
+
+    fn bounded_policy() -> DrainOverrideReloadPolicy {
+        DrainOverrideReloadPolicy::Bounded {
+            lock_timeout: Duration::from_secs(20),
+            command_timeout: Duration::from_secs(10),
+        }
+    }
+
+    #[tokio::test]
+    async fn absent_override_is_reconciled_through_both_reload_policies() {
+        for policy in [DrainOverrideReloadPolicy::Unbounded, bounded_policy()] {
+            let mut ops = fake_ops(Ok(false), []);
+
+            reconcile_drain_restart_override_removal_with_ops(&service_unit(), policy, &mut ops)
+                .await
+                .unwrap();
+
+            assert_eq!(
+                ops.events,
+                [
+                    Event::Remove,
+                    Event::Reload(
+                        policy,
+                        SystemdReloadRequirement::dirty().with_drain_override(false),
+                    ),
+                ]
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_retry_does_not_restore_override_absent_before_this_attempt() {
+        let mut ops = fake_ops(Ok(false), [Err(fake_error("reload failed"))]);
+
+        let error = reconcile_drain_restart_override_removal_with_ops(
+            &service_unit(),
+            DrainOverrideReloadPolicy::Unbounded,
+            &mut ops,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "internal error: reload failed");
+        assert_eq!(
+            ops.events,
+            [
+                Event::Remove,
+                Event::Reload(
+                    DrainOverrideReloadPolicy::Unbounded,
+                    SystemdReloadRequirement::dirty().with_drain_override(false),
+                ),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_removal_reload_restores_with_same_policy() {
+        let policy = bounded_policy();
+        let mut ops = fake_ops(Ok(true), [Err(fake_error("reload failed")), Ok(())]);
+
+        let error =
+            reconcile_drain_restart_override_removal_with_ops(&service_unit(), policy, &mut ops)
+                .await
+                .unwrap_err();
+
+        assert_eq!(error.to_string(), "internal error: reload failed");
+        assert_eq!(
+            ops.events,
+            [
+                Event::Remove,
+                Event::Reload(
+                    policy,
+                    SystemdReloadRequirement::dirty().with_drain_override(false),
+                ),
+                Event::Restore,
+                Event::Reload(
+                    policy,
+                    SystemdReloadRequirement::dirty().with_drain_override(true),
+                ),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn removal_and_reload_failures_keep_both_errors_without_restoration() {
+        let mut ops = fake_ops(
+            Err(fake_error("remove failed")),
+            [Err(fake_error("reload failed"))],
+        );
+
+        let error = reconcile_drain_restart_override_removal_with_ops(
+            &service_unit(),
+            DrainOverrideReloadPolicy::Unbounded,
+            &mut ops,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("remove failed"));
+        assert!(error.to_string().contains("reload failed"));
+        assert!(!ops.events.contains(&Event::Restore));
+    }
+
+    #[tokio::test]
+    async fn reload_and_restoration_failures_keep_both_errors() {
+        let mut ops = fake_ops(Ok(true), [Err(fake_error("reload failed"))]);
+        ops.restore_result = Some(Err(fake_error("restore failed")));
+
+        let error = reconcile_drain_restart_override_removal_with_ops(
+            &service_unit(),
+            DrainOverrideReloadPolicy::Unbounded,
+            &mut ops,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("reload failed"));
+        assert!(error.to_string().contains("restore failed"));
+    }
+}

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -13,6 +13,7 @@ use tracing::{info, warn};
 
 mod diagnostic;
 mod drain_override;
+mod drain_override_cleanup;
 mod drain_resume;
 mod gate;
 mod reload;
@@ -29,6 +30,7 @@ pub(crate) use target::RunnerServiceUnit;
 pub(crate) use unit_config::read_unit_config_path;
 
 use drain_override::{remove_drain_restart_override, write_drain_restart_override};
+use drain_override_cleanup::{DrainOverrideReloadPolicy, reconcile_drain_restart_override_removal};
 use gate::check_active_jobs_gate;
 use reload::{SystemdReloadRequirement, coordinate_systemd_reload};
 use systemctl::{
@@ -186,69 +188,6 @@ fn systemd_run_limit_nofile_property_arg() -> String {
 
 type ServiceFuture<'a, T> = Pin<Box<dyn Future<Output = RunnerResult<T>> + 'a>>;
 
-fn drain_override_cleanup_reload_error(
-    unit: &RunnerServiceUnit,
-    reload_error: RunnerError,
-    restore_error: RunnerError,
-) -> RunnerError {
-    RunnerError::Internal(format!(
-        "failed to reload systemd after removing drain restart override for {}: {reload_error}; additionally failed to restore drain restart override: {restore_error}",
-        unit.unit_name()
-    ))
-}
-
-async fn restore_drain_restart_override_after_failed_cleanup(
-    unit: &RunnerServiceUnit,
-    context: &str,
-) -> RunnerResult<()> {
-    if let Err(e) = write_drain_restart_override(unit) {
-        return Err(RunnerError::Internal(format!(
-            "failed to restore drain restart override for {} after cleanup reload failure ({context}): {e}",
-            unit.unit_name()
-        )));
-    }
-    if let Err(e) = coordinate_systemd_reload(
-        unit,
-        SystemdReloadRequirement::dirty().with_drain_override(true),
-    )
-    .await
-    {
-        return Err(RunnerError::Internal(format!(
-            "failed to reload systemd after restoring drain restart override for {} ({context}): {e}",
-            unit.unit_name()
-        )));
-    }
-    Ok(())
-}
-
-async fn reload_systemd_if_drain_restart_override_removed(
-    unit: &RunnerServiceUnit,
-) -> RunnerResult<bool> {
-    if !remove_drain_restart_override(unit)? {
-        return Ok(false);
-    }
-
-    if let Err(reload_error) = coordinate_systemd_reload(
-        unit,
-        SystemdReloadRequirement::dirty().with_drain_override(false),
-    )
-    .await
-    {
-        if let Err(restore_error) =
-            restore_drain_restart_override_after_failed_cleanup(unit, "remove_reload").await
-        {
-            return Err(drain_override_cleanup_reload_error(
-                unit,
-                reload_error,
-                restore_error,
-            ));
-        }
-        return Err(reload_error);
-    }
-
-    Ok(true)
-}
-
 async fn restore_service_state_after_reload_failure(
     unit: &RunnerServiceUnit,
     prior_enablement: SystemdUnitEnablement,
@@ -368,7 +307,7 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
     )?;
     validate_systemd_path("current executable path", &exe_path)?;
     validate_systemd_path("config path", &config_path)?;
-    reload_systemd_if_drain_restart_override_removed(&unit).await?;
+    reconcile_drain_restart_override_removal(&unit, DrainOverrideReloadPolicy::Unbounded).await?;
 
     let unit_arg = format!("--unit={}", unit.unit_name());
     let desc_arg = format!("--description=VM0 Runner ({})", unit.unit_name());

--- a/crates/runner/src/cmd/service/reload.rs
+++ b/crates/runner/src/cmd/service/reload.rs
@@ -339,6 +339,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stale_loaded_drain_override_reloads_with_bounded_and_unbounded_lock_modes() {
+        for lock_timeout in [None, Some(Duration::from_secs(1))] {
+            let dir = tempfile::tempdir().unwrap();
+            let home = HomePaths::with_root(dir.path().join("home"));
+            let unit = RunnerServiceUnit::from_suffix("test").unwrap();
+            let mut ops = fake_ops(false);
+            ops.drain_override_loaded = true;
+
+            assert!(
+                coordinate_systemd_reload_with_ops(
+                    &unit,
+                    &home,
+                    SystemdReloadRequirement::dirty().with_drain_override(false),
+                    lock_timeout,
+                    &mut ops,
+                )
+                .await
+                .unwrap()
+            );
+            assert_eq!(ops.reload_count.load(Ordering::SeqCst), 1);
+        }
+    }
+
+    #[tokio::test]
     async fn different_units_coalesce_one_dirty_generation_under_real_flock() {
         const RENDEZVOUS_TIMEOUT: Duration = Duration::from_secs(5);
 

--- a/crates/runner/src/cmd/service/stop.rs
+++ b/crates/runner/src/cmd/service/stop.rs
@@ -5,17 +5,15 @@ use tracing::{info, warn};
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
 
-use super::drain_override::{remove_drain_restart_override, write_drain_restart_override};
+use super::drain_override_cleanup::{
+    DrainOverrideReloadPolicy, reconcile_drain_restart_override_removal,
+};
 use super::gate::check_active_jobs_gate;
-use super::reload::{SystemdReloadRequirement, coordinate_systemd_reload_bounded};
 use super::systemctl::{
     BoundedSystemctlOutcome, CleanupUnitActiveState, cleanup_unit_active_state_bounded,
     is_unit_active, is_unit_enabled_bounded, run_systemctl, run_systemctl_bounded,
 };
-use super::{
-    RunnerServiceUnit, ServiceFuture, acquire_service_lock, drain_override_cleanup_reload_error,
-    reload_systemd_if_drain_restart_override_removed,
-};
+use super::{RunnerServiceUnit, ServiceFuture, acquire_service_lock};
 
 const CLEANUP_LOCK_TIMEOUT: TokioDuration = TokioDuration::from_secs(20);
 const CLEANUP_LOCK_POLL_INTERVAL: TokioDuration = TokioDuration::from_millis(250);
@@ -145,71 +143,6 @@ async fn run_cleanup_systemctl(args: &[&str], duration: TokioDuration) -> Runner
     }
 }
 
-async fn reload_systemd_if_drain_restart_override_removed_bounded(
-    unit: &RunnerServiceUnit,
-) -> RunnerResult<bool> {
-    let remove_result = remove_drain_restart_override(unit);
-    let removed = matches!(&remove_result, Ok(true));
-
-    let reload_result = coordinate_systemd_reload_bounded(
-        unit,
-        SystemdReloadRequirement::dirty().with_drain_override(false),
-        CLEANUP_LOCK_TIMEOUT,
-        CLEANUP_ACTION_TIMEOUT,
-    )
-    .await;
-
-    if let Err(reload_error) = reload_result {
-        let reload_error = if removed {
-            match restore_drain_restart_override_after_failed_cleanup_bounded(unit, "remove_reload")
-                .await
-            {
-                Ok(()) => reload_error,
-                Err(restore_error) => {
-                    drain_override_cleanup_reload_error(unit, reload_error, restore_error)
-                }
-            }
-        } else {
-            reload_error
-        };
-        return match remove_result {
-            Ok(_) => Err(reload_error),
-            Err(remove_error) => Err(RunnerError::Internal(format!(
-                "failed to remove drain restart override for {} during cleanup: {remove_error}; additionally failed to reload systemd: {reload_error}",
-                unit.unit_name()
-            ))),
-        };
-    }
-
-    remove_result.map(|_| removed)
-}
-
-async fn restore_drain_restart_override_after_failed_cleanup_bounded(
-    unit: &RunnerServiceUnit,
-    context: &str,
-) -> RunnerResult<()> {
-    if let Err(e) = write_drain_restart_override(unit) {
-        return Err(RunnerError::Internal(format!(
-            "failed to restore drain restart override for {} after cleanup reload failure ({context}): {e}",
-            unit.unit_name()
-        )));
-    }
-    if let Err(e) = coordinate_systemd_reload_bounded(
-        unit,
-        SystemdReloadRequirement::dirty().with_drain_override(true),
-        CLEANUP_LOCK_TIMEOUT,
-        CLEANUP_ACTION_TIMEOUT,
-    )
-    .await
-    {
-        return Err(RunnerError::Internal(format!(
-            "failed to reload systemd after restoring drain restart override for {} ({context}): {e}",
-            unit.unit_name()
-        )));
-    }
-    Ok(())
-}
-
 impl ServiceStopOps for RealServiceStopOps {
     type LockGuard = nix::fcntl::Flock<std::fs::File>;
 
@@ -327,9 +260,8 @@ impl ServiceStopOps for RealServiceStopOps {
         unit: &'a RunnerServiceUnit,
     ) -> ServiceFuture<'a, ()> {
         Box::pin(async move {
-            reload_systemd_if_drain_restart_override_removed(unit)
+            reconcile_drain_restart_override_removal(unit, DrainOverrideReloadPolicy::Unbounded)
                 .await
-                .map(|_| ())
         })
     }
 
@@ -338,9 +270,14 @@ impl ServiceStopOps for RealServiceStopOps {
         unit: &'a RunnerServiceUnit,
     ) -> ServiceFuture<'a, ()> {
         Box::pin(async move {
-            reload_systemd_if_drain_restart_override_removed_bounded(unit)
-                .await
-                .map(|_| ())
+            reconcile_drain_restart_override_removal(
+                unit,
+                DrainOverrideReloadPolicy::Bounded {
+                    lock_timeout: CLEANUP_LOCK_TIMEOUT,
+                    command_timeout: CLEANUP_ACTION_TIMEOUT,
+                },
+            )
+            .await
         })
     }
 


### PR DESCRIPTION
## Summary

- centralize start and stop drain-override cleanup in one private lifecycle transaction
- always reconcile expected override absence, including retries where the on-disk file is already gone
- distinguish override-file removal from empty-directory cleanup so compensation never synthesizes `Restart=no`
- preserve bounded cleanup timeouts, conditional compensation, and combined failure context
- cover the interrupted retry state through both reload policies and the actual `DropInPaths` coordinator logic

## Behavior

`service start`, default `service stop`, and cleanup-mode stop now use the same removal, reload, and compensation transaction. The transaction retains a structured removal outcome, but always asks the reload coordinator to make expected absence effective. A retry after interruption can therefore reload a stale systemd `Restart=no` policy even when file removal is already idempotently complete.

When effective state already matches, the existing host-global coordinator performs only the state query and skips `daemon-reload`. Cleanup mode keeps its 20-second reload-lock timeout and 10-second systemd-command timeout. Reload failure recreates the override only when the current attempt removed the override file; removing only an already-empty drop-in directory still preserves the legacy reload signal without permitting compensation. Restoration uses the same bounded or unbounded policy as the failed cleanup.

Install, uninstall, drain, resume, CLI shape, persisted state, and external protocols are unchanged.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner cmd::service::drain_override` (14 passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner cmd::service::reload` (6 passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner cmd::service` (243 passed, 1 ignored child fixture)
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features` (3,209 binary tests passed, 20 ignored fixtures; 1 integration test passed)
- `git diff --check`
- repository pre-commit and commit-message hooks

Closes #28295
