### PR TITLE
docs(python): document provider timing store locking and retention contract

### DIFF
--- a/crates/runner/mitm-addon/src/provider_timing_store.py
+++ b/crates/runner/mitm-addon/src/provider_timing_store.py
@@ -2,8 +2,9 @@
 
 Each provider timing module owns one store keyed by ``run_id``. Provider observers must coordinate
 their state transitions through ``locked()``; the map is LRU-bounded independently for Codex and
-Claude. The store retains only fixed timing operations, their observation timestamps, and minimal
-platform reporting context, never provider content.
+Claude. The retained delivery data is limited to fixed timing operations, their observation
+timestamps, and minimal platform reporting context; provider-specific state is timing metadata and
+never provider content.
 
 Pending operations are not admitted until a complete reporting context is available, and no lease
 is acquired for incomplete context. Once a buffered-report lease is acquired, saturated webhook
@@ -86,8 +87,9 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
     def get_locked(self, run_id: str) -> StateT | None:
         """Return a run's state without changing its LRU recency.
 
-        The caller must hold ``locked()``. Unlike ``state_for_run_locked()`` and ``touch_locked()``,
-        this lookup does not move a tracked run to the newest position and does not create state.
+        The caller must hold ``locked()``. It returns ``None`` when the run is not tracked. Unlike
+        ``state_for_run_locked()`` and ``touch_locked()``, this lookup does not move a tracked run
+        to the newest position and does not create state.
         """
         return self._run_states.get(run_id)
 
@@ -171,9 +173,9 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
     def retry_all_pending(self) -> None:
         """Retry retained reports in current LRU order until admission is saturated.
 
-        This entry point acquires the store lock internally. Each successful admission clears its
-        retained state; the first rejected admission leaves that run and all later runs for a future
-        retry. This sweep does not touch LRU order.
+        This entry point acquires the store lock internally. Each successful admission clears that
+        run's retained operations, context, and buffered lease; the first rejected admission leaves
+        that run and all later runs for a future retry. This sweep does not touch LRU order.
         """
         with self._lock:
             for run_id, state in self._run_states.items():

--- a/crates/runner/mitm-addon/src/provider_timing_store.py
+++ b/crates/runner/mitm-addon/src/provider_timing_store.py
@@ -1,4 +1,21 @@
-"""Shared run-scoped delivery state for provider-output timing."""
+"""Shared run-scoped delivery state for provider-output timing.
+
+Each provider timing module owns one store keyed by ``run_id``. Provider observers must coordinate
+their state transitions through ``locked()``; the map is LRU-bounded independently for Codex and
+Claude. The store retains only fixed timing operations, their observation timestamps, and minimal
+platform reporting context, never provider content.
+
+Pending operations are not admitted until a complete reporting context is available, and no lease
+is acquired for incomplete context. Once a buffered-report lease is acquired, saturated webhook
+admission keeps the operations, context, and lease together for retry. Successful webhook admission
+transfers delivery ownership to ``usage.webhook``. The store then clears its pending state and
+releases the buffered lease.
+Eviction, explicit discard, and reset release any lease that remains locally retained.
+
+See ``codex_output_timing.py`` and ``claude_output_timing.py`` for provider usage, and
+``tests/test_provider_output_timing.py``, ``tests/test_codex_output_timing.py``, and
+``tests/test_claude_output_timing.py`` for lifecycle coverage.
+"""
 
 from __future__ import annotations
 
@@ -16,7 +33,12 @@ from usage.reporting_context import UsageReportingContext, usage_reporting_conte
 
 @dataclass
 class ProviderTimingState:
-    """Delivery fields shared by one provider's run-specific timing state."""
+    """Delivery fields shared by one provider's run-specific timing state.
+
+    ``pending_operations`` contains fixed action names and their original observation timestamps.
+    ``pending_context`` and ``buffered_report`` remain paired with those operations while webhook
+    admission can still be retried. Provider-specific milestone flags are stored by subclasses.
+    """
 
     pending_operations: dict[str, str] = field(default_factory=dict)
     pending_context: UsageReportingContext | None = None
@@ -24,7 +46,18 @@ class ProviderTimingState:
 
 
 class ProviderTimingStore[StateT: ProviderTimingState]:
