### PR TITLE
fix(api): share clerk read context across pagination

### DIFF
--- a/turbo/apps/api/src/signals/services/credit-low-balance-alert.service.ts
+++ b/turbo/apps/api/src/signals/services/credit-low-balance-alert.service.ts
@@ -12,9 +12,11 @@ import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import {
   clerk$,
+  createClerkReadContext,
   type ClerkClient,
   type ClerkOrganizationMembership,
 } from "../external/clerk";
+import { listAllOrganizationMemberships } from "../external/clerk-organization-lists";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../../lib/time";
 import {
@@ -32,7 +34,6 @@ type OrganizationMembership = ClerkOrganizationMembership;
 export const LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS = 5000;
 
 const L = logger("CreditLowBalanceAlert");
-const ORG_MEMBERSHIP_PAGE_SIZE = 100;
 function billingCreditsUrl(publicBrand: PublicBrand): string {
   return `${appUrlForPublicBrand(env("APP_URL"), publicBrand)}/?settings=billing&billingView=credits`;
 }
@@ -54,26 +55,6 @@ interface OrgMemberCacheRow {
   readonly userId: string;
   readonly role: "admin" | "member";
   readonly cachedAt: Date;
-}
-
-async function listCurrentOrgMemberships(
-  clerk: ClerkClient,
-  orgId: string,
-  signal: AbortSignal,
-): Promise<OrganizationMembership[]> {
-  const memberships: OrganizationMembership[] = [];
-  for (let offset = 0; ; offset += ORG_MEMBERSHIP_PAGE_SIZE) {
-    const page = await clerk.organizations.getOrganizationMembershipList({
-      organizationId: orgId,
-      limit: ORG_MEMBERSHIP_PAGE_SIZE,
-      offset,
-    });
-    signal.throwIfAborted();
-    memberships.push(...page.data);
-    if (page.data.length < ORG_MEMBERSHIP_PAGE_SIZE) {
-      return memberships;
-    }
-  }
 }
 
 function membershipUserId(
@@ -254,9 +235,10 @@ export const enqueueCreditLowBalanceAlert$ = command(
   ): Promise<void> => {
     const db = set(writeDb$);
     const clerk = get(clerk$);
-    const memberships = await listCurrentOrgMemberships(
-      clerk,
+    const memberships = await listAllOrganizationMemberships(
+      clerk.organizations,
       args.orgId,
+      createClerkReadContext(),
       signal,
     );
     await refreshOrgMemberCache(db, args.orgId, memberships);

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -39,7 +39,7 @@ import {
   sharedThreadArtifactAuthorUserId,
   SHARED_THREAD_ARTIFACT_LOGICAL_KEY_PREFIX,
 } from "../../lib/shared-thread-artifact";
-import { clerk$ } from "../external/clerk";
+import { clerk$, createClerkReadContext } from "../external/clerk";
 import { writeDb$, type Db } from "../external/db";
 import {
   deleteS3Objects,
@@ -573,13 +573,19 @@ async function isClerkOrgEmptyAfterDeletingUser(
   userId: string,
   signal: AbortSignal,
 ): Promise<boolean> {
+  const readContext = createClerkReadContext();
   for (let offset = 0; ; offset += CLERK_ORG_MEMBERSHIP_PAGE_SIZE) {
     const memberships = await settle(
-      clerk.organizations.getOrganizationMembershipList({
-        organizationId: orgId,
-        limit: CLERK_ORG_MEMBERSHIP_PAGE_SIZE,
-        offset,
-      }),
+      clerk.organizations.getOrganizationMembershipList(
+        {
+          organizationId: orgId,
+          limit: CLERK_ORG_MEMBERSHIP_PAGE_SIZE,
+          offset,
+        },
+        readContext,
+        signal,
+      ),
+      signal,
     );
     signal.throwIfAborted();
 


### PR DESCRIPTION
## Summary

- reuse the shared complete-membership pagination helper for low-credit alerts so every page uses one Clerk read context and the owning cancellation signal
- pass one Clerk read context and the owning cancellation signal through user-deletion organization-membership pagination

## Scope

- no change to the centralized Clerk retry policy or its attempt and delay limits
- no Clerk mutation retry or API contract change
- follow-up to #28282
- relates to #28273

## Validation

- `pnpm -F @okouai/db db:migrate`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/email.test.ts src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts --maxWorkers=4 --silent=passed-only` (60 passed)
