### PR TITLE
fix(billing): support fully discounted usage pack purchases

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -9949,6 +9949,118 @@ describe("usage pack allocation management", () => {
     expect(state.grants).toHaveLength(4);
   });
 
+  it("completes a fully discounted usage pack upgrade with nonrefundable credits", async () => {
+    mockNow(new Date("2035-01-20T00:00:00.000Z"));
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    const userId = `user_${randomUUID()}`;
+    const fixture = await seedManagedUsagePack([{ userId, usagePackUsd: 20 }]);
+    await enableSavedBillingPurchasePreview(fixture);
+    const paymentMethodId = `pm_${randomUUID()}`;
+    const oldSubscription = {
+      ...managedUsagePackSubscription(
+        fixture,
+        new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
+      ),
+      default_payment_method: paymentMethodId,
+    };
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      oldSubscription,
+    );
+    mockUsagePackChangePreviews(0, 5000);
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
+      billingUsagePackManagementContract,
+    );
+    const preview = await accept(
+      client.previewChange({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          memberId: userId,
+          targetUsagePackUsd: 50,
+          supportsInAppPreview: true,
+          returnUrl: `${APP_ORIGIN}/billing`,
+        },
+      }),
+      [200],
+    );
+    expect(preview.body.immediateAmountCents).toBe(0);
+    expect(preview.body.paymentMethodPreviewToken).toBeUndefined();
+    const prorationTimestamp = Math.floor(
+      new Date(preview.body.prorationDate).getTime() / 1000,
+    );
+    const invoice = {
+      ...managedUsagePackUpgradeInvoice(fixture, {
+        invoiceId: `in_zero_upgrade_${randomUUID()}`,
+        sourcePriceId: TEST_PRICE_USAGE_PACK_20,
+        targetPriceId: TEST_PRICE_USAGE_PACK_50,
+        prorationTimestamp,
+      }),
+      amount_due: 0,
+      currency: "usd",
+      paid: true,
+      lines: {
+        has_more: false,
+        data: managedUsagePackUpgradeInvoice(fixture, {
+          invoiceId: `in_zero_upgrade_lines_${randomUUID()}`,
+          sourcePriceId: TEST_PRICE_USAGE_PACK_20,
+          targetPriceId: TEST_PRICE_USAGE_PACK_50,
+          prorationTimestamp,
+        }).lines.data.map((line) => {
+          return { ...line, amount: 0, subtotal: 0 };
+        }),
+      },
+    };
+    const upgradedSubscription = managedUsagePackSubscription(
+      fixture,
+      new Map([[TEST_PRICE_USAGE_PACK_50, 1]]),
+      fixture.billingPeriod,
+      { latestInvoice: invoice },
+    );
+    context.mocks.stripe.subscriptions.retrieve
+      .mockResolvedValueOnce(oldSubscription)
+      .mockResolvedValue(upgradedSubscription);
+    context.mocks.stripe.subscriptions.update.mockResolvedValue(
+      upgradedSubscription,
+    );
+
+    const confirmed = await accept(
+      client.confirmChange({
+        params: { changeId: preview.body.changeId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: {},
+      }),
+      [200],
+    );
+
+    expect(confirmed.body.status).toBe("completed");
+    const state = await readUsagePackState(
+      fixture.orgId,
+      fixture.usagePackSubscriptionId,
+    );
+    expect(state.allocations).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ usagePackUsd: 20, status: "inactive" }),
+        expect.objectContaining({ usagePackUsd: 50, status: "active" }),
+      ]),
+    );
+    expect(state.grants).toContainEqual(
+      expect.objectContaining({
+        userId,
+        grantType: "purchased",
+        originalAmount: 15_000,
+      }),
+    );
+    expect(state.refunds).toContainEqual(
+      expect.objectContaining({
+        userId,
+        sourceType: "invoice",
+        sourceAmountCents: 0,
+        status: "available",
+      }),
+    );
+  });
+
   it("expires a failed pending upgrade without changing allocation or credits", async () => {
     const initialNow = new Date("2035-02-16T00:00:00.000Z");
     mockNow(initialNow);
@@ -11085,17 +11197,30 @@ describe("usage pack allocation management", () => {
     });
   });
 
