### PR TITLE
fix(python): retain multiple prewarm response ids

### DIFF
--- a/crates/runner/mitm-addon/src/model_websocket_usage.py
+++ b/crates/runner/mitm-addon/src/model_websocket_usage.py
@@ -1,6 +1,6 @@
 """Model-provider WebSocket usage lifecycle state and settlement."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from mitmproxy import http
@@ -12,6 +12,7 @@ from logging_utils import log_proxy_entry
 
 _MODEL_WEBSOCKET_USAGE_ENABLED = "model_websocket_usage_enabled"
 _MODEL_WEBSOCKET_PREWARM_STATE = "_model_websocket_prewarm_state"
+_MAX_IGNORED_RESPONSE_IDS = 100
 
 
 @dataclass(slots=True)
@@ -19,10 +20,9 @@ class _OpenAIResponsesPrewarmState:
     pending_intent: Literal["normal", "prewarm"] | None = None
     active_intent: Literal["normal", "prewarm"] | None = None
     active_response_id: str | None = None
-    ignored_response_id: str | None = None
+    ignored_response_diagnostics: dict[str, bool] = field(default_factory=dict)
     ambiguous: bool = False
     ambiguity_diagnostic_emitted: bool = False
-    ignored_diagnostic_emitted: bool = False
 
 
 _WebSocketCorrelationReason = Literal[
@@ -73,16 +73,6 @@ def _clear_correlation_candidate(state: _OpenAIResponsesPrewarmState) -> None:
     state.active_response_id = None
 
 
-def _retain_ignored_response_id(
-    state: _OpenAIResponsesPrewarmState,
-    response_id: str,
-) -> None:
-    if state.ignored_response_id == response_id:
-        return
-    state.ignored_response_id = response_id
-    state.ignored_diagnostic_emitted = False
-
-
 def _lifecycle_ambiguity_reason(
     lifecycle: usage.OpenAIResponsesServerLifecycle,
 ) -> _WebSocketCorrelationReason:
@@ -99,9 +89,9 @@ def _mark_correlation_ambiguous(
     """Disable prewarm exclusion after ownership can no longer be proven."""
     state.ambiguous = True
     _clear_correlation_candidate(state)
-    # Fail-open is sticky for the rest of the flow. A previously ignored ID
+    # Fail-open is sticky for the rest of the flow. Previously ignored IDs
     # must not remain capable of suppressing usage after that transition.
-    state.ignored_response_id = None
+    state.ignored_response_diagnostics.clear()
     if state.ambiguity_diagnostic_emitted:
         return
     log_proxy_entry(
@@ -117,6 +107,20 @@ def _mark_correlation_ambiguous(
         firewall_name=flow_metadata.firewall_name(flow.metadata),
     )
     state.ambiguity_diagnostic_emitted = True
+
+
+def _retain_ignored_response_id(
+    flow: http.HTTPFlow,
+    state: _OpenAIResponsesPrewarmState,
+    response_id: str,
+) -> bool:
+    if response_id in state.ignored_response_diagnostics:
+        return True
+    if len(state.ignored_response_diagnostics) >= _MAX_IGNORED_RESPONSE_IDS:
+        _mark_correlation_ambiguous(flow, state, "correlation_cap")
+        return False
+    state.ignored_response_diagnostics[response_id] = False
+    return True
 
 
 def observe_client_event(
@@ -162,7 +166,7 @@ def _observe_server_lifecycle(
                 _lifecycle_ambiguity_reason(lifecycle),
             )
             return
-        if lifecycle.response_id == state.ignored_response_id:
+        if lifecycle.response_id in state.ignored_response_diagnostics:
             # A retained ID only proves duplicate terminal ownership. Reusing it
             # at a new created boundary cannot be correlated safely.
             _mark_correlation_ambiguous(flow, state, "invalid_lifecycle")
@@ -183,7 +187,7 @@ def _observe_server_lifecycle(
                     _lifecycle_ambiguity_reason(lifecycle),
                 )
             return
-        if lifecycle.response_id == state.ignored_response_id:
+        if lifecycle.response_id in state.ignored_response_diagnostics:
             # A pending request has no bound ID yet, so this could be either an
             # old duplicate or that request's terminal after a missing created
             # boundary. Only an idle flow or a differently bound active response
@@ -194,7 +198,7 @@ def _observe_server_lifecycle(
         if (
             state.active_intent is None
             and state.pending_intent is not None
-            and lifecycle.response_id != state.ignored_response_id
+            and lifecycle.response_id not in state.ignored_response_diagnostics
         ):
             _mark_correlation_ambiguous(flow, state, "invalid_lifecycle")
             return
@@ -232,7 +236,7 @@ def feed_usage(
         and (
             prewarm_state.pending_intent is not None
             or prewarm_state.active_intent is not None
-            or prewarm_state.ignored_response_id is not None
+            or bool(prewarm_state.ignored_response_diagnostics)
             or event.event_type is None
             or event.event_type in _WEBSOCKET_LIFECYCLE_EVENT_TYPES
         )
@@ -282,13 +286,15 @@ def feed_usage(
                 and prewarm_state.active_intent == "prewarm"
                 and prewarm_state.active_response_id == message_id
             ):
-                _retain_ignored_response_id(prewarm_state, message_id)
-                suppressed = True
-            elif not prewarm_state.ambiguous and prewarm_state.ignored_response_id == message_id:
+                suppressed = _retain_ignored_response_id(flow, prewarm_state, message_id)
+            elif (
+                not prewarm_state.ambiguous
+                and message_id in prewarm_state.ignored_response_diagnostics
+            ):
                 suppressed = True
             if (
                 suppressed
-                and not prewarm_state.ignored_diagnostic_emitted
+                and not prewarm_state.ignored_response_diagnostics[message_id]
                 and usage.has_positive_model_provider_usage(usage_result)
             ):
                 usage.log_ignored_model_provider_usage_source(
@@ -298,7 +304,7 @@ def feed_usage(
                     usage_result,
                     reason="responses_generate_false",
                 )
-                prewarm_state.ignored_diagnostic_emitted = True
+                prewarm_state.ignored_response_diagnostics[message_id] = True
         if (
             not suppressed
             and usage_result is not None
@@ -366,6 +372,6 @@ def feed_usage(
         and active_response_id == lifecycle.response_id
     ):
         if prewarm_state.active_intent == "prewarm":
-            _retain_ignored_response_id(prewarm_state, active_response_id)
+            _retain_ignored_response_id(flow, prewarm_state, active_response_id)
         prewarm_state.active_intent = None
         prewarm_state.active_response_id = None

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
@@ -167,7 +167,6 @@ class TestModelProviderWebSocketPrewarmUsage:
                 json.dumps({"type": "response.create", "generate": False}).encode(),
             )
             feed_websocket_server_message(flow, _openai_websocket_created_frame("warm-second"))
-            feed_websocket_server_message(flow, first_usage)
             feed_websocket_server_message(
                 flow,
                 openai_websocket_usage_frame(
@@ -176,6 +175,7 @@ class TestModelProviderWebSocketPrewarmUsage:
                     output_tokens=0,
                 ),
             )
+            feed_websocket_server_message(flow, first_usage)
             mitm_addon.websocket_end(flow)
             usage.flush_usage_events(trigger="test")
 
@@ -191,6 +191,64 @@ class TestModelProviderWebSocketPrewarmUsage:
             "warm-second",
         ]
         assert not _correlation_entries(flow)
+
+    def test_model_websocket_ignored_response_cap_fails_open(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            for index in range(100):
+                response_id = f"warm-retained-{index}"
+                feed_websocket_client_message(
+                    flow,
+                    json.dumps({"type": "response.create", "generate": False}).encode(),
+                )
+                feed_websocket_server_message(
+                    flow,
+                    _openai_websocket_created_frame(response_id),
+                )
+                feed_websocket_server_message(
+                    flow,
+                    json.dumps(
+                        {
+                            "type": "response.completed",
+                            "response": {"id": response_id},
+                        }
+                    ).encode(),
+                )
+
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("warm-over-cap"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame(
+                    "warm-over-cap",
+                    input_tokens=9,
+                    output_tokens=0,
+                ),
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [("gpt-5.5", "tokens.input", 9)]
+        assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+        assert not any(
+            entry.get("disposition") == "ignored" for entry in model_usage_source_entries(flow)
+        )
+        [correlation_entry] = _correlation_entries(flow)
+        assert correlation_entry["reason"] == "correlation_cap"
 
     def test_model_websocket_ignores_bound_prewarm_and_reports_normal_input_only_turn(
         self,
@@ -350,7 +408,7 @@ class TestModelProviderWebSocketPrewarmUsage:
         )
         assert not _correlation_entries(flow)
 
-    def test_model_websocket_reused_ignored_id_fails_open(self, tmp_path, real_flow):
+    def test_model_websocket_reused_older_ignored_id_fails_open(self, tmp_path, real_flow):
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
 
@@ -363,6 +421,16 @@ class TestModelProviderWebSocketPrewarmUsage:
             feed_websocket_server_message(
                 flow,
                 openai_websocket_usage_frame("reused-id", input_tokens=5, output_tokens=0),
+            )
+
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("later-warm"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("later-warm", input_tokens=6, output_tokens=0),
             )
 
             feed_websocket_client_message(
@@ -388,7 +456,10 @@ class TestModelProviderWebSocketPrewarmUsage:
         ignored_entries = [
             entry for entry in source_entries if entry.get("disposition") == "ignored"
         ]
-        assert len(ignored_entries) == 1
+        assert [entry["provider_response_id"] for entry in ignored_entries] == [
+            "reused-id",
+            "later-warm",
+        ]
         reported_entries = [
             entry
             for entry in source_entries


### PR DESCRIPTION
## Summary

- retain bounded correlation for multiple completed OpenAI Responses WebSocket prewarm IDs
- keep one ignored-source diagnostic per retained response and suppress older delayed duplicates after later prewarms settle
- enter observable sticky `correlation_cap` fail-open at 100 retained IDs and preserve fail-open for response-ID reuse
- add entry-point regressions for A/B/delayed-A, older-ID reuse, and capacity exhaustion

## Scope

This change is local to the runner MITM addon's in-memory WebSocket lifecycle. It does not change JSON parsing, usage idempotency, pricing, APIs, persisted state, queue payloads, migrations, or runner/guest compatibility contracts.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_model_provider_websocket_prewarm.py` (27 passed)
- `uv run --no-sync python -m pytest tests/` (6,424 passed)
- `lefthook run pre-commit`
- commitlint hook

Closes #28386
