### PR TITLE
perf(runner): coordinate routine cache gc per host

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -29,8 +29,8 @@
 //!   main reactor or overlap a newer snapshot;
 //! - workspace-cache watcher work is pinned across reactor turns so async
 //!   metadata classification cannot lose already-drained kernel events;
-//! - routine workspace-cache GC is pinned and single-flight so its I/O does
-//!   not stall the main reactor or queue behind another capacity-lock owner;
+//! - routine workspace-cache GC is pinned and process-local single-flight, and
+//!   its host-global cadence is coordinated through the capacity lock;
 //! - the first routine heartbeat tick is deferred;
 //! - teardown drains heartbeat work and drops discovery before provider
 //!   shutdown.
@@ -191,7 +191,7 @@ async fn next_workspace_cache_change(
 type WorkspaceCacheGcFuture = BoxFuture<'static, RunnerResult<Option<u64>>>;
 
 fn workspace_cache_gc_future(cache: WorkspaceImageCache) -> WorkspaceCacheGcFuture {
-    Box::pin(async move { cache.try_gc().await })
+    Box::pin(async move { cache.try_routine_gc(WORKSPACE_CACHE_GC_PERIOD).await })
 }
 
 async fn next_workspace_cache_gc(

--- a/crates/runner/src/workspace_image_cache/gc.rs
+++ b/crates/runner/src/workspace_image_cache/gc.rs
@@ -110,7 +110,6 @@ impl WorkspaceImageCache {
 
         let freed_bytes = self.gc_locked(false).await?;
         capacity_lock.write_all(b"\0")?;
-        capacity_lock.set_times(std::fs::FileTimes::new().set_modified(SystemTime::now()))?;
         Ok(Some(freed_bytes))
     }
 

--- a/crates/runner/src/workspace_image_cache/gc.rs
+++ b/crates/runner/src/workspace_image_cache/gc.rs
@@ -1,6 +1,8 @@
 use std::fs::File;
+use std::io::Write;
 use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
 
 use nix::fcntl::Flock;
 use tokio::fs;
@@ -85,13 +87,31 @@ impl WorkspaceImageCache {
         self.gc_locked(dry_run).await
     }
 
-    pub(crate) async fn try_gc(&self) -> RunnerResult<Option<u64>> {
-        let _capacity_lock =
+    pub(crate) async fn try_routine_gc(
+        &self,
+        minimum_interval: Duration,
+    ) -> RunnerResult<Option<u64>> {
+        let mut capacity_lock =
             match crate::lock::try_acquire_or_busy(self.capacity_lock_path()).await? {
                 crate::lock::TryLock::Acquired(lock) => lock,
                 crate::lock::TryLock::Busy => return Ok(None),
             };
-        self.gc_locked(false).await.map(Some)
+        // The persistent lock file doubles as an opaque completion marker. Old
+        // runners ignore its contents and preserve them when opening the lock.
+        let marker = capacity_lock.metadata()?;
+        if marker.len() > 0
+            && SystemTime::now()
+                .duration_since(marker.modified()?)
+                .unwrap_or_default()
+                < minimum_interval
+        {
+            return Ok(None);
+        }
+
+        let freed_bytes = self.gc_locked(false).await?;
+        capacity_lock.write_all(b"\0")?;
+        capacity_lock.set_times(std::fs::FileTimes::new().set_modified(SystemTime::now()))?;
+        Ok(Some(freed_bytes))
     }
 
     pub(super) async fn gc_locked(&self, dry_run: bool) -> RunnerResult<u64> {

--- a/crates/runner/src/workspace_image_cache/tests/gc.rs
+++ b/crates/runner/src/workspace_image_cache/tests/gc.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, SystemTime};
+
 use tokio::fs;
 
 use super::super::fs::{allocated_bytes, workspace_cache_path_allocated_bytes};
@@ -14,6 +16,7 @@ use super::support::{
     TEST_PROFILE_NAME, local_cache, promote_current_cache_entry, timestamp_for_index,
     write_current_cache_entry,
 };
+use crate::error::RunnerError;
 use crate::ids::RunId;
 use crate::paths::{HomePaths, RunnerPaths, workspace_image_cache_key};
 use crate::storage_fingerprints::StorageFingerprints;
@@ -115,10 +118,14 @@ async fn routine_gc_cleans_stale_entries_when_capacity_lock_is_available() {
         .unwrap();
     cache.reset_gc_root_scan_count();
 
-    let freed = cache.try_gc().await.unwrap();
+    let freed = cache.try_routine_gc(Duration::from_secs(60)).await.unwrap();
 
     assert!(freed.is_some());
     assert_eq!(cache.gc_root_scan_count(), 1);
+    assert!(
+        std::fs::metadata(cache.capacity_lock_path()).unwrap().len() > 0,
+        "successful routine GC should record host-global completion"
+    );
     assert!(
         !cache
             .entry_paths(&cache_key)
@@ -136,10 +143,124 @@ async fn routine_gc_skips_without_scanning_when_capacity_lock_is_busy() {
         .unwrap();
     cache.reset_gc_root_scan_count();
 
-    let freed = cache.try_gc().await.unwrap();
+    let freed = cache.try_routine_gc(Duration::from_secs(60)).await.unwrap();
 
     assert_eq!(freed, None);
     assert_eq!(cache.gc_root_scan_count(), 0);
+}
+
+#[tokio::test]
+async fn routine_gc_runs_once_per_interval_across_shared_cache_instances() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = HomePaths::with_root(dir.path().join("home"));
+    let runner_a = RunnerPaths::new(dir.path().join("runner-a"));
+    let runner_b = RunnerPaths::new(dir.path().join("runner-b"));
+    tokio::fs::create_dir_all(runner_a.base_dir())
+        .await
+        .unwrap();
+    tokio::fs::create_dir_all(runner_b.base_dir())
+        .await
+        .unwrap();
+    let cache_a = WorkspaceImageCache::shared(runner_a, &home, "group-a");
+    let cache_b = WorkspaceImageCache::shared(runner_b, &home, "group-b");
+    let stale_key = workspace_image_cache_key("sess-stale", "/workspace");
+    tokio::fs::create_dir_all(cache_a.entry_paths(&stale_key).entry_dir())
+        .await
+        .unwrap();
+
+    let first = cache_a
+        .try_routine_gc(Duration::from_secs(60))
+        .await
+        .unwrap();
+    let second = cache_b
+        .try_routine_gc(Duration::from_secs(60))
+        .await
+        .unwrap();
+
+    assert!(first.is_some());
+    assert_eq!(second, None);
+    assert_eq!(cache_a.gc_root_scan_count(), 1);
+    assert_eq!(cache_b.gc_root_scan_count(), 0);
+}
+
+#[tokio::test]
+async fn routine_gc_runs_again_after_shared_completion_expires() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = HomePaths::with_root(dir.path().join("home"));
+    let runner_a = RunnerPaths::new(dir.path().join("runner-a"));
+    let runner_b = RunnerPaths::new(dir.path().join("runner-b"));
+    tokio::fs::create_dir_all(runner_a.base_dir())
+        .await
+        .unwrap();
+    tokio::fs::create_dir_all(runner_b.base_dir())
+        .await
+        .unwrap();
+    let cache_a = WorkspaceImageCache::shared(runner_a, &home, "group-a");
+    let cache_b = WorkspaceImageCache::shared(runner_b, &home, "group-b");
+    cache_a
+        .try_routine_gc(Duration::from_secs(60))
+        .await
+        .unwrap()
+        .expect("first routine GC should record completion");
+    let future_completion = SystemTime::now() + Duration::from_secs(60);
+    std::fs::File::options()
+        .write(true)
+        .open(cache_a.capacity_lock_path())
+        .unwrap()
+        .set_times(std::fs::FileTimes::new().set_modified(future_completion))
+        .unwrap();
+    cache_b.reset_gc_root_scan_count();
+
+    let future = cache_b
+        .try_routine_gc(Duration::from_secs(60))
+        .await
+        .unwrap();
+
+    assert_eq!(future, None);
+    assert_eq!(cache_b.gc_root_scan_count(), 0);
+    let old_completion = SystemTime::now() - Duration::from_secs(61);
+    std::fs::File::options()
+        .write(true)
+        .open(cache_a.capacity_lock_path())
+        .unwrap()
+        .set_times(std::fs::FileTimes::new().set_modified(old_completion))
+        .unwrap();
+    cache_b.reset_gc_root_scan_count();
+
+    let next = cache_b
+        .try_routine_gc(Duration::from_secs(60))
+        .await
+        .unwrap();
+
+    assert!(next.is_some());
+    assert_eq!(cache_b.gc_root_scan_count(), 1);
+}
+
+#[tokio::test]
+async fn failed_routine_gc_does_not_suppress_retry() {
+    let (_dir, paths, cache) = local_cache().await;
+    let cache_root = paths.workspace_image_cache_dir();
+    tokio::fs::write(&cache_root, b"not a directory")
+        .await
+        .unwrap();
+
+    let error = cache
+        .try_routine_gc(Duration::from_secs(60))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, RunnerError::Io(_)));
+    assert_eq!(
+        std::fs::metadata(cache.capacity_lock_path()).unwrap().len(),
+        0,
+        "failed routine GC must not record completion"
+    );
+    tokio::fs::remove_file(&cache_root).await.unwrap();
+
+    let retry = cache.try_routine_gc(Duration::from_secs(60)).await.unwrap();
+
+    assert!(retry.is_some());
+    assert_eq!(cache.gc_root_scan_count(), 2);
 }
 
 #[tokio::test]
@@ -335,7 +456,7 @@ async fn global_gc_evicts_old_entry_from_other_group_under_free_space_pressure()
     .await;
 
     let freed = cache_b
-        .try_gc()
+        .try_routine_gc(Duration::from_secs(60))
         .await
         .unwrap()
         .expect("routine GC should acquire the idle capacity lock");


### PR DESCRIPTION
## Summary

- coordinate periodic workspace cache GC across runner processes that share one host cache
- reuse the persistent capacity-lock file as an opaque successful-completion marker, skipping root scans until the 60-second cadence expires
- preserve immediate retries after failed GC and cover shared-runner, clock-skew, and failure behavior with real-filesystem tests

## Compatibility

- old runner binaries preserve and ignore the lock-file marker during rolling deployment
- workspace cache formats, runner/backend protocols, promotion locking, pressure GC, and manual GC are unchanged
- old periodic runners can continue their previous scans until they drain; new runners coordinate with each other immediately

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `git diff --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner workspace_image_cache::tests::gc::routine_gc -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner workspace_image_cache::tests::gc::failed_routine_gc_does_not_suppress_retry -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner workspace_image_cache::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner --quiet`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `lefthook run pre-commit`

Closes #28364