-  it("explains when an invitation package has no prorated amount due", async () => {
+  it("purchases, accepts, and removes a fully discounted invitation through Stripe", async () => {
+    mockNow(new Date("2035-02-16T00:00:00.000Z"));
+    onTestFinished(() => {
+      clearMockNow();
+    });
     const existingMemberUserId = `user_${randomUUID()}`;
     const fixture = await seedManagedUsagePack([
       { userId: existingMemberUserId, usagePackUsd: 20 },
     ]);
-    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
-      managedUsagePackSubscription(
+    const subscription = {
+      ...managedUsagePackSubscription(
         fixture,
         new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
       ),
-    );
+      default_payment_method: null,
+      default_source: null,
+    };
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(subscription);
+    context.mocks.stripe.customers.retrieve.mockResolvedValue({
+      id: fixture.customerId,
+      invoice_settings: { default_payment_method: null },
+      default_source: null,
+    });
+    context.mocks.stripe.paymentMethods.list.mockResolvedValue({ data: [] });
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
         data: [
@@ -11113,26 +11238,223 @@ describe("usage pack allocation management", () => {
       { data: [] },
     );
     mockUsagePackChangePreviews(0, 2000);
+    const email = `zero-proration-${randomUUID()}@example.test`;
+    const invitationId = `inv_zero_${randomUUID()}`;
+    const acceptedUserId = `user_zero_${randomUUID()}`;
+    context.mocks.clerk.organizations.createOrganizationInvitation.mockResolvedValue(
+      {
+        id: invitationId,
+        emailAddress: email,
+        organizationId: fixture.orgId,
+        status: "pending",
+      },
+    );
 
-    const response = await accept(
-      setupApp({ context, routes: orgInviteRoutes })(
-        orgInviteContract,
-      ).previewPurchase({
+    const client = setupApp({ context, routes: orgInviteRoutes })(
+      orgInviteContract,
+    );
+    const preview = await accept(
+      client.previewPurchase({
         headers: { authorization: "Bearer clerk-session" },
         body: {
-          email: `zero-proration-${randomUUID()}@example.test`,
+          email,
           role: "member",
           usagePackUsd: 20,
         },
       }),
-      [409],
+      [200],
+    );
+    expect(preview.body).toStrictEqual({
+      purchaseId: expect.any(String),
+      usagePackUsd: 20,
+      immediateAmountCents: 0,
+      currency: "usd",
+      purchasedCredits: 10_000,
+      bonusCredits: 200,
+      totalCredits: 10_200,
+      currentPeriodEnd: new Date(
+        fixture.billingPeriod.end * 1000,
+      ).toISOString(),
+      expiresAt: expect.any(String),
+    });
+
+    const invoiceId = `in_zero_invite_${randomUUID()}`;
+    const metadata = {
+      purpose: "usage_pack_invitation_purchase",
+      usagePackInvitationPurchaseId: preview.body.purchaseId,
+    };
+    context.mocks.stripe.invoices.create.mockResolvedValue({
+      id: invoiceId,
+      customer: fixture.customerId,
+      metadata,
+      amount_due: 0,
+      currency: "usd",
+      status: "draft",
+      hosted_invoice_url: null,
+      lines: { has_more: false, data: [] },
+      parent: null,
+    });
+    context.mocks.stripe.invoiceItems.create.mockResolvedValue({
+      id: `ii_zero_invite_${randomUUID()}`,
+    });
+    context.mocks.stripe.invoices.finalizeInvoice.mockResolvedValue({
+      id: invoiceId,
+      customer: fixture.customerId,
+      metadata,
+      amount_due: 0,
+      currency: "usd",
+      status: "paid",
+      paid: true,
+      hosted_invoice_url: null,
+      lines: { has_more: false, data: [] },
+      parent: null,
+    });
+    context.mocks.stripe.invoices.retrieve.mockResolvedValue({
+      id: invoiceId,
+      customer: fixture.customerId,
+      metadata,
+      amount_due: 0,
+      currency: "usd",
+      status: "paid",
+      paid: true,
+      hosted_invoice_url: null,
+      status_transitions: { paid_at: Math.floor(now() / 1000) },
+      payments: { data: [] },
+      lines: { has_more: false, data: [] },
+      parent: null,
+    });
+
+    const confirmation = await accept(
+      client.confirmPurchase({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { purchaseId: preview.body.purchaseId },
+        body: {},
+      }),
+      [200],
+    );
+    expect(confirmation.body.message).toBe("Invitation purchased and sent");
+    expect(context.mocks.stripe.invoiceItems.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invoice: invoiceId,
+        amount: 0,
+        currency: "usd",
+      }),
+      expect.any(Object),
+    );
+    expect(context.mocks.stripe.invoices.pay).not.toHaveBeenCalled();
+    expect(
+      context.mocks.stripe.checkout.sessions.create,
+    ).not.toHaveBeenCalled();
+
+    const pending = await readUsagePackState(
+      fixture.orgId,
+      fixture.usagePackSubscriptionId,
+    );
+    expect(pending.invitationPurchases[0]).toStrictEqual(
+      expect.objectContaining({
+        status: "invitation_pending",
+        expectedAmountCents: 0,
+        amountPaidCents: 0,
+        stripePaymentIntentId: null,
+        clerkInvitationId: invitationId,
+      }),
     );
 
-    expect(response.body.error).toStrictEqual({
-      code: "INVITATION_PURCHASE_NO_AMOUNT_DUE",
-      message:
-        "This member package has no charge to collect right now. Try again after your billing period renews.",
+    context.mocks.stripe.subscriptions.update.mockResolvedValue({});
+    const purchase: InvitationPurchaseFixture = {
+      fixture,
+      existingMemberUserId,
+      email,
+      purchaseId: preview.body.purchaseId,
+      paymentIntentId: `pi_unused_${randomUUID()}`,
+    };
+    await postClerkInvitationAccepted({
+      purchase,
+      invitationId,
+      userId: acceptedUserId,
     });
+
+    const accepted = await readUsagePackState(
+      fixture.orgId,
+      fixture.usagePackSubscriptionId,
+    );
+    expect(accepted.invitationPurchases[0]).toStrictEqual(
+      expect.objectContaining({ status: "accepted", acceptedUserId }),
+    );
+    expect(
+      accepted.grants.filter((grant) => {
+        return grant.userId === acceptedUserId;
+      }),
+    ).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          grantType: "purchased",
+          originalAmount: 10_000,
+        }),
+        expect.objectContaining({ grantType: "bonus", originalAmount: 200 }),
+      ]),
+    );
+    expect(
+      accepted.refunds.filter((refund) => {
+        return refund.userId === acceptedUserId;
+      }),
+    ).toStrictEqual([]);
+
+    context.mocks.stripe.subscriptions.update.mockClear();
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      managedUsagePackSubscription(
+        fixture,
+        new Map([[TEST_PRICE_USAGE_PACK_20, 2]]),
+      ),
+    );
+    const removalEvent = {
+      type: "organizationMembership.deleted",
+      data: {
+        id: `mem_zero_${randomUUID()}`,
+        organization: { id: fixture.orgId },
+        publicUserData: { userId: acceptedUserId },
+        role: "org:member",
+      },
+    };
+    context.mocks.clerk.verifyWebhook.mockResolvedValueOnce(removalEvent);
+    await accept(
+      setupApp({ context, routes: webhooksClerkRoutes })(
+        webhookClerkContract,
+      ).post({ body: JSON.stringify(removalEvent) }),
+      [200],
+    );
+    await flushWaitUntilForTest();
+
+    const removed = await readUsagePackState(
+      fixture.orgId,
+      fixture.usagePackSubscriptionId,
+    );
+    expect(
+      removed.allocations.find((allocation) => {
+        return allocation.userId === acceptedUserId;
+      })?.status,
+    ).toBe("inactive");
+    expect(removed.remainingCredits).toContainEqual({
+      userId: acceptedUserId,
+      amount: 0,
+    });
+    expect(
+      removed.refunds.filter((refund) => {
+        return refund.userId === acceptedUserId;
+      }),
+    ).toStrictEqual([]);
+    expect(context.mocks.stripe.refunds.create).not.toHaveBeenCalled();
+    expect(context.mocks.stripe.creditNotes.create).not.toHaveBeenCalled();
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledWith(
+      fixture.subscriptionId,
+      {
+        items: [{ id: `si_${TEST_PRICE_USAGE_PACK_20}`, quantity: 1 }],
+        proration_behavior: "none",
+      },
+      expect.objectContaining({
+        idempotencyKey: expect.stringContaining("member-removal"),
+      }),
+    );
   });
 
   it("asks the buyer to restore a canceling subscription before inviting", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -10993,6 +10993,93 @@ describe("usage pack allocation management", () => {
     expect(state.org?.cancelAtPeriodEnd).toBeTruthy();
   });
 
+  it("removes a member when a legacy invoice has no refundable amount", async () => {
+    mockNow(new Date("2035-04-20T00:00:00.000Z"));
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    const targetUserId = `user_${randomUUID()}`;
+    const targetEmail = `${targetUserId}@example.test`;
+    const fixture = await seedManagedUsagePack([
+      { userId: targetUserId, usagePackUsd: 20 },
+    ]);
+    await usagePackStateAction({
+      action: "delete-refund-source",
+      orgId: fixture.orgId,
+      userId: targetUserId,
+    });
+    await updateFeatureSwitchesForUser(context, fixture, {
+      [FeatureSwitchKey.UsagePackPlans]: false,
+    });
+    context.mocks.clerk.users.getUserList.mockResolvedValue({
+      data: [{ id: targetUserId }],
+    });
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+      {
+        data: [
+          { publicUserData: { userId: fixture.userId } },
+          { publicUserData: { userId: targetUserId } },
+        ],
+      },
+    );
+    context.mocks.clerk.organizations.deleteOrganizationMembership.mockResolvedValue(
+      {},
+    );
+    const currentSubscription = managedUsagePackSubscription(
+      fixture,
+      new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
+    );
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      currentSubscription,
+    );
+    context.mocks.stripe.subscriptions.update.mockResolvedValue(
+      currentSubscription,
+    );
+    context.mocks.stripe.creditNotes.preview.mockResolvedValue({
+      id: "cn_preview_zero_usage_pack_removal",
+      status: "issued",
+      pre_payment_amount: 0,
+      post_payment_amount: 0,
+      refunds: [],
+    });
+
+    await accept(
+      setupApp({ context, routes: orgMembersRoutes })(
+        orgMembersContract,
+      ).removeMember({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { email: targetEmail },
+      }),
+      [200],
+    );
+
+    const state = await readUsagePackState(
+      fixture.orgId,
+      fixture.usagePackSubscriptionId,
+    );
+    expect(state.remainingCredits).toContainEqual({
+      userId: targetUserId,
+      amount: 0,
+    });
+    expect(state.refunds).toContainEqual(
+      expect.objectContaining({
+        userId: targetUserId,
+        sourceType: "invoice",
+        sourceAmountCents: 2000,
+        status: "succeeded",
+        requestedAmountCents: 2000,
+        refundedAmountCents: 0,
+        stripeCreditNoteId: null,
+        stripeRefundId: null,
+      }),
+    );
+    expect(context.mocks.stripe.creditNotes.create).not.toHaveBeenCalled();
+    expect(context.mocks.stripe.refunds.retrieve).not.toHaveBeenCalled();
+    expect(state.changes[0]).toStrictEqual(
+      expect.objectContaining({ kind: "removal", status: "scheduled" }),
+    );
+  });
+
   it.each(["pro", "team"] as const)(
     "requires a usage pack for managed %s invitation entitlements",
     async (tier) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/org-delete-billing.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-delete-billing.test.ts
@@ -454,6 +454,48 @@ test("cancels trials and unpaid subscriptions without inventing a refund", async
   expect(context.mocks.stripe.creditNotes.create).not.toHaveBeenCalled();
 });
 