-    """Own one provider's bounded run state and retained report lifecycle."""
+    """Own one provider's bounded run state and retained report lifecycle.
+
+    ``locked()`` is the synchronization boundary for provider transitions. Callers must hold it
+    before invoking any ``*_locked`` method, including when they mutate the returned state. The
+    ``retry_pending()``, ``retry_all_pending()``, and ``reset()`` entry points acquire this same
+    lock internally and are intended to be called outside an existing ``locked()`` block.
+
+    State creation and access maintain the run map's LRU order. Retained operations stay local until
+    a complete reporting context and bounded webhook admission are available; queue saturation
+    leaves the state and its buffered lease retained, while successful admission hands delivery to
+    ``usage.webhook``.
+    """
 
     def __init__(
         self,
@@ -41,14 +74,31 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
 
     @contextmanager
     def locked(self) -> Iterator[None]:
-        """Serialize provider-specific transitions with store lifecycle work."""
+        """Serialize provider transitions with store lifecycle work.
+
+        Hold this context before calling or mutating through any ``*_locked`` method. The retry and
+        reset entry points acquire the same non-reentrant lock internally instead of requiring this
+        context from their callers.
+        """
         with self._lock:
             yield
 
     def get_locked(self, run_id: str) -> StateT | None:
+        """Return a run's state without changing its LRU recency.
+
+        The caller must hold ``locked()``. Unlike ``state_for_run_locked()`` and ``touch_locked()``,
+        this lookup does not move a tracked run to the newest position and does not create state.
+        """
         return self._run_states.get(run_id)
 
     def state_for_run_locked(self, run_id: str) -> StateT:
+        """Return a run's state, creating it and maintaining LRU retention.
+
+        The caller must hold ``locked()``. A new state is inserted at the newest position. If that
+        exceeds ``max_tracked_runs``, the oldest state is evicted, its buffered-report lease is
+        released, and its remaining pending operations and context are discarded. An existing state
+        is touched before it is returned.
+        """
         state = self._run_states.get(run_id)
         if state is None:
             state = self._state_factory()
@@ -62,9 +112,19 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
         return state
 
     def touch_locked(self, run_id: str) -> None:
+        """Mark an existing run as most recently used.
+
+        The caller must hold ``locked()``. This changes only LRU order; it does not create state or
+        alter pending operations, reporting context, or lease ownership.
+        """
         self._run_states.move_to_end(run_id)
 
     def discard_locked(self, run_id: str) -> None:
+        """Discard a tracked run and release any retained buffered-report lease.
+
+        The caller must hold ``locked()``. Pending operations and reporting context for the run are
+        discarded with its state; no delivery retry remains after this terminal removal.
+        """
         state = self._run_states.pop(run_id)
         self._release_buffered_report_locked(state)
 
@@ -74,6 +134,15 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
         run_id: str,
         state: StateT,
     ) -> None:
+        """Attempt webhook admission for a run's pending timing operations.
+
+        The caller must hold ``locked()``. Empty pending operations are a no-op. An incomplete flow
+        context leaves operations untouched and acquires no buffered-report lease. With complete
+        context, the store retains that context and acquires one lease if needed. Saturated webhook
+        admission leaves operations, context, and lease paired for retry. Successful admission
+        transfers delivery ownership to ``usage.webhook``, clears the pending state, and releases
+        the buffered lease.
+        """
         if not state.pending_operations:
             return
 
@@ -86,6 +155,12 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
         self._admit_retained_locked(run_id, state)
 
     def retry_pending(self, flow: http.HTTPFlow, run_id: str) -> None:
+        """Retry one tracked run's pending admission using the flow's reporting context.
+
+        This entry point acquires the store lock internally. An unknown run is ignored; a tracked
+        run is touched before its pending operations are retried through
+        ``admit_pending_locked()``.
+        """
         with self._lock:
             state = self._run_states.get(run_id)
             if state is None:
@@ -94,19 +169,36 @@ class ProviderTimingStore[StateT: ProviderTimingState]:
             self.admit_pending_locked(flow, run_id, state)
 
     def retry_all_pending(self) -> None:
-        """Retry retained reports until admission capacity is saturated."""
+        """Retry retained reports in current LRU order until admission is saturated.
+
+        This entry point acquires the store lock internally. Each successful admission clears its
+        retained state; the first rejected admission leaves that run and all later runs for a future
+        retry. This sweep does not touch LRU order.
+        """
         with self._lock:
             for run_id, state in self._run_states.items():
                 if not self._admit_retained_locked(run_id, state):
                     return
 
     def reset(self) -> None:
+        """Release all retained leases and remove every tracked run.
+
+        This entry point acquires the store lock internally. Pending operations and reporting
+        context are discarded together with the run map, so no retained report remains for a later
+        retry.
+        """
         with self._lock:
             for state in self._run_states.values():
                 self._release_buffered_report_locked(state)
             self._run_states.clear()
 
     def _admit_retained_locked(self, run_id: str, state: StateT) -> bool:
+        """Admit retained state while the caller holds ``locked()``.
+
+        Return ``False`` when bounded webhook admission is saturated and leave the retained state
+        unchanged. On success, clear the pending operations and context and release the buffered
+        lease after delivery ownership transfers to ``usage.webhook``.
+        """
         context = state.pending_context
         if not state.pending_operations or context is None:
             return True


### PR DESCRIPTION
## Summary

- Document the shared `ProviderTimingStore` locking, LRU, context, and buffered-report lifecycle.
- Clarify method-level lock ownership, state creation/touch/eviction/discard behavior, retry
  boundaries, webhook admission saturation, and lease release.
- Link maintainers to the Codex, Claude, and cross-provider timing implementations and tests.

## Scope

The tracked change is limited to docstrings in
`crates/runner/mitm-addon/src/provider_timing_store.py`. The wording preserves the existing
content-free retention model and distinguishes bounded webhook admission from downstream delivery.

No executable behavior, tests, API or schema, dependency, configuration, persistence, runner
protocol, deployment, migration, rollout, or feature-switch changes are included.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 6423 passed, 59 warnings
- `git diff --check`

Closes #28379
