### PR TITLE
fix(events): preserve timeout and connect observations

### DIFF
--- a/crates/guest-agent/src/cli/event_delivery.rs
+++ b/crates/guest-agent/src/cli/event_delivery.rs
@@ -430,7 +430,13 @@ impl HttpAttemptObserver for DeliveryAttemptObserver {
             )
         })?;
         active_batch.active_attempt = None;
-        if let HttpAttemptOutcome::Failure { kind, http_status } = attempt.outcome {
+        if let HttpAttemptOutcome::Failure {
+            kind,
+            http_status,
+            timeout_observed,
+            connect_observed,
+        } = attempt.outcome
+        {
             active_batch
                 .completed_attempts
                 .push(EventDeliveryCompletedAttemptDiagnostic {
@@ -439,6 +445,8 @@ impl HttpAttemptObserver for DeliveryAttemptObserver {
                     elapsed_ms: attempt.elapsed_ms,
                     failure_kind: event_attempt_failure_kind(kind),
                     http_status,
+                    timeout_observed,
+                    connect_observed,
                 });
         }
         Ok(())

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -58,6 +58,8 @@ pub(crate) enum HttpAttemptOutcome {
     Failure {
         kind: HttpAttemptFailureKind,
         http_status: Option<u16>,
+        timeout_observed: Option<bool>,
+        connect_observed: Option<bool>,
     },
 }
 
@@ -402,6 +404,8 @@ where
                     HttpAttemptOutcome::Failure {
                         kind: HttpAttemptFailureKind::HttpStatus,
                         http_status: Some(status.as_u16()),
+                        timeout_observed: None,
+                        connect_observed: None,
                     },
                 )?;
                 // 4xx errors are deterministic except for rate limits.
@@ -414,9 +418,11 @@ where
                 );
             }
             Err(error) => {
-                let failure_kind = if error.is_timeout() {
+                let timeout_observed = error.is_timeout();
+                let connect_observed = error.is_connect();
+                let failure_kind = if timeout_observed {
                     HttpAttemptFailureKind::Timeout
-                } else if error.is_connect() {
+                } else if connect_observed {
                     HttpAttemptFailureKind::Connect
                 } else {
                     HttpAttemptFailureKind::Transport
@@ -427,6 +433,8 @@ where
                     HttpAttemptOutcome::Failure {
                         kind: failure_kind,
                         http_status: None,
+                        timeout_observed: Some(timeout_observed),
+                        connect_observed: Some(connect_observed),
                     },
                 )?;
                 let error = format_reqwest_error(error);

--- a/crates/guest-agent/tests/event_delivery_drain_timeout.rs
+++ b/crates/guest-agent/tests/event_delivery_drain_timeout.rs
@@ -101,6 +101,8 @@ async fn event_delivery_aborts_after_the_global_drain_deadline()
     assert!(failed_batch.attempts.iter().all(|attempt| {
         attempt.failure_kind == EventDeliveryAttemptFailureKind::Timeout
             && attempt.http_status.is_none()
+            && attempt.timeout_observed == Some(true)
+            && attempt.connect_observed == Some(false)
     }));
     let drain = delivery
         .drain_timeout

--- a/crates/guest-agent/tests/event_delivery_nonretryable_failure.rs
+++ b/crates/guest-agent/tests/event_delivery_nonretryable_failure.rs
@@ -116,6 +116,8 @@ async fn nonretryable_client_rejection_records_one_attempt()
         EventDeliveryAttemptFailureKind::HttpStatus
     );
     assert_eq!(failed_batch.attempts[0].http_status, Some(400));
+    assert_eq!(failed_batch.attempts[0].timeout_observed, None);
+    assert_eq!(failed_batch.attempts[0].connect_observed, None);
     assert_eq!(
         failed_batch.outcome,
         EventDeliveryAcceptanceOutcome::ConfirmedRejection

--- a/crates/guest-agent/tests/event_delivery_transport_classification.rs
+++ b/crates/guest-agent/tests/event_delivery_transport_classification.rs
@@ -206,28 +206,18 @@ async fn run_connect_timeout_failure() -> Result<EventDeliveryDiagnostic, Box<dy
     .map_err(|_| io::Error::other("connect-timeout server accepted no request"))?;
 
     tokio::time::pause();
-    for attempt in 1..=3 {
-        tokio::time::advance(Duration::from_secs(11)).await;
-        for _ in 0..1_000 {
-            if attempt == 3 && execution.is_finished()
-                || accepted_count.load(Ordering::SeqCst) > attempt
-            {
-                break;
-            }
-            tokio::task::yield_now().await;
+    for _ in 0..35 {
+        if execution.is_finished() {
+            break;
         }
-        if attempt < 3 {
-            assert_eq!(
-                accepted_count.load(Ordering::SeqCst),
-                attempt + 1,
-                "connect timeout should advance to the next retry"
-            );
-        }
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
     }
     assert!(
         execution.is_finished(),
         "connect-timeout delivery should exhaust three attempts"
     );
+    assert_eq!(accepted_count.load(Ordering::SeqCst), 3);
     let joined = execution.await;
     tokio::time::resume();
     server.abort();

--- a/crates/guest-agent/tests/event_delivery_transport_classification.rs
+++ b/crates/guest-agent/tests/event_delivery_transport_classification.rs
@@ -9,18 +9,27 @@ use guest_contracts::diagnostics::{
 };
 use serde_json::json;
 use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 #[tokio::test]
 async fn response_less_failures_have_stable_classifications()
 -> Result<(), Box<dyn std::error::Error>> {
     let connect_delivery = run_connect_failure().await?;
-    assert_failed_attempts(&connect_delivery, EventDeliveryAttemptFailureKind::Connect)?;
+    assert_failed_attempts(
+        &connect_delivery,
+        EventDeliveryAttemptFailureKind::Connect,
+        false,
+        true,
+    )?;
 
     let (transport_delivery, on_wire_request_ids) = run_transport_failure().await?;
     let transport_attempts = assert_failed_attempts(
         &transport_delivery,
         EventDeliveryAttemptFailureKind::Transport,
+        false,
+        false,
     )?;
     assert_eq!(
         transport_attempts
@@ -29,6 +38,14 @@ async fn response_less_failures_have_stable_classifications()
             .collect::<Vec<_>>(),
         on_wire_request_ids
     );
+
+    let connect_timeout_delivery = run_connect_timeout_failure().await?;
+    assert_failed_attempts(
+        &connect_timeout_delivery,
+        EventDeliveryAttemptFailureKind::Timeout,
+        true,
+        true,
+    )?;
 
     Ok(())
 }
@@ -136,9 +153,96 @@ async fn run_transport_failure()
     Ok((delivery, request_ids))
 }
 
+async fn run_connect_timeout_failure() -> Result<EventDeliveryDiagnostic, Box<dyn std::error::Error>>
+{
+    let mock_cli = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let base_url = format!("https://{}", listener.local_addr()?);
+    let accepted_count = Arc::new(AtomicUsize::new(0));
+    let server_accepted_count = Arc::clone(&accepted_count);
+    let server = tokio::spawn(async move {
+        let mut connections = Vec::new();
+        while let Ok((connection, _)) = listener.accept().await {
+            server_accepted_count.fetch_add(1, Ordering::SeqCst);
+            connections.push(connection);
+        }
+    });
+    let prompt = format!(
+        "@ECHO@\n{}",
+        json!({ "type": "result", "marker": "connect-timeout" })
+    );
+
+    unsafe {
+        common::setup_env(&mock_cli, tmp.path(), &prompt, 3, 1)?;
+        std::env::set_var("VM0_API_BACKEND_URL", &base_url);
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+    }
+    let mut runtime = common::guest_runtime_from_process_env()?;
+    let run_id = runtime.config.run_id.clone();
+    runtime.http = guest_agent::http::HttpClient::with_api_config(
+        &base_url,
+        "test-token",
+        "",
+        run_id,
+        Duration::ZERO,
+    )?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let execution = tokio::spawn(async move {
+        common::execute_cli_for_runtime(
+            &runtime,
+            &SecretMasker::from_raw(""),
+            common::spawn_dummy_heartbeat(),
+        )
+        .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while accepted_count.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .map_err(|_| io::Error::other("connect-timeout server accepted no request"))?;
+
+    tokio::time::pause();
+    for attempt in 1..=3 {
+        tokio::time::advance(Duration::from_secs(11)).await;
+        for _ in 0..1_000 {
+            if attempt == 3 && execution.is_finished()
+                || accepted_count.load(Ordering::SeqCst) > attempt
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        if attempt < 3 {
+            assert_eq!(
+                accepted_count.load(Ordering::SeqCst),
+                attempt + 1,
+                "connect timeout should advance to the next retry"
+            );
+        }
+    }
+    assert!(
+        execution.is_finished(),
+        "connect-timeout delivery should exhaust three attempts"
+    );
+    let joined = execution.await;
+    tokio::time::resume();
+    server.abort();
+    let result = joined??;
+
+    result
+        .event_delivery
+        .ok_or_else(|| io::Error::other("connect timeout omitted delivery diagnostic").into())
+}
+
 fn assert_failed_attempts(
     delivery: &EventDeliveryDiagnostic,
     expected_kind: EventDeliveryAttemptFailureKind,
+    timeout_observed: bool,
+    connect_observed: bool,
 ) -> Result<
     &[guest_contracts::diagnostics::EventDeliveryCompletedAttemptDiagnostic],
     Box<dyn std::error::Error>,
@@ -148,11 +252,12 @@ fn assert_failed_attempts(
         .as_ref()
         .ok_or_else(|| io::Error::other("delivery diagnostic omitted first failed batch"))?;
     assert_eq!(failed_batch.attempts.len(), 3);
-    assert!(
-        failed_batch.attempts.iter().all(|attempt| {
-            attempt.failure_kind == expected_kind && attempt.http_status.is_none()
-        })
-    );
+    assert!(failed_batch.attempts.iter().all(|attempt| {
+        attempt.failure_kind == expected_kind
+            && attempt.http_status.is_none()
+            && attempt.timeout_observed == Some(timeout_observed)
+            && attempt.connect_observed == Some(connect_observed)
+    }));
     assert_eq!(
         failed_batch.outcome,
         EventDeliveryAcceptanceOutcome::OutcomeUnknown

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -231,6 +231,12 @@ pub struct EventDeliveryCompletedAttemptDiagnostic {
     /// HTTP response status, when a response was received.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http_status: Option<u16>,
+    /// Whether Reqwest identified the response-less failure as timeout-related.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_observed: Option<bool>,
+    /// Whether Reqwest identified the response-less failure as connection-related.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connect_observed: Option<bool>,
 }
 
 /// Delivery state captured when the global drain deadline expires.
@@ -1426,6 +1432,17 @@ mod tests {
             elapsed_ms: 30_000,
             failure_kind: EventDeliveryAttemptFailureKind::HttpStatus,
             http_status: Some(500),
+            timeout_observed: None,
+            connect_observed: None,
+        };
+        let combined_transport_attempt = EventDeliveryCompletedAttemptDiagnostic {
+            attempt: 1,
+            client_request_id: "33333333-3333-4333-8333-333333333333".to_string(),
+            elapsed_ms: 10_000,
+            failure_kind: EventDeliveryAttemptFailureKind::Timeout,
+            http_status: None,
+            timeout_observed: Some(true),
+            connect_observed: Some(true),
         };
         let active_attempt = EventDeliveryActiveAttemptDiagnostic {
             attempt: 2,
@@ -1455,7 +1472,7 @@ mod tests {
                     last_sequence: 39,
                     event_count: 24,
                     conservative_bytes: 8_192,
-                    completed_attempts: vec![first_attempt],
+                    completed_attempts: vec![combined_transport_attempt],
                     active_attempt: Some(active_attempt),
                     outcome: EventDeliveryAcceptanceOutcome::OutcomeUnknown,
                 }),
@@ -1479,6 +1496,14 @@ mod tests {
             "http_status"
         );
         assert_eq!(
+            json["eventDelivery"]["drainTimeout"]["activeBatch"]["completedAttempts"][0]["timeoutObserved"],
+            true
+        );
+        assert_eq!(
+            json["eventDelivery"]["drainTimeout"]["activeBatch"]["completedAttempts"][0]["connectObserved"],
+            true
+        );
+        assert_eq!(
             json["eventDelivery"]["drainTimeout"]["activeBatch"]["outcome"],
             "outcome_unknown"
         );
@@ -1493,6 +1518,21 @@ mod tests {
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json.clone()).unwrap();
         assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn completed_event_attempt_deserializes_without_transport_observations() {
+        let attempt: EventDeliveryCompletedAttemptDiagnostic =
+            serde_json::from_value(serde_json::json!({
+                "attempt": 3,
+                "clientRequestId": "11111111-1111-4111-8111-111111111111",
+                "elapsedMs": 12_000,
+                "failureKind": "timeout"
+            }))
+            .unwrap();
+
+        assert_eq!(attempt.timeout_observed, None);
+        assert_eq!(attempt.connect_observed, None);
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/job_terminal_log.rs
+++ b/crates/runner/src/cmd/start/job_terminal_log.rs
@@ -123,6 +123,10 @@ fn log_job_execution_failed(
                     event_delivery_fields.first_failure_final_attempt_number,
                 event_delivery_first_failure_final_attempt_kind =
                     event_delivery_fields.first_failure_final_attempt_kind,
+                event_delivery_first_failure_final_attempt_timeout_observed =
+                    event_delivery_fields.first_failure_final_attempt_timeout_observed,
+                event_delivery_first_failure_final_attempt_connect_observed =
+                    event_delivery_fields.first_failure_final_attempt_connect_observed,
                 event_delivery_first_failure_final_attempt_http_status =
                     event_delivery_fields.first_failure_final_attempt_http_status,
                 event_delivery_first_failure_final_attempt_request_id =
@@ -240,6 +244,8 @@ struct JobEventDeliveryLogFields<'a> {
     first_failure_attempt_count: Option<u64>,
     first_failure_final_attempt_number: Option<u32>,
     first_failure_final_attempt_kind: Option<&'static str>,
+    first_failure_final_attempt_timeout_observed: Option<bool>,
+    first_failure_final_attempt_connect_observed: Option<bool>,
     first_failure_final_attempt_http_status: Option<u16>,
     first_failure_final_attempt_request_id: Option<&'a str>,
     first_failure_final_attempt_elapsed_ms: Option<u64>,
@@ -323,6 +329,10 @@ impl<'a> From<Option<&'a EventDeliveryDiagnostic>> for JobEventDeliveryLogFields
                 .map(|attempt| attempt.attempt),
             first_failure_final_attempt_kind: first_failure_final_attempt
                 .map(|attempt| attempt.failure_kind.as_str()),
+            first_failure_final_attempt_timeout_observed: first_failure_final_attempt
+                .and_then(|attempt| attempt.timeout_observed),
+            first_failure_final_attempt_connect_observed: first_failure_final_attempt
+                .and_then(|attempt| attempt.connect_observed),
             first_failure_final_attempt_http_status: first_failure_final_attempt
                 .and_then(|attempt| attempt.http_status),
             first_failure_final_attempt_request_id: first_failure_final_attempt
@@ -794,6 +804,8 @@ mod tests {
             elapsed_ms: 30_000,
             failure_kind: EventDeliveryAttemptFailureKind::HttpStatus,
             http_status: Some(500),
+            timeout_observed: None,
+            connect_observed: None,
         };
         let diagnostic = FailureDiagnostic::new(
             FailureClass::EventUploadFailed,
@@ -859,6 +871,16 @@ mod tests {
             "event_delivery_first_failure_final_attempt_kind",
             "http_status",
         );
+        assert!(
+            !event
+                .fields
+                .contains_key("event_delivery_first_failure_final_attempt_timeout_observed")
+        );
+        assert!(
+            !event
+                .fields
+                .contains_key("event_delivery_first_failure_final_attempt_connect_observed")
+        );
         assert_field_eq(
             &event,
             "event_delivery_first_failure_final_attempt_http_status",
@@ -890,6 +912,53 @@ mod tests {
         );
         assert!(!event.fields.contains_key("event_delivery_attempts"));
         assert!(!event.fields.contains_key("event_delivery_body"));
+    }
+
+    #[test]
+    fn diagnostic_failure_logs_event_transport_observations() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::EventUploadFailed,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("continue"),
+        )
+        .with_cli_exit_code(0)
+        .with_event_delivery(EventDeliveryDiagnostic {
+            total_events: 1,
+            total_batches: 1,
+            failed_batches: 1,
+            last_acknowledged_sequence: None,
+            first_failed_batch: Some(EventDeliveryFailedBatchDiagnostic {
+                first_sequence: 0,
+                last_sequence: 0,
+                event_count: 1,
+                conservative_bytes: 128,
+                outcome: EventDeliveryAcceptanceOutcome::OutcomeUnknown,
+                attempts: vec![EventDeliveryCompletedAttemptDiagnostic {
+                    attempt: 3,
+                    client_request_id: "11111111-1111-4111-8111-111111111111".to_string(),
+                    elapsed_ms: 10_000,
+                    failure_kind: EventDeliveryAttemptFailureKind::Timeout,
+                    http_status: None,
+                    timeout_observed: Some(true),
+                    connect_observed: Some(true),
+                }],
+            }),
+            drain_timeout: None,
+        });
+        let failure = executor::ExecutionFailure::new(1, "event delivery failed", Some(diagnostic));
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_field_eq(
+            &event,
+            "event_delivery_first_failure_final_attempt_timeout_observed",
+            "true",
+        );
+        assert_field_eq(
+            &event,
+            "event_delivery_first_failure_final_attempt_connect_observed",
+            "true",
+        );
     }
 
     #[test]

--- a/crates/runner/src/executor/tests/diagnostics_tests/guest_files.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests/guest_files.rs
@@ -1,6 +1,8 @@
 use guest_contracts::diagnostics::{
-    AgentFramework, FailureClass, FailureDetailSource, FailureDiagnostic, FailureReason,
-    PromptMetadata, SessionHistoryStatus,
+    AgentFramework, EventDeliveryAcceptanceOutcome, EventDeliveryAttemptFailureKind,
+    EventDeliveryCompletedAttemptDiagnostic, EventDeliveryDiagnostic,
+    EventDeliveryFailedBatchDiagnostic, FailureClass, FailureDetailSource, FailureDiagnostic,
+    FailureReason, PromptMetadata, SessionHistoryStatus,
 };
 use sandbox_mock::MockSandbox;
 
@@ -154,6 +156,47 @@ async fn read_guest_failure_diagnostic_file_accepts_unknown_schema_field() {
     );
     let mut json = serde_json::to_value(&diagnostic).unwrap();
     json["schemaVersion"] = serde_json::json!(999);
+    sandbox.push_read_file_result(Ok(Some(serde_json::to_vec(&json).unwrap())));
+
+    let read = read_guest_failure_diagnostic_file(&sandbox, RunId::nil()).await;
+
+    assert_eq!(read, Some(diagnostic));
+}
+
+#[tokio::test]
+async fn read_guest_failure_diagnostic_file_accepts_unknown_event_attempt_field() {
+    let sandbox = MockSandbox::new("test");
+    let diagnostic = FailureDiagnostic::new(
+        FailureClass::EventUploadFailed,
+        AgentFramework::ClaudeCode,
+        PromptMetadata::from_prompt("continue"),
+    )
+    .with_event_delivery(EventDeliveryDiagnostic {
+        total_events: 1,
+        total_batches: 1,
+        failed_batches: 1,
+        last_acknowledged_sequence: None,
+        first_failed_batch: Some(EventDeliveryFailedBatchDiagnostic {
+            first_sequence: 0,
+            last_sequence: 0,
+            event_count: 1,
+            conservative_bytes: 128,
+            outcome: EventDeliveryAcceptanceOutcome::OutcomeUnknown,
+            attempts: vec![EventDeliveryCompletedAttemptDiagnostic {
+                attempt: 1,
+                client_request_id: "11111111-1111-4111-8111-111111111111".to_string(),
+                elapsed_ms: 10_000,
+                failure_kind: EventDeliveryAttemptFailureKind::Timeout,
+                http_status: None,
+                timeout_observed: None,
+                connect_observed: None,
+            }],
+        }),
+        drain_timeout: None,
+    });
+    let mut json = serde_json::to_value(&diagnostic).unwrap();
+    json["eventDelivery"]["firstFailedBatch"]["attempts"][0]["futureTransportObservation"] =
+        serde_json::json!(true);
     sandbox.push_read_file_result(Ok(Some(serde_json::to_vec(&json).unwrap())));
 
     let read = read_guest_failure_diagnostic_file(&sandbox, RunId::nil()).await;

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -1214,6 +1214,8 @@ async fn execute_inner_nonzero_with_failure_diagnostic_skips_abnormal_exit_diagn
                 elapsed_ms: 10_000,
                 failure_kind: EventDeliveryAttemptFailureKind::Timeout,
                 http_status: None,
+                timeout_observed: None,
+                connect_observed: None,
             }],
         }),
         drain_timeout: None,


### PR DESCRIPTION
## Summary

- retain Reqwest timeout and connection observations independently on response-less event-delivery attempts
- keep the existing `failureKind` classification and all retry, timeout, acknowledgement, watermark, checkpoint, and failure behavior unchanged
- project the two optional observations as bounded runner terminal fields for the first failed batch's final attempt
- cover timeout-only, connect-only, combined timeout/connect, and neither through controlled loopback integration scenarios

## Compatibility and safety

- the shared diagnostic fields are optional, omitted when unavailable, and default to absent when reading an older GuestAgent payload
- older runners ignore the additive object fields; nested unknown-field coverage protects that rollout behavior
- diagnostics add only two booleans and retain no raw error text, URL, body, event content, or credentials

## Out of scope

- no timeout or retry changes
- no replay, delivery policy, acknowledgement boundary, or API changes
- no claim about DNS, TCP, TLS, proxy, upload, or response phases beyond Reqwest's two predicates

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- focused event transport, drain timeout, runner compatibility, and terminal projection tests

Closes #28290