+test("cancels fully discounted subscriptions without inventing a refund", async () => {
+  const deletionTimestamp = 1_800_000_000;
+  const periodStart = deletionTimestamp - 500;
+  const periodEnd = deletionTimestamp + 500;
+  const subscriptionId = "sub_delete_fully_discounted";
+  const fixture = createOrgDeleteBillingFixture();
+  await seedPlanSubscription(fixture, subscriptionId, periodEnd);
+  mockNow(deletionTimestamp * 1000);
+  mockOrgDeletion(fixture);
+  context.mocks.stripe.subscriptions.list.mockResolvedValue({
+    data: [subscription(subscriptionId, fixture.customerId)],
+    has_more: false,
+  });
+  const invoiceLine = {
+    ...subscriptionLine(1000, periodStart, periodEnd),
+    discount_amounts: [{ amount: 1000 }],
+  };
+  context.mocks.stripe.invoices.list.mockResolvedValue({
+    data: [
+      {
+        ...paidInvoice(
+          "in_delete_fully_discounted",
+          fixture.customerId,
+          subscriptionId,
+          [invoiceLine],
+        ),
+        amount_due: 0,
+      },
+    ],
+    has_more: false,
+  });
+
+  await accept(requestOrgDeletion(), [200]);
+
+  expect(context.mocks.stripe.subscriptions.cancel).toHaveBeenCalledOnce();
+  expect(context.mocks.stripe.creditNotes.preview).not.toHaveBeenCalled();
+  expect(context.mocks.stripe.creditNotes.create).not.toHaveBeenCalled();
+  expect(
+    context.mocks.clerk.organizations.deleteOrganization,
+  ).toHaveBeenCalledOnce();
+});
+
 test("nets upgrade credits and excludes one-time invoice items from proration", async () => {
   const deletionTimestamp = 1_800_000_000;
   const originalStart = deletionTimestamp - 600;

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-pack-subscription-lifecycle.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-pack-subscription-lifecycle.test.ts
@@ -181,6 +181,7 @@ function paidInvoice(
     readonly paidPeriod: { readonly start: number; readonly end: number };
     readonly quantities: ReadonlyMap<string, number>;
     readonly fraction?: number;
+    readonly fullyDiscounted?: boolean;
     readonly linePeriodEnd?: number;
   },
 ) {
@@ -206,6 +207,7 @@ function paidInvoice(
         return {
           id: `il_${randomUUID()}`,
           amount,
+          discount_amounts: args.fullyDiscounted ? [{ amount }] : [],
           subtotal: amount,
           quantity,
           price: { id: priceId },
@@ -549,6 +551,62 @@ describe("usage pack subscription Stripe lifecycle", () => {
         expiresAt: new Date(paidPeriod.end * 1000).toISOString(),
       },
     ]);
+  });
+
+  it("grants fully discounted renewal credits without a refundable amount", async () => {
+    const userId = `user_${randomUUID()}`;
+    const fixture = await seedUsagePackLifecycle([
+      { userId, usagePackUsd: 20 },
+    ]);
+    const quantities = new Map([[TEST_PRICE_PACK_20, 1]]);
+    const paidPeriod = period(0);
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      stripeSubscription(fixture, paidPeriod, quantities),
+    );
+
+    await postStripeEvent(
+      stripeEvent(
+        "customer.subscription.created",
+        stripeSubscription(fixture, paidPeriod, quantities),
+      ),
+      200,
+    );
+    await postStripeEvent(
+      stripeEvent(
+        "invoice.paid",
+        paidInvoice(fixture, {
+          invoiceId: `in_discounted_${randomUUID()}`,
+          paidPeriod,
+          quantities,
+          fullyDiscounted: true,
+        }),
+      ),
+      200,
+    );
+
+    const state = await readUsagePackState(fixture);
+    expect(state.grants).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          userId,
+          grantType: "purchased",
+          originalAmount: 20_000,
+        }),
+        expect.objectContaining({
+          userId,
+          grantType: "bonus",
+          originalAmount: 400,
+        }),
+      ]),
+    );
+    expect(state.refunds).toContainEqual(
+      expect.objectContaining({
+        userId,
+        sourceType: "invoice",
+        sourceAmountCents: 0,
+        status: "available",
+      }),
+    );
   });
 
   it("grants independent one-time Atom member credits for Atom and subscribed plans", async () => {

--- a/turbo/apps/api/src/signals/routes/org-invite.ts
+++ b/turbo/apps/api/src/signals/routes/org-invite.ts
@@ -95,12 +95,6 @@ const INVITATION_PURCHASE_ERRORS = {
     code: "INVITATION_PURCHASE_INVITEE_UNAVAILABLE",
     message: "This person is already a member or has a pending invitation.",
   },
-  no_amount_due: {
-    status: 409,
-    code: "INVITATION_PURCHASE_NO_AMOUNT_DUE",
-    message:
-      "This member package has no charge to collect right now. Try again after your billing period renews.",
-  },
   no_credits: {
     status: 409,
     code: "INVITATION_PURCHASE_NO_CREDITS",

--- a/turbo/apps/api/src/signals/services/org-deletion-billing.service.ts
+++ b/turbo/apps/api/src/signals/services/org-deletion-billing.service.ts
@@ -299,10 +299,19 @@ function proratedLineAmount(
   if (end <= start || deletionTimestamp >= end) {
     return 0;
   }
+  const discountAmount = (line.discount_amounts ?? []).reduce(
+    (total, discount) => {
+      return total + discount.amount;
+    },
+    0,
+  );
   const exclusiveTax = (line.taxes ?? []).reduce((total, tax) => {
     return tax.tax_behavior === "exclusive" ? total + tax.amount : total;
   }, 0);
-  const amount = line.amount + exclusiveTax;
+  const amount =
+    line.amount +
+    (line.amount < 0 ? discountAmount : -discountAmount) +
+    exclusiveTax;
   if (!Number.isSafeInteger(amount)) {
     throw new Error("Stripe invoice line has an invalid amount");
   }

--- a/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
@@ -196,6 +196,7 @@ interface UsagePackChangeSubscriptionInput {
 interface UsagePackChangeInvoiceLineInput {
   readonly id?: string;
   readonly amount?: number | null;
+  readonly discount_amounts?: readonly { readonly amount: number }[] | null;
   readonly subtotal?: number | null;
   readonly quantity?: number | null;
   readonly price?: { readonly id: string } | null;
@@ -205,6 +206,12 @@ interface UsagePackChangeInvoiceLineInput {
     } | null;
   } | null;
   readonly proration?: boolean;
+  readonly taxes?:
+    | readonly {
+        readonly amount: number;
+        readonly tax_behavior: "exclusive" | "inclusive";
+      }[]
+    | null;
   readonly period: { readonly start?: number; readonly end: number };
   readonly parent: {
     readonly type: "subscription_item_details" | "invoice_item_details";
@@ -368,6 +375,27 @@ function invoiceLineAmount(
   return typeof amount === "number" && Number.isSafeInteger(amount)
     ? amount
     : null;
+}
+
+function invoiceLineRefundableAmountWithTax(
+  line: UsagePackChangeInvoiceLineInput,
+): number | null {
+  const amount = line.amount ?? line.subtotal;
+  if (typeof amount !== "number" || !Number.isSafeInteger(amount)) {
+    return null;
+  }
+  const discountAmount = (line.discount_amounts ?? []).reduce(
+    (total, discount) => {
+      return total + discount.amount;
+    },
+    0,
+  );
+  const exclusiveTax = (line.taxes ?? []).reduce((total, tax) => {
+    return tax.tax_behavior === "exclusive" ? total + tax.amount : total;
+  }, 0);
+  const refundableAmount =
+    amount + (amount < 0 ? discountAmount : -discountAmount) + exclusiveTax;
+  return Number.isSafeInteger(refundableAmount) ? refundableAmount : null;
 }
 
 function invoiceLineIsProration(
@@ -739,10 +767,16 @@ function safeInvoiceAmount(invoice: StripeInvoice, label: string): number {
 }
 
 function invoiceLineAmountWithTax(line: StripeInvoiceLine): number {
+  const discountAmount = (line.discount_amounts ?? []).reduce(
+    (total, discount) => {
+      return total + discount.amount;
+    },
+    0,
+  );
   const exclusiveTax = (line.taxes ?? []).reduce((total, tax) => {
     return tax.tax_behavior === "exclusive" ? total + tax.amount : total;
   }, 0);
-  const amount = line.amount + exclusiveTax;
+  const amount = line.amount - discountAmount + exclusiveTax;
   if (!Number.isSafeInteger(amount)) {
     throw new Error("Stripe usage pack preview line has an invalid amount");
   }
@@ -2744,8 +2778,8 @@ function upgradeProrationPeriod(
     return (
       invoiceLineIsProration(line) &&
       amount !== null &&
-      ((priceId === change.sourceStripePriceId && amount < 0) ||
-        (priceId === change.targetStripePriceId && amount > 0))
+      ((priceId === change.sourceStripePriceId && amount <= 0) ||
+        (priceId === change.targetStripePriceId && amount >= 0))
     );
   });
   const sourceLine = matchingLines.find((line) => {
@@ -2775,24 +2809,54 @@ function upgradeProrationPeriod(
   return { start, end };
 }
 
-function upgradeRefundInvoiceLineId(
+interface UsagePackUpgradeRefundInvoiceSource {
+  readonly invoiceLineId: string | null;
+  readonly amountCents: number;
+}
+
+function upgradeRefundInvoiceSource(
   invoice: UsagePackChangeInvoiceInput,
   change: UsagePackAllocationChangeRow,
-): string | null {
+): UsagePackUpgradeRefundInvoiceSource | null {
   if (!change.targetStripePriceId) {
     return null;
   }
-  const targetLine = invoice.lines.data.find((line) => {
+  const matchingLines = invoice.lines.data.filter((line) => {
     const amount = invoiceLineAmount(line);
+    const priceId = invoiceLinePriceId(line);
     return (
-      invoiceLinePriceId(line) === change.targetStripePriceId &&
       invoiceLineIsProration(line) &&
       amount !== null &&
-      amount > 0 &&
+      ((priceId === change.sourceStripePriceId && amount <= 0) ||
+        (priceId === change.targetStripePriceId && amount >= 0)) &&
       line.period.start === change.prorationTimestamp
     );
   });
-  return targetLine?.id ?? null;
+  const targetLine = matchingLines.find((line) => {
+    return invoiceLinePriceId(line) === change.targetStripePriceId;
+  });
+  const sourceLine = change.sourceStripePriceId
+    ? matchingLines.find((line) => {
+        return invoiceLinePriceId(line) === change.sourceStripePriceId;
+      })
+    : undefined;
+  if (!targetLine || (change.sourceStripePriceId && !sourceLine)) {
+    return null;
+  }
+  let amountCents = 0;
+  for (const line of matchingLines) {
+    const amount = invoiceLineRefundableAmountWithTax(line);
+    if (amount === null) {
+      return null;
+    }
+    amountCents += amount;
+  }
+  if (!Number.isSafeInteger(amountCents) || amountCents < 0) {
+    throw new Error(
+      `Usage pack change invoice ${invoice.id} has an invalid refundable amount`,
+    );
+  }
+  return { invoiceLineId: targetLine.id ?? null, amountCents };
 }
 
 function proratedCreditDelta(
@@ -3032,6 +3096,7 @@ async function commitUsagePackUpgradeInvoice(
       throw new Error(`Usage pack change ${change.id} has another invoice`);
     }
     if (args.purchasedCredits > 0) {
+      const refundSource = upgradeRefundInvoiceSource(args.invoice, change);
       await createUsagePackCreditGrant(tx, {
         orgId: change.orgId,
         userId: change.userId,
@@ -3042,8 +3107,10 @@ async function commitUsagePackUpgradeInvoice(
         refundSource: {
           type: "invoice",
           invoiceId: args.invoice.id,
-          invoiceLineId: upgradeRefundInvoiceLineId(args.invoice, change),
-          amountCents: Math.floor(args.purchasedCredits / CREDITS_PER_CENT),
+          invoiceLineId: refundSource?.invoiceLineId ?? null,
+          amountCents:
+            refundSource?.amountCents ??
+            Math.floor(args.purchasedCredits / CREDITS_PER_CENT),
         },
       });
     }
@@ -3090,6 +3157,7 @@ interface PreparedSubscriptionChangeGrant {
   readonly purchasedCredits: number;
   readonly bonusCredits: number;
   readonly stripeInvoiceLineId: string | null;
+  readonly sourceAmountCents: number;
 }
 
 async function prepareSubscriptionChangeFulfillment(
@@ -3149,10 +3217,14 @@ async function prepareSubscriptionChangeFulfillment(
           { start: args.periodStart, end: args.periodEnd },
           args.prorationTimestamp,
         );
+        const refundSource = upgradeRefundInvoiceSource(args.invoice, change);
         return {
           change,
           ...grant,
-          stripeInvoiceLineId: upgradeRefundInvoiceLineId(args.invoice, change),
+          stripeInvoiceLineId: refundSource?.invoiceLineId ?? null,
+          sourceAmountCents:
+            refundSource?.amountCents ??
+            Math.floor(grant.purchasedCredits / CREDITS_PER_CENT),
         };
       }
       if (!change.sourceAllocationId || !change.sourceStripePriceId) {
@@ -3174,21 +3246,26 @@ async function prepareSubscriptionChangeFulfillment(
         usagePackCreditsForPrice(change.sourceStripePriceId),
         usagePackCreditsForPrice(change.targetStripePriceId),
       ]);
+      const purchasedCredits = proratedCreditDelta(
+        sourceCredits.purchased,
+        targetCredits.purchased,
+        sourceAllocation,
+        prorationPeriod,
+      );
+      const refundSource = upgradeRefundInvoiceSource(args.invoice, change);
       return {
         change,
-        purchasedCredits: proratedCreditDelta(
-          sourceCredits.purchased,
-          targetCredits.purchased,
-          sourceAllocation,
-          prorationPeriod,
-        ),
+        purchasedCredits,
         bonusCredits: proratedCreditDelta(
           sourceCredits.bonus,
           targetCredits.bonus,
           sourceAllocation,
           prorationPeriod,
         ),
-        stripeInvoiceLineId: upgradeRefundInvoiceLineId(args.invoice, change),
+        stripeInvoiceLineId: refundSource?.invoiceLineId ?? null,
+        sourceAmountCents:
+          refundSource?.amountCents ??
+          Math.floor(purchasedCredits / CREDITS_PER_CENT),
       };
     }),
   );
@@ -3251,7 +3328,7 @@ async function fulfillPreparedSubscriptionChange(
           type: "invoice",
           invoiceId: args.invoice.id,
           invoiceLineId: prepared.stripeInvoiceLineId,
-          amountCents: Math.floor(prepared.purchasedCredits / CREDITS_PER_CENT),
+          amountCents: prepared.sourceAmountCents,
         },
       });
     }

--- a/turbo/apps/api/src/signals/services/usage-pack-credit-refund.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-credit-refund.service.ts
@@ -372,6 +372,25 @@ async function markRefundSucceeded(
     .where(eq(usagePackCreditRefunds.creditGrantId, row.creditGrantId));
 }
 
+async function markRefundNotRequired(
+  db: Pick<Db, "update">,
+  row: UsagePackCreditRefundRow,
+): Promise<void> {
+  const at = nowDate();
+  await db
+    .update(usagePackCreditRefunds)
+    .set({
+      status: "succeeded",
+      stripeCreditNoteId: null,
+      stripeRefundId: null,
+      refundedAmountCents: 0,
+      failureReason: null,
+      refundedAt: at,
+      updatedAt: at,
+    })
+    .where(eq(usagePackCreditRefunds.creditGrantId, row.creditGrantId));
+}
+
 async function applyPaymentIntentRefundState(
   db: Pick<Db, "update">,
   row: UsagePackCreditRefundRow,
@@ -468,7 +487,7 @@ async function processPaymentIntentRefund(
 async function loadOrCreateCreditNote(
   db: Pick<Db, "update">,
   row: UsagePackCreditRefundRow,
-): Promise<StripeCreditNote> {
+): Promise<StripeCreditNote | null> {
   const stripe = getStripeClient();
   if (row.stripeCreditNoteId) {
     return await stripe.creditNotes.retrieve(row.stripeCreditNoteId);
@@ -492,8 +511,16 @@ async function loadOrCreateCreditNote(
     },
   };
   let refundAmountCents = row.refundedAmountCents;
+  if (refundAmountCents === 0) {
+    await markRefundNotRequired(db, row);
+    return null;
+  }
   if (refundAmountCents === null) {
     const preview = await stripe.creditNotes.preview(commonParams);
+    if (preview.pre_payment_amount === 0 && preview.post_payment_amount === 0) {
+      await markRefundNotRequired(db, row);
+      return null;
+    }
     if (preview.pre_payment_amount !== 0 || preview.post_payment_amount <= 0) {
       throw new Error(
         `Usage pack refund ${row.creditGrantId} credit note is not fully refundable`,
@@ -518,6 +545,9 @@ async function processInvoiceRefund(
   row: UsagePackCreditRefundRow,
 ): Promise<void> {
   const creditNote = await loadOrCreateCreditNote(db, row);
+  if (!creditNote) {
+    return;
+  }
   if (creditNote.status !== "issued" || creditNote.post_payment_amount <= 0) {
     throw new Error(
       `Usage pack refund ${row.creditGrantId} has an invalid credit note`,

--- a/turbo/apps/api/src/signals/services/usage-pack-credit-refund.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-credit-refund.service.ts
@@ -200,7 +200,7 @@ function legacyInvitationPurchaseId(idempotencyKey: string): string | null {
 async function inferLegacyRefundSource(
   db: Pick<Db, "select">,
   grant: UsagePackCreditGrantRow,
-): Promise<UsagePackCreditRefundSource> {
+): Promise<UsagePackCreditRefundSource | null> {
   const invitationPurchaseId = legacyInvitationPurchaseId(grant.idempotencyKey);
   if (invitationPurchaseId) {
     const [purchase] = await db
@@ -217,10 +217,16 @@ async function inferLegacyRefundSource(
     if (
       !purchase ||
       purchase.orgId !== grant.orgId ||
-      purchase.acceptedUserId !== grant.userId ||
-      !purchase.amountPaidCents ||
-      !purchase.stripePaymentIntentId
+      purchase.acceptedUserId !== grant.userId
     ) {
+      throw new Error(
+        `Usage pack grant ${grant.id} has no refundable invitation payment`,
+      );
+    }
+    if (purchase.amountPaidCents === 0) {
+      return null;
+    }
+    if (purchase.amountPaidCents === null || !purchase.stripePaymentIntentId) {
       throw new Error(
         `Usage pack grant ${grant.id} has no refundable invitation payment`,
       );
@@ -245,7 +251,7 @@ async function inferLegacyRefundSource(
 async function loadRefundSource(
   db: CreditRefundStore,
   grant: UsagePackCreditGrantRow,
-): Promise<UsagePackCreditRefundRow> {
+): Promise<UsagePackCreditRefundRow | null> {
   const [existing] = await db
     .select()
     .from(usagePackCreditRefunds)
@@ -255,6 +261,9 @@ async function loadRefundSource(
     return existing;
   }
   const source = await inferLegacyRefundSource(db, grant);
+  if (!source) {
+    return null;
+  }
   await ensureUsagePackCreditRefundSource(db, {
     creditGrantId: grant.id,
     orgId: grant.orgId,
@@ -290,7 +299,7 @@ export async function prepareUsagePackMemberCreditRefunds(
   let prepared = 0;
   for (const grant of grants) {
     const source = await loadRefundSource(db, grant);
-    if (source.status !== "available") {
+    if (!source || source.status !== "available") {
       continue;
     }
     const requestedAmountCents = Math.floor(

--- a/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
@@ -100,7 +100,6 @@ export type UsagePackInvitationPurchaseConflictReason =
   | "billing_period_ending"
   | "billing_state_changed"
   | "invitee_unavailable"
-  | "no_amount_due"
   | "no_credits"
   | "payment_method_changed"
   | "purchase_in_progress"
@@ -138,7 +137,7 @@ interface PendingInvitationPurchaseArgs {
 interface SuccessfulPaymentArgs {
   readonly purchaseId: string;
   readonly checkoutSessionId?: string;
-  readonly paymentIntentId: string;
+  readonly paymentIntentId: string | null;
   readonly customerId: string;
   readonly amountPaidCents: number;
   readonly currency: string;
@@ -549,17 +548,6 @@ async function prepareNewUsagePackInvitationPurchase(
     },
     signal,
   );
-  if (preview.amountCents <= 0) {
-    return {
-      status: "conflict",
-      reason: "no_amount_due",
-      diagnostics: {
-        amountCents: preview.amountCents,
-        currency: preview.currency,
-        currentPeriodEnd: preview.currentPeriodEnd.toISOString(),
-      },
-    };
-  }
   const stripe = getStripeClient();
   const price = await stripe.prices.retrieve(stripePriceId, {
     expand: ["product"],
@@ -573,11 +561,34 @@ async function prepareNewUsagePackInvitationPurchase(
     throw new Error("Usage pack invitation Price does not match its preview");
   }
   const unitAmountCents = price.unit_amount;
-  const purchasedCredits = Math.floor(
-    (catalogItem.purchasedCredits * preview.amountCents) / unitAmountCents,
+  const currentPeriodStart = Math.floor(
+    preview.currentPeriodStart.getTime() / 1000,
   );
-  const bonusCredits = Math.floor(
-    (catalogItem.bonusCredits * preview.amountCents) / unitAmountCents,
+  const currentPeriodEnd = Math.floor(
+    preview.currentPeriodEnd.getTime() / 1000,
+  );
+  const periodSeconds = currentPeriodEnd - currentPeriodStart;
+  const remainingSeconds = currentPeriodEnd - preview.prorationTimestamp;
+  if (
+    periodSeconds <= 0 ||
+    remainingSeconds <= 0 ||
+    remainingSeconds > periodSeconds
+  ) {
+    throw new Error("Usage pack invitation preview has an invalid period");
+  }
+  const purchasedCredits = Math.max(
+    Math.floor(
+      (catalogItem.purchasedCredits * preview.amountCents) / unitAmountCents,
+    ),
+    Math.floor(
+      (catalogItem.purchasedCredits * remainingSeconds) / periodSeconds,
+    ),
+  );
+  const bonusCredits = Math.max(
+    Math.floor(
+      (catalogItem.bonusCredits * preview.amountCents) / unitAmountCents,
+    ),
+    Math.floor((catalogItem.bonusCredits * remainingSeconds) / periodSeconds),
   );
   if (purchasedCredits <= 0) {
     return {
@@ -585,7 +596,7 @@ async function prepareNewUsagePackInvitationPurchase(
       reason: "no_credits",
       diagnostics: {
         amountCents: preview.amountCents,
-        unitAmountCents,
+        remainingSeconds,
         purchasedCredits,
       },
     };
@@ -764,8 +775,9 @@ function validateSuccessfulPayment(
     throw new Error("Stripe invitation payment does not match local billing");
   }
   if (
-    purchase.stripePaymentIntentId &&
-    purchase.stripePaymentIntentId !== args.paymentIntentId
+    (args.amountPaidCents > 0 && !args.paymentIntentId) ||
+    (purchase.stripePaymentIntentId &&
+      purchase.stripePaymentIntentId !== args.paymentIntentId)
   ) {
     throw new Error("Invitation purchase has a different PaymentIntent");
   }
@@ -1390,7 +1402,7 @@ export async function handleUsagePackInvitationInvoicePaid(
   }
   const customerId = stripeObjectId(invoice.customer);
   const payment = paidInvoicePaymentIntent(invoice);
-  if (!customerId || !payment) {
+  if (!customerId || (!payment && invoice.amount_due !== 0)) {
     throw new Error("Paid invitation invoice is incomplete");
   }
   const paidAtSeconds = invoice.status_transitions?.paid_at;
@@ -1400,9 +1412,9 @@ export async function handleUsagePackInvitationInvoicePaid(
       : nowDate();
   const purchase = await recordSuccessfulPayment(db, {
     purchaseId,
-    paymentIntentId: payment.id,
+    paymentIntentId: payment?.id ?? null,
     customerId,
-    amountPaidCents: payment.amountPaidCents,
+    amountPaidCents: payment?.amountPaidCents ?? 0,
     currency: invoice.currency,
     paidAt,
   });
@@ -1845,7 +1857,10 @@ async function activateAcceptedPurchase(
       signal,
     );
     if (current.purchasedCredits > 0) {
-      if (!current.amountPaidCents || !current.stripePaymentIntentId) {
+      if (
+        current.amountPaidCents === null ||
+        (current.amountPaidCents > 0 && !current.stripePaymentIntentId)
+      ) {
         throw new Error("Invitation acceptance has no refundable payment");
       }
       await createUsagePackCreditGrant(tx, {
@@ -1855,11 +1870,15 @@ async function activateAcceptedPurchase(
         idempotencyKey: `usage-pack-invitation:${current.id}:purchased`,
         amount: current.purchasedCredits,
         expiresAt: current.currentPeriodEnd,
-        refundSource: {
-          type: "payment_intent",
-          paymentIntentId: current.stripePaymentIntentId,
-          amountCents: current.amountPaidCents,
-        },
+        ...(current.amountPaidCents > 0 && current.stripePaymentIntentId
+          ? {
+              refundSource: {
+                type: "payment_intent" as const,
+                paymentIntentId: current.stripePaymentIntentId,
+                amountCents: current.amountPaidCents,
+              },
+            }
+          : {}),
       });
     }
     if (current.bonusCredits > 0) {

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
@@ -208,6 +208,7 @@ export interface UsagePackSubscriptionInput {
 interface UsagePackInvoiceLineInput {
   readonly id?: string;
   readonly amount?: number | null;
+  readonly discount_amounts?: readonly { readonly amount: number }[] | null;
   readonly subtotal?: number | null;
   readonly quantity?: number | null;
   readonly price?: { readonly id: string } | null;
@@ -217,6 +218,12 @@ interface UsagePackInvoiceLineInput {
     } | null;
   } | null;
   readonly proration?: boolean;
+  readonly taxes?:
+    | readonly {
+        readonly amount: number;
+        readonly tax_behavior: "exclusive" | "inclusive";
+      }[]
+    | null;
   readonly period: { readonly start?: number; readonly end: number };
   readonly parent: {
     readonly type: "subscription_item_details" | "invoice_item_details";
@@ -2327,6 +2334,28 @@ function invoiceLineAmount(line: UsagePackInvoiceLineInput): number | null {
     : null;
 }
 
+function invoiceLineRefundableAmount(
+  line: UsagePackInvoiceLineInput,
+): number | null {
+  const amount = line.amount ?? line.subtotal;
+  if (typeof amount !== "number" || !Number.isSafeInteger(amount)) {
+    return null;
+  }
+  const discountAmount = (line.discount_amounts ?? []).reduce(
+    (total, discount) => {
+      return total + discount.amount;
+    },
+    0,
+  );
+  const exclusiveTax = (line.taxes ?? []).reduce((total, tax) => {
+    return tax.tax_behavior === "exclusive" ? total + tax.amount : total;
+  }, 0);
+  const refundableAmount = amount - discountAmount + exclusiveTax;
+  return Number.isSafeInteger(refundableAmount) && refundableAmount >= 0
+    ? refundableAmount
+    : null;
+}
+
 function invoiceHasUsagePackLine(invoice: UsagePackInvoiceInput): boolean {
   return (invoice.lines?.data ?? []).some((line) => {
     const priceId = invoiceLinePriceId(line);
@@ -2419,6 +2448,12 @@ function prepareUsagePackPriceCredits(
       `Invoice ${invoice.id} has an invalid amount for ${priceId}`,
     );
   }
+  const sourceAmountCents = invoiceLineRefundableAmount(line);
+  if (sourceAmountCents === null) {
+    throw new Error(
+      `Invoice ${invoice.id} has an invalid refundable amount for ${priceId}`,
+    );
+  }
   const fullAmount = catalogItem.unitAmountCents * subscriptionQuantity;
   if (!Number.isSafeInteger(fullAmount) || amount > fullAmount) {
     throw new Error(
@@ -2456,7 +2491,7 @@ function prepareUsagePackPriceCredits(
     purchasedCredits: Math.floor(catalogItem.purchasedCredits * fraction),
     bonusCredits: Math.floor(catalogItem.bonusCredits * fraction),
     stripeInvoiceLineId: line.id ?? null,
-    sourceAmountCents: amount,
+    sourceAmountCents,
     quantity: subscriptionQuantity,
   };
 }

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -125,6 +125,7 @@ interface InvoiceInput {
     readonly data: readonly {
       readonly id?: string;
       readonly amount?: number | null;
+      readonly discount_amounts?: readonly { readonly amount: number }[] | null;
       readonly subtotal?: number | null;
       readonly quantity?: number | null;
       readonly metadata?: Record<string, string> | null;
@@ -135,6 +136,12 @@ interface InvoiceInput {
         } | null;
       } | null;
       readonly proration?: boolean;
+      readonly taxes?:
+        | readonly {
+            readonly amount: number;
+            readonly tax_behavior: "exclusive" | "inclusive";
+          }[]
+        | null;
       readonly period: { readonly start?: number; readonly end: number };
       readonly parent: {
         readonly type: "subscription_item_details" | "invoice_item_details";

--- a/turbo/packages/api-contracts/src/contracts/org-members.ts
+++ b/turbo/packages/api-contracts/src/contracts/org-members.ts
@@ -101,7 +101,7 @@ export const previewOrgInvitationPurchaseRequestSchema =
 export const orgInvitationPurchasePreviewResponseSchema = z.object({
   purchaseId: z.uuid(),
   usagePackUsd: usagePackUsdSchema,
-  immediateAmountCents: z.number().int().positive(),
+  immediateAmountCents: z.number().int().nonnegative(),
   currency: z.string().length(3),
   purchasedCredits: z.number().int().nonnegative(),
   bonusCredits: z.number().int().nonnegative(),


### PR DESCRIPTION
## Summary

- allow fully discounted member invitation invoices to complete without a PaymentIntent while still creating the invitation, allocation, and period-based credits
- record the actual refundable amount after discounts and tax, and skip Stripe refunds for zero-paid grants, including legacy grants without a local refund-source row
- support zero-valued usage-pack renewal and allocation-change invoice lines so discounted renewals and upgrades can fulfill normally
- calculate organization-deletion refunds from the discounted net amount so free subscriptions are cancelled without inventing a refund
- accept zero-dollar invitation previews in the API contract

## Root cause

A 100% discount makes Stripe return a zero-dollar proration. The invitation flow treated that as `no_amount_due`, while downstream fulfillment assumed every successful purchase had a positive payment, a PaymentIntent, and refundable funds. The same assumptions existed in usage-pack renewal, allocation-change refund bookkeeping, legacy member-removal refunds, and organization deletion.

## Similar paths audited

The audit covered invitation purchases, recurring usage-pack invoices, allocation upgrades, acceptance, member removal and refunds, organization deletion, plan purchases, concurrency purchases, and direct credit purchases. The remaining `<= 0` guards protect quantities, timestamps, catalog invariants, or actual Stripe refund operations that genuinely require a positive value.

## Testing

- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` (203 files, 3233 tests)
- fully discounted invitation, renewal, upgrade, acceptance, member-removal, and organization-deletion integration coverage
- `pnpm -F api exec vitest run src/signals/routes/__tests__/billing-checkout.test.ts src/signals/routes/__tests__/org-delete-billing.test.ts --maxWorkers=4 --silent=passed-only` (2 files, 211 tests)
- `pnpm -F @okouai/api-contracts test` (32 files, 590 tests)
- API and API-contract lint/type checks
- platform contract-consumer type check
- `pnpm knip`
