### PR TITLE
perf(runner): bound local queue job reads

### DIFF
--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -410,6 +410,13 @@ impl SubmitPlan {
 
         let request_json = serde_json::to_vec(&request)
             .map_err(|e| RunnerError::Internal(format!("serialize request: {e}")))?;
+        if request_json.len() > local_queue::LOCAL_JOB_MAX_BYTES {
+            return Err(RunnerError::Config(format!(
+                "serialized local job request exceeds {} bytes (got {} bytes)",
+                local_queue::LOCAL_JOB_MAX_BYTES,
+                request_json.len()
+            )));
+        }
         let queue = SubmitQueueEntry::for_job(&group_dir, &profile, job_id)?;
 
         Ok(Self {

--- a/crates/runner/src/cmd/local/submit/tests/validation.rs
+++ b/crates/runner/src/cmd/local/submit/tests/validation.rs
@@ -1,10 +1,17 @@
 use std::process::ExitCode;
 
-use super::super::{MAX_LOCAL_SUBMIT_TIMEOUT_SECS, SubmitArgs, run_submit_with_home};
+use super::super::{MAX_LOCAL_SUBMIT_TIMEOUT_SECS, SubmitArgs, SubmitPlan, run_submit_with_home};
 use super::support::{run_submit_and_write_success, submit_args_for_test};
 use crate::error::RunnerError;
 use crate::local_queue;
 use crate::paths::HomePaths;
+
+fn prompt_len_for_serialized_job_size(root: &std::path::Path, target_bytes: usize) -> usize {
+    let mut args = submit_args_for_test();
+    args.prompt.clear();
+    let plan = SubmitPlan::from_args(args, HomePaths::with_root(root.to_path_buf())).unwrap();
+    target_bytes.checked_sub(plan.request_json.len()).unwrap()
+}
 
 #[tokio::test]
 async fn rejects_invalid_profile_name() {
@@ -163,6 +170,55 @@ async fn oversized_timeouts_are_rejected_before_publishing_job() {
             "invalid timeout must not create a local queue group directory"
         );
     }
+}
+
+#[test]
+fn serialized_job_at_size_limit_is_accepted_and_published() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let prompt_len = prompt_len_for_serialized_job_size(root, local_queue::LOCAL_JOB_MAX_BYTES);
+    let mut args = submit_args_for_test();
+    args.prompt = "x".repeat(prompt_len);
+
+    let plan = SubmitPlan::from_args(args, HomePaths::with_root(root.to_path_buf())).unwrap();
+
+    assert_eq!(plan.request_json.len(), local_queue::LOCAL_JOB_MAX_BYTES);
+    plan.write_job_file().unwrap();
+    assert_eq!(
+        std::fs::metadata(&plan.queue.job).unwrap().len(),
+        local_queue::LOCAL_JOB_MAX_BYTES as u64
+    );
+}
+
+#[test]
+fn serialized_job_over_size_limit_is_rejected_before_publication() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let prompt_len = prompt_len_for_serialized_job_size(root, local_queue::LOCAL_JOB_MAX_BYTES) + 1;
+    let mut args = submit_args_for_test();
+    args.prompt = "x".repeat(prompt_len);
+
+    let error = match SubmitPlan::from_args(args, HomePaths::with_root(root.to_path_buf())) {
+        Ok(_) => panic!("expected oversized serialized job to be rejected"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(error, RunnerError::Config(_)), "got: {error:?}");
+    assert!(
+        error
+            .to_string()
+            .contains(&local_queue::LOCAL_JOB_MAX_BYTES.to_string()),
+        "got: {error}"
+    );
+    let job_dir = local_queue::profile_jobs_dir(
+        &root.join("groups/test/group"),
+        crate::profile::DEFAULT_PROFILE,
+    )
+    .unwrap();
+    assert!(
+        std::fs::read_dir(job_dir).unwrap().next().is_none(),
+        "oversized request must not publish a local job"
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/cmd/local/submit/tests/validation.rs
+++ b/crates/runner/src/cmd/local/submit/tests/validation.rs
@@ -172,36 +172,37 @@ async fn oversized_timeouts_are_rejected_before_publishing_job() {
     }
 }
 
-#[test]
-fn serialized_job_at_size_limit_is_accepted_and_published() {
+#[tokio::test]
+async fn serialized_job_at_size_limit_is_accepted() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
     let prompt_len = prompt_len_for_serialized_job_size(root, local_queue::LOCAL_JOB_MAX_BYTES);
     let mut args = submit_args_for_test();
     args.prompt = "x".repeat(prompt_len);
 
-    let plan = SubmitPlan::from_args(args, HomePaths::with_root(root.to_path_buf())).unwrap();
+    let (exit_code, request) =
+        run_submit_and_write_success(args, HomePaths::with_root(root.to_path_buf()))
+            .await
+            .unwrap();
 
-    assert_eq!(plan.request_json.len(), local_queue::LOCAL_JOB_MAX_BYTES);
-    plan.write_job_file().unwrap();
+    assert_eq!(exit_code, ExitCode::SUCCESS);
     assert_eq!(
-        std::fs::metadata(&plan.queue.job).unwrap().len(),
-        local_queue::LOCAL_JOB_MAX_BYTES as u64
+        serde_json::to_vec(&request).unwrap().len(),
+        local_queue::LOCAL_JOB_MAX_BYTES
     );
 }
 
-#[test]
-fn serialized_job_over_size_limit_is_rejected_before_publication() {
+#[tokio::test]
+async fn serialized_job_over_size_limit_is_rejected_before_publication() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
     let prompt_len = prompt_len_for_serialized_job_size(root, local_queue::LOCAL_JOB_MAX_BYTES) + 1;
     let mut args = submit_args_for_test();
     args.prompt = "x".repeat(prompt_len);
 
-    let error = match SubmitPlan::from_args(args, HomePaths::with_root(root.to_path_buf())) {
-        Ok(_) => panic!("expected oversized serialized job to be rejected"),
-        Err(error) => error,
-    };
+    let error = run_submit_with_home(args, HomePaths::with_root(root.to_path_buf()))
+        .await
+        .unwrap_err();
 
     assert!(matches!(error, RunnerError::Config(_)), "got: {error:?}");
     assert!(

--- a/crates/runner/src/local_queue/fs.rs
+++ b/crates/runner/src/local_queue/fs.rs
@@ -128,6 +128,60 @@ pub(crate) fn read_private_file(path: &Path, context: &str) -> io::Result<Vec<u8
     Ok(bytes)
 }
 
+pub(crate) fn read_private_file_with_max(
+    path: &Path,
+    context: &str,
+    max_bytes: usize,
+) -> io::Result<Vec<u8>> {
+    let file = open_private_read_file(path, context)?;
+    let metadata = file
+        .metadata()
+        .map_err(|e| io::Error::new(e.kind(), format!("stat {context} {}: {e}", path.display())))?;
+    if metadata.len() > max_bytes as u64 {
+        return Err(private_file_too_large(
+            path,
+            context,
+            metadata.len(),
+            max_bytes,
+        ));
+    }
+
+    let read_limit = max_bytes.checked_add(1).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("read limit for {context} {} is too large", path.display()),
+        )
+    })?;
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(read_limit as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|e| io::Error::new(e.kind(), format!("read {context} {}: {e}", path.display())))?;
+    if bytes.len() > max_bytes {
+        return Err(private_file_too_large(
+            path,
+            context,
+            bytes.len() as u64,
+            max_bytes,
+        ));
+    }
+    Ok(bytes)
+}
+
+fn private_file_too_large(
+    path: &Path,
+    context: &str,
+    observed_bytes: u64,
+    max_bytes: usize,
+) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "{context} {} exceeds {max_bytes} bytes (observed at least {observed_bytes} bytes)",
+            path.display()
+        ),
+    )
+}
+
 pub(crate) fn private_file_has_content(path: &Path, context: &str) -> io::Result<bool> {
     let file = match open_private_read_file(path, context) {
         Ok(file) => file,

--- a/crates/runner/src/local_queue/mod.rs
+++ b/crates/runner/src/local_queue/mod.rs
@@ -9,8 +9,9 @@ pub(crate) use fs::{
     create_private_marker, ensure_cancels_dir, ensure_claims_dir, ensure_group_dir,
     ensure_profile_jobs_dir, ensure_results_dir, ensure_run_inputs_dir, marker_file_exists,
     marker_path_occupied, open_private_new_file, private_file_has_content, read_private_file,
-    validate_cancels_dir, validate_claims_dir, validate_group_dir, validate_inputs_dir,
-    validate_results_dir, validate_run_inputs_dir, write_private_file, write_private_marker,
+    read_private_file_with_max, validate_cancels_dir, validate_claims_dir, validate_group_dir,
+    validate_inputs_dir, validate_results_dir, validate_run_inputs_dir, write_private_file,
+    write_private_marker,
 };
 pub(crate) use paths::{
     active_input_path, cancel_path, cancels_dir, claim_path, claims_dir, inputs_dir, job_path,
@@ -18,3 +19,9 @@ pub(crate) use paths::{
 };
 pub(crate) use state::{CancelTargetState, LocalClaimResult, LocalDiscoveredJob, LocalQueue};
 pub(crate) use types::{ActiveInputEntry, JobRequest, JobResponse};
+
+/// Maximum byte length of one complete serialized local [`JobRequest`].
+///
+/// Submit, discovery, and claim share this limit so independently deployed
+/// producers and consumers enforce the same local queue resource boundary.
+pub(crate) const LOCAL_JOB_MAX_BYTES: usize = 16 * 1024 * 1024;

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -188,12 +188,13 @@ impl LocalQueue {
                 if self.discovery_candidate_ineligible(&candidate, snapshot.as_ref()) {
                     continue;
                 }
-                let metadata =
-                    super::read_private_file(&candidate.path, "local job discovery metadata")
-                        .ok()
-                        .and_then(|bytes| {
-                            serde_json::from_slice::<LocalDiscoveryMetadata>(&bytes).ok()
-                        });
+                let metadata = super::read_private_file_with_max(
+                    &candidate.path,
+                    "local job discovery metadata",
+                    super::LOCAL_JOB_MAX_BYTES,
+                )
+                .ok()
+                .and_then(|bytes| serde_json::from_slice::<LocalDiscoveryMetadata>(&bytes).ok());
                 let reuse_key = metadata.and_then(|metadata| metadata.reuse_key);
                 return Some(LocalDiscoveredJob {
                     run_id: candidate.run_id,
@@ -398,7 +399,11 @@ impl LocalQueue {
             return LocalClaimResult::NotClaimed;
         }
 
-        let buf = match super::read_private_file(job_file, "local job file") {
+        let buf = match super::read_private_file_with_max(
+            job_file,
+            "local job file",
+            super::LOCAL_JOB_MAX_BYTES,
+        ) {
             Ok(b) => b,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 warn!(run_id = %run_id, error = %e, "local: failed to read job file");

--- a/crates/runner/src/provider/local/tests/claim.rs
+++ b/crates/runner/src/provider/local/tests/claim.rs
@@ -189,6 +189,51 @@ async fn claim_handles_poison_job_json() {
 }
 
 #[tokio::test]
+async fn claim_terminally_fails_oversized_sparse_job() {
+    let dir = tempfile::tempdir().unwrap();
+    let provider = default_provider(dir.path(), CancellationToken::new(), empty_cancel_tokens());
+    let run_id = RunId::new_v4();
+    let profile = crate::profile::DEFAULT_PROFILE;
+    let job_path = local_queue::job_path(dir.path(), profile, run_id).unwrap();
+    local_queue::ensure_profile_jobs_dir(dir.path(), profile).unwrap();
+    local_queue::write_private_file(&job_path, b"", "oversized sparse test job").unwrap();
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&job_path)
+        .unwrap()
+        .set_len((local_queue::LOCAL_JOB_MAX_BYTES as u64) * 64)
+        .unwrap();
+
+    let candidate = provider.discover().await.unwrap();
+    assert_eq!(candidate.run_id(), run_id);
+    assert_eq!(candidate.reuse_key(), None);
+    assert!(provider.claim(candidate).await.is_none());
+
+    assert!(!job_path.exists(), "oversized job file must be removed");
+    assert!(
+        !local_queue::claim_path(dir.path(), run_id).exists(),
+        "claim marker must be released after terminal failure"
+    );
+    let result = read_result(dir.path(), run_id);
+    assert_ne!(result.exit_code, 0);
+    assert!(
+        result
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains(&format!(
+                "exceeds {} bytes",
+                local_queue::LOCAL_JOB_MAX_BYTES
+            ))),
+        "oversized job result must report the protocol limit, got: {:?}",
+        result.error
+    );
+    assert!(
+        provider.find_unclaimed_job().is_none(),
+        "terminal result must prevent oversized job rediscovery"
+    );
+}
+
+#[tokio::test]
 async fn claim_failure_removes_duplicate_job_files_across_profiles() {
     let dir = tempfile::tempdir().unwrap();
     let provider = provider_with_profiles(


### PR DESCRIPTION
## Summary

- define a shared 16 MiB limit for serialized local queue job requests and reject oversized submits before publication
- bound discovery and claim reads with opened-descriptor metadata checks plus a `max + 1` content read limit
- route oversized legacy or manual jobs through the existing atomic claim and durable terminal cleanup path
- cover exact-limit publication, one-byte-over rejection, and a 1 GiB sparse poison job

## Scope

This PR only changes `.job` request limits. Local result and active-input files retain their existing behavior because their size contracts and recovery semantics are independent.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner serialized_job_ -- --nocapture`
- `cargo test -p runner claim_terminally_fails_oversized_sparse_job -- --nocapture`
- `cargo test -p runner` (3205 passed, 20 ignored)
- pre-commit workspace Rust format, Clippy, Rustdoc, and file-size checks

Closes #28383
