### PR TITLE
refactor(python): centralize websocket handshake header parsing

### DIFF
--- a/crates/runner/mitm-addon/src/http_header_syntax.py
+++ b/crates/runner/mitm-addon/src/http_header_syntax.py
@@ -1,14 +1,17 @@
-"""Shared HTTP header syntax predicates.
+"""Shared HTTP header syntax helpers.
 
-These helpers only answer syntax questions. Callers keep ownership of their
+These helpers only implement dependency-light syntax rules. Callers keep ownership of their
 trust-boundary-specific encoding rules, exception types, and error messages.
 """
+
+from collections.abc import Sequence
 
 _HTTP_TOKEN_CHARS: frozenset[str] = frozenset(
     "!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 )
 _ASCII_CONTROL_MAX = 0x1F
 _ASCII_DELETE = 0x7F
+_HTTP_OWS_CHARS = " \t"
 
 
 def is_http_header_name(value: str) -> bool:
@@ -20,3 +23,17 @@ def has_forbidden_header_value_control(value: str) -> bool:
         (ord(char) <= _ASCII_CONTROL_MAX and char != "\t") or ord(char) == _ASCII_DELETE
         for char in value
     )
+
+
+def header_values_contain_token(values: Sequence[str], expected: str) -> bool:
+    return any(
+        token.strip(_HTTP_OWS_CHARS).lower() == expected
+        for value in values
+        for token in value.split(",")
+    )
+
+
+def single_header_value(values: Sequence[str]) -> str | None:
+    if len(values) != 1:
+        return None
+    return values[0].strip(_HTTP_OWS_CHARS)

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -27,7 +27,8 @@ from mitmproxy.addonmanager import Loader
 # --- Sub-module imports ---
 #
 # auth_base_forwarder/body_capture/connector_diagnostics/connector_intent/content_length/
-# matching/model_websocket_usage/registry/response_encoding_negotiation/response_streaming/
+# http_header_syntax/matching/model_websocket_usage/registry/response_encoding_negotiation/
+# response_streaming/
 # runner_flush_lifecycle/terminal_usage/upstream_admission/usage/websocket_framing/
 # websocket_retention are imported
 # by module (not selective `from X import ...`) so that:
@@ -54,6 +55,7 @@ import connector_intent
 import content_length
 import flow_metadata
 import flow_metadata_keys as metadata_keys
+import http_header_syntax
 import http_local_responses
 import http_network_log
 import matching
@@ -111,8 +113,6 @@ from request_authority import AuthorityValidationError, TrustedAuthority, get_tr
 _HTTP_STATUS_UNAUTHORIZED = 401
 _HTTP_STATUS_BAD_GATEWAY = 502
 _HTTP_STATUS_ERROR_MIN = 400  # inclusive: start of 4xx/5xx error range
-_HTTP_OWS_CHARS = " \t"
-
 # Request-header phase state.
 # Creator: requestheaders() and header-phase stream/auth helpers.
 # Consumer: request() and terminal cleanup.
@@ -1527,31 +1527,24 @@ def _is_websocket_upgrade_request(flow: http.HTTPFlow) -> bool:
         return False
     if flow.request.http_version != "HTTP/1.1":
         return False
-    if not _header_values_contain_token(flow.request.headers, "Upgrade", "websocket"):
+    if not http_header_syntax.header_values_contain_token(
+        flow.request.headers.get_all("Upgrade"), "websocket"
+    ):
         return False
-    websocket_key = _single_header_value(flow.request.headers, "Sec-WebSocket-Key")
+    websocket_key = http_header_syntax.single_header_value(
+        flow.request.headers.get_all("Sec-WebSocket-Key")
+    )
     if websocket_key is None or not _is_valid_websocket_key(websocket_key):
         return False
-    websocket_version = _single_header_value(flow.request.headers, "Sec-WebSocket-Version")
+    websocket_version = http_header_syntax.single_header_value(
+        flow.request.headers.get_all("Sec-WebSocket-Version")
+    )
     if websocket_version != "13":
         return False
 
-    return _header_values_contain_token(flow.request.headers, "Connection", "upgrade")
-
-
-def _header_values_contain_token(headers: http.Headers, name: str, expected: str) -> bool:
-    return any(
-        token.strip(_HTTP_OWS_CHARS).lower() == expected
-        for value in headers.get_all(name)
-        for token in value.split(",")
+    return http_header_syntax.header_values_contain_token(
+        flow.request.headers.get_all("Connection"), "upgrade"
     )
-
-
-def _single_header_value(headers: http.Headers, name: str) -> str | None:
-    values = headers.get_all(name)
-    if len(values) != 1:
-        return None
-    return values[0].strip(_HTTP_OWS_CHARS)
 
 
 def _is_valid_websocket_key(value: str) -> bool:

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -24,6 +24,7 @@ import body_decoding
 import claude_output_timing
 import flow_metadata
 import flow_metadata_keys as metadata_keys
+import http_header_syntax
 import model_websocket_usage
 import runtime_url_parsing
 import stream_capture
@@ -376,13 +377,21 @@ def _is_confirmed_websocket_upgrade_response(flow: http.HTTPFlow) -> bool:
         return False
     if flow.metadata.get(metadata_keys.WEBSOCKET_UPGRADE_REQUEST) is not True:
         return False
-    if not _header_values_contain_token(response.headers, "Upgrade", "websocket"):
+    if not http_header_syntax.header_values_contain_token(
+        response.headers.get_all("Upgrade"), "websocket"
+    ):
         return False
-    if not _header_values_contain_token(response.headers, "Connection", "upgrade"):
+    if not http_header_syntax.header_values_contain_token(
+        response.headers.get_all("Connection"), "upgrade"
+    ):
         return False
 
-    request_key = _single_header_value(flow.request.headers, "Sec-WebSocket-Key")
-    response_accept = _single_header_value(response.headers, "Sec-WebSocket-Accept")
+    request_key = http_header_syntax.single_header_value(
+        flow.request.headers.get_all("Sec-WebSocket-Key")
+    )
+    response_accept = http_header_syntax.single_header_value(
+        response.headers.get_all("Sec-WebSocket-Accept")
+    )
     if request_key is None or response_accept is None:
         return False
     try:
@@ -390,21 +399,6 @@ def _is_confirmed_websocket_upgrade_response(flow: http.HTTPFlow) -> bool:
     except UnicodeEncodeError:
         return False
     return response_accept == expected_accept
-
-
-def _header_values_contain_token(headers: http.Headers, name: str, expected: str) -> bool:
-    return any(
-        token.strip(_HTTP_OWS_CHARS).lower() == expected
-        for value in headers.get_all(name)
-        for token in value.split(",")
-    )
-
-
-def _single_header_value(headers: http.Headers, name: str) -> str | None:
-    values = headers.get_all(name)
-    if len(values) != 1:
-        return None
-    return values[0].strip(_HTTP_OWS_CHARS)
 
 
 def configure_response_stream(flow: http.HTTPFlow) -> None:

--- a/crates/runner/mitm-addon/tests/test_http_header_syntax.py
+++ b/crates/runner/mitm-addon/tests/test_http_header_syntax.py
@@ -89,3 +89,68 @@ def test_has_forbidden_header_value_control_rejects_control_values(value: str) -
 
 def test_has_forbidden_header_value_control_accepts_non_ascii_value() -> None:
     assert http_header_syntax.has_forbidden_header_value_control("\u00e9") is False
+
+
+@pytest.mark.parametrize(
+    ("values", "expected_token", "contains_token"),
+    [
+        pytest.param((), "upgrade", False, id="empty-values"),
+        pytest.param(
+            ("keep-alive", "websocket"),
+            "websocket",
+            True,
+            id="repeated-upgrade-values",
+        ),
+        pytest.param(
+            ("keep-alive,\tUpGrAdE ",),
+            "upgrade",
+            True,
+            id="connection-list-case-and-ows",
+        ),
+        pytest.param(
+            ("h2c, websocket\u2028",),
+            "websocket",
+            False,
+            id="trailing-unicode-whitespace",
+        ),
+        pytest.param(
+            ("\u2028upgrade",),
+            "upgrade",
+            False,
+            id="leading-unicode-whitespace",
+        ),
+        pytest.param(("upgraded",), "upgrade", False, id="nonmatching-token"),
+    ],
+)
+def test_header_values_contain_token(
+    values: tuple[str, ...],
+    expected_token: str,
+    *,
+    contains_token: bool,
+) -> None:
+    assert http_header_syntax.header_values_contain_token(values, expected_token) is contains_token
+
+
+@pytest.mark.parametrize(
+    ("values", "expected_value"),
+    [
+        pytest.param((), None, id="missing-value"),
+        pytest.param(
+            (" \tdGhlIHNhbXBsZSBub25jZQ==\t ",),
+            "dGhlIHNhbXBsZSBub25jZQ==",
+            id="websocket-key-ows",
+        ),
+        pytest.param(("13\u2028",), "13\u2028", id="version-unicode-whitespace"),
+        pytest.param((" \t",), "", id="blank-singleton"),
+        pytest.param(
+            ("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=", "duplicate"),
+            None,
+            id="duplicate-websocket-accept",
+        ),
+    ],
+)
+def test_single_header_value(
+    values: tuple[str, ...],
+    expected_value: str | None,
+) -> None:
+    assert http_header_syntax.single_header_value(values) == expected_value


### PR DESCRIPTION
## Summary

- move repeated WebSocket comma-list token matching and singleton extraction into the dependency-light HTTP header syntax owner
- route request classification and response upgrade confirmation through the same raw-value helpers while preserving their existing policy checks
- add direct contract coverage for repeated values, comma lists, ASCII case folding, SP/HTAB trimming, Unicode whitespace, and singleton cardinality

## Scope

- no request or response WebSocket validation policy changes
- no API, runner protocol, persisted state, migration, generated artifact, or deployment configuration changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_http_header_syntax.py tests/test_response_encoding_negotiation.py tests/test_model_provider_websocket_lifecycle.py` (353 passed)
- `uv run --no-sync python -m pytest tests/` (6437 passed)

Closes #28389
