### PR TITLE
fix(python): reject oversized firewall auth expiries

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -1,7 +1,6 @@
 """Firewall auth cache, fetch admission, and force-refresh lifecycle."""
 
 import asyncio
-import math
 import time
 from dataclasses import dataclass, field
 
@@ -10,6 +9,7 @@ from firewall_auth_client import (
     FirewallAuthPayload,
     FirewallAuthRequest,
     fetch_firewall_headers,
+    is_supported_expiry,
 )
 
 
@@ -295,9 +295,7 @@ def auth_state_is_empty_for_tests() -> bool:
 
 
 def _has_valid_expiry(value: object, now: float | None = None) -> bool:
-    if isinstance(value, bool) or not isinstance(value, int | float):
-        return False
-    if not math.isfinite(value):
+    if not is_supported_expiry(value):
         return False
     return (time.time() if now is None else now) < value
 

--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -15,7 +15,7 @@ import urllib.request
 from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from email.message import Message
-from typing import NamedTuple, Protocol
+from typing import NamedTuple, Protocol, TypeGuard
 
 import h11
 import mitmproxy_rs
@@ -751,17 +751,23 @@ def _parse_required_string_list(decoded: dict[object, object], field_name: str) 
     return list(value)
 
 
+def is_supported_expiry(value: object) -> TypeGuard[int | float]:
+    """Return whether an expiry is a finite number supported by the runtime."""
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return False
+    try:
+        return math.isfinite(value)
+    except OverflowError:
+        return False
+
+
 def _parse_expires_at(decoded: dict[object, object]) -> int | float | None:
     if "expiresAt" not in decoded:
         raise _malformed_firewall_auth_success("expiresAt is required")
     value = decoded["expiresAt"]
     if value is None:
         return None
-    if (
-        isinstance(value, bool)
-        or not isinstance(value, int | float)
-        or (isinstance(value, float) and not math.isfinite(value))
-    ):
+    if not is_supported_expiry(value):
         raise _malformed_firewall_auth_success("expiresAt must be a finite number or null")
     return value
 

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -643,7 +643,6 @@ class TestGetFirewallHeaders:
             pytest.param("123", 100.0, id="string"),
             pytest.param(float("inf"), 100.0, id="infinity"),
             pytest.param(float("nan"), 100.0, id="nan"),
-            pytest.param(10**400, 100.0, id="oversized-integer"),
             pytest.param(100.0, 100.0, id="exact-now"),
         ],
     )
@@ -652,7 +651,13 @@ class TestGetFirewallHeaders:
 
     @pytest.mark.parametrize(
         "expiry",
-        [True, "123", float("inf"), float("nan"), 10**400],
+        [
+            True,
+            "123",
+            float("inf"),
+            float("nan"),
+            pytest.param(10**400, id="oversized-integer"),
+        ],
     )
     async def test_cache_with_invalid_expiry_refetches(self, headers, expiry):
         cache_key = auth_cache_key()

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -643,13 +643,17 @@ class TestGetFirewallHeaders:
             pytest.param("123", 100.0, id="string"),
             pytest.param(float("inf"), 100.0, id="infinity"),
             pytest.param(float("nan"), 100.0, id="nan"),
+            pytest.param(10**400, 100.0, id="oversized-integer"),
             pytest.param(100.0, 100.0, id="exact-now"),
         ],
     )
     def test_expiry_validation_rejects_invalid_values(self, expiry, now):
         assert auth_cache._has_valid_expiry(expiry, now=now) is False
 
-    @pytest.mark.parametrize("expiry", [True, "123", float("inf"), float("nan")])
+    @pytest.mark.parametrize(
+        "expiry",
+        [True, "123", float("inf"), float("nan"), 10**400],
+    )
     async def test_cache_with_invalid_expiry_refetches(self, headers, expiry):
         cache_key = auth_cache_key()
         set_cached_headers(
@@ -724,6 +728,7 @@ class TestGetFirewallHeaders:
             pytest.param("123", id="string"),
             pytest.param(float("inf"), id="infinity"),
             pytest.param(float("nan"), id="nan"),
+            pytest.param(10**400, id="oversized-integer"),
             pytest.param(0, id="expired"),
         ],
     )

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
@@ -1110,6 +1110,12 @@ class TestHandleFirewallRequest:
                 id="expires-at-negative-infinity",
             ),
             pytest.param(
+                "expiresAt",
+                10**400,
+                "expiresAt must be a finite number or null",
+                id="expires-at-oversized-integer",
+            ),
+            pytest.param(
                 "resolvedSecrets",
                 _MISSING_FIELD,
                 "resolvedSecrets is required",


### PR DESCRIPTION
## Summary

- centralize supported firewall auth expiry validation across response parsing and cache checks
- reject oversized integer expiries through the existing malformed-success and billable fail-closed paths
- cover parser handling, non-billable cache refetch, and fresh billable rejection regressions

## Compatibility

- preserves supported integer and finite-float expiry values without normalization
- does not change the firewall auth wire shape, cache identity, persisted state, or runner protocol
- does not add a migration, feature switch, or rollout requirement

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_firewall_auth_handling.py -k oversized`
- `uv run --no-sync python -m pytest tests/test_auth_cache.py -k oversized`
- `uv run --no-sync python -m pytest tests/` (6426 passed)

Closes #28377
