### PR TITLE
fix(guest-agent): classify mid-response failures

### DIFF
--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -294,6 +294,11 @@ fn classify_cli_failure_reason(
         return Some(FailureReason::ProviderServerError);
     }
     if matches!(framework, AgentFramework::ClaudeCode)
+        && is_claude_result_response_connection_lost(source, &normalized)
+    {
+        return Some(FailureReason::ResponseConnectionLost);
+    }
+    if matches!(framework, AgentFramework::ClaudeCode)
         && is_claude_output_token_limit_error(&normalized)
     {
         return Some(FailureReason::OutputTokenLimit);
@@ -418,9 +423,20 @@ fn is_claude_result_stalled_mid_stream(trimmed: &str) -> bool {
 
 fn is_claude_provider_server_error(source: FailureDetailSource, normalized: &str) -> bool {
     source == FailureDetailSource::ClaudeResult
-        && has_claude_api_status(normalized, "500")
-        && normalized.contains("internal server error")
-        && normalized.contains("server-side issue")
+        && ((has_claude_api_status(normalized, "500")
+            && normalized.contains("internal server error")
+            && normalized.contains("server-side issue"))
+            || normalized.trim()
+                == "api error: server error mid-response. the response above may be incomplete.")
+}
+
+fn is_claude_result_response_connection_lost(
+    source: FailureDetailSource,
+    normalized: &str,
+) -> bool {
+    source == FailureDetailSource::ClaudeResult
+        && normalized.trim()
+            == "api error: connection lost mid-response. the response above may be incomplete."
 }
 
 fn is_claude_output_token_limit_error(normalized: &str) -> bool {

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -45,6 +45,10 @@ fn classify_cli_failure_reason(
 }
 
 const CLAUDE_PROVIDER_SERVER_ERROR_MESSAGE: &str = "API Error: 500 Internal server error. This is a server-side issue, usually temporary - try again in a moment. If it persists, check https://status.claude.com.";
+const CLAUDE_MID_RESPONSE_SERVER_ERROR_MESSAGE: &str =
+    "API Error: Server error mid-response. The response above may be incomplete.";
+const CLAUDE_MID_RESPONSE_CONNECTION_LOST_MESSAGE: &str =
+    "API Error: Connection lost mid-response. The response above may be incomplete.";
 
 #[test]
 fn cli_failure_message_logs_stderr_to_system_log() {
@@ -838,6 +842,89 @@ fn cli_failure_reason_classifies_claude_result_provider_server_error_diagnostic(
         diagnostic.failure_detail_source,
         Some(FailureDetailSource::ClaudeResult)
     );
+}
+
+#[test]
+fn cli_failure_reason_classifies_claude_result_mid_response_failures() {
+    for (message, expected_reason) in [
+        (
+            CLAUDE_MID_RESPONSE_SERVER_ERROR_MESSAGE,
+            FailureReason::ProviderServerError,
+        ),
+        (
+            CLAUDE_MID_RESPONSE_CONNECTION_LOST_MESSAGE,
+            FailureReason::ResponseConnectionLost,
+        ),
+    ] {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            FailureDetailSource::ClaudeResult,
+            message,
+        );
+
+        assert_eq!(reason, Some(expected_reason), "message: {message}");
+    }
+}
+
+#[test]
+fn cli_failure_reason_classifies_claude_result_mid_response_diagnostics() {
+    for (message, expected_reason) in [
+        (
+            CLAUDE_MID_RESPONSE_SERVER_ERROR_MESSAGE,
+            FailureReason::ProviderServerError,
+        ),
+        (
+            CLAUDE_MID_RESPONSE_CONNECTION_LOST_MESSAGE,
+            FailureReason::ResponseConnectionLost,
+        ),
+    ] {
+        let msg = cli_failure_message(
+            1,
+            &["background stderr noise".to_string()],
+            Some(&cli_diagnostic(message, FailureDetailSource::ClaudeResult)),
+        );
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_detail_source(msg.source);
+        let diagnostic = with_cli_failure_reason(diagnostic, &msg);
+
+        assert_eq!(msg.source, FailureDetailSource::ClaudeResult);
+        assert_eq!(diagnostic.failure_reason, Some(expected_reason));
+        assert_eq!(
+            diagnostic.failure_detail_source,
+            Some(FailureDetailSource::ClaudeResult)
+        );
+    }
+}
+
+#[test]
+fn cli_failure_reason_rejects_untrusted_mid_response_failure_contexts() {
+    for message in [
+        CLAUDE_MID_RESPONSE_SERVER_ERROR_MESSAGE,
+        CLAUDE_MID_RESPONSE_CONNECTION_LOST_MESSAGE,
+    ] {
+        for (framework, source) in [
+            (AgentFramework::ClaudeCode, FailureDetailSource::Stderr),
+            (AgentFramework::Codex, FailureDetailSource::ClaudeResult),
+        ] {
+            let reason = super::classify_cli_failure_reason(framework, source, message);
+
+            assert_eq!(reason, None, "message: {message}");
+        }
+
+        let explanatory_message = format!("Observed {message} in an earlier run");
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            FailureDetailSource::ClaudeResult,
+            &explanatory_message,
+        );
+
+        assert_eq!(reason, None, "message: {explanatory_message}");
+    }
 }
 
 #[test]

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -642,6 +642,8 @@ pub enum FailureReason {
     ProviderStreamTimeout,
     /// The provider returned a server error.
     ProviderServerError,
+    /// The response connection was lost.
+    ResponseConnectionLost,
     /// The provider refused the request under a safety policy.
     SafetyPolicyRefusal,
     /// The CLI requires reconnecting or re-authentication.
@@ -665,6 +667,7 @@ impl FailureReason {
             Self::ProviderOverloaded => "provider_overloaded",
             Self::ProviderStreamTimeout => "provider_stream_timeout",
             Self::ProviderServerError => "provider_server_error",
+            Self::ResponseConnectionLost => "response_connection_lost",
             Self::SafetyPolicyRefusal => "safety_policy_refusal",
             Self::ReconnectRequired => "reconnect_required",
             Self::UsageLimit => "usage_limit",
@@ -1374,6 +1377,28 @@ mod tests {
 
         let json = serde_json::to_value(&diagnostic).unwrap();
         assert_eq!(json["failureReason"], "provider_server_error");
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_diagnostic_serializes_response_connection_lost_reason() {
+        assert_eq!(
+            FailureReason::ResponseConnectionLost.as_str(),
+            "response_connection_lost"
+        );
+
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_reason(FailureReason::ResponseConnectionLost);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["failureReason"], "response_connection_lost");
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);

--- a/crates/runner/src/cmd/start/job_terminal_log.rs
+++ b/crates/runner/src/cmd/start/job_terminal_log.rs
@@ -639,6 +639,55 @@ mod tests {
     }
 
     #[test]
+    fn claude_result_mid_response_failures_log_structured_outcomes() {
+        for (reason, error, expected_level) in [
+            (
+                FailureReason::ProviderServerError,
+                "API Error: Server error mid-response. The response above may be incomplete.",
+                Level::INFO,
+            ),
+            (
+                FailureReason::ResponseConnectionLost,
+                "API Error: Connection lost mid-response. The response above may be incomplete.",
+                Level::ERROR,
+            ),
+        ] {
+            let diagnostic = FailureDiagnostic::new(
+                FailureClass::CliNonzero,
+                AgentFramework::ClaudeCode,
+                PromptMetadata::from_prompt("plain prompt"),
+            )
+            .with_cli_exit_code(1)
+            .with_cli_observed_exit(CliObservedExitDiagnostic::from_exit_code(1))
+            .with_claude_num_turns(Some(48))
+            .with_failure_detail_source(FailureDetailSource::ClaudeResult)
+            .with_session_history_status(SessionHistoryStatus::Present)
+            .with_failure_reason(reason);
+            let failure = executor::ExecutionFailure::new(1, error, Some(diagnostic));
+
+            let event = capture_job_failure_log(&failure);
+
+            assert_eq!(event.level, expected_level);
+            assert_eq!(
+                event.fields.get("message").map(String::as_str),
+                Some("job execution failed")
+            );
+            assert_field_eq(&event, "error", error);
+            assert_field_eq(&event, "failure_reason", reason.as_str());
+            assert_field_eq(&event, "failure_class", "cli_nonzero");
+            assert_field_eq(&event, "failure_framework", "claude_code");
+            assert_field_eq(&event, "failure_detail_source", "claude_result");
+            assert_field_eq(&event, "failure_claude_num_turns", "48");
+            assert_field_eq(&event, "cli_observed_exit_kind", "exit");
+            assert_field_eq(&event, "cli_observed_exit_code", "1");
+            assert!(!event.fields.contains_key("cli_termination_initiator"));
+            assert!(!event.fields.contains_key("cli_termination_reason"));
+            assert!(!event.fields.contains_key("cli_observed_signal_number"));
+            assert!(!event.fields.contains_key("cli_observed_signal_name"));
+        }
+    }
+
+    #[test]
     fn claude_zero_turn_no_history_logs_job_execution_failed_at_info() {
         let diagnostic = FailureDiagnostic::new(
             FailureClass::ClaudeZeroTurnNoHistory,


### PR DESCRIPTION
## Summary

- classify the exact Claude `Server error mid-response` terminal result as the existing `provider_server_error`
- add the neutral `response_connection_lost` reason for the exact `Connection lost mid-response` result
- keep classification scoped to ClaudeResult diagnostics and preserve turn count, regular exit attribution, and independent local termination fields

## Behavior

- server errors inherit the existing info-level `ProviderServerError` policy
- connection loss remains error-level because the available evidence does not establish its network owner
- CLI exit code 1 still fails the run
- no retry, resume, response recovery, broad future-message matching, or runner severity-policy change is added

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts failure_diagnostic_serializes_response_connection_lost_reason`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent cli_failure_reason_classifies_claude_result_mid_response`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent cli_failure_reason_rejects_untrusted_mid_response_failure_contexts`
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner claude_result_mid_response_failures_log_structured_outcomes`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-targets --all-features`
- pre-commit Rust formatting, workspace rustdoc, workspace Clippy, file-size check, and commitlint hooks

Closes #28297
