### PR TITLE
test(guest-agent): make child activation marker harness-independent

### DIFF
--- a/crates/guest-agent/tests/process_control_env.rs
+++ b/crates/guest-agent/tests/process_control_env.rs
@@ -109,7 +109,7 @@ async fn process_control_endpoint_is_not_inherited_by_cli_child()
         output.status
     );
     assert!(
-        stdout.lines().any(|line| line == ISOLATED_CHILD_MARKER),
+        stdout.contains(ISOLATED_CHILD_MARKER),
         "isolated process-control environment test did not activate; stdout:\n{stdout}\nstderr:\n{stderr}"
     );
     Ok(())
@@ -122,7 +122,7 @@ async fn process_control_endpoint_is_not_inherited_by_cli_child_isolated()
     if std::env::var(ISOLATED_CHILD_GUARD).ok().as_deref() != Some(ISOLATED_CHILD_GUARD_VALUE) {
         return Ok(());
     }
-    println!("{ISOLATED_CHILD_MARKER}");
+    println!("isolated child output: {ISOLATED_CHILD_MARKER}; continuing");
 
     let mock = std::env::var_os(ISOLATED_CHILD_MOCK_PATH)
         .map(PathBuf::from)


### PR DESCRIPTION
## Summary

- recognize the guarded process-control child marker anywhere in captured stdout instead of requiring a harness-owned exact line
- emit stable same-line context around the marker so the regression is exercised across libtest formatting versions
- preserve exact child selection, zero-test protection, status validation, timeout cleanup, and captured failure diagnostics

## Scope

This is test-only. It does not change guest-agent runtime behavior, production protocols, timeouts, deployment compatibility, or persisted data.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test process_control_env process_control_endpoint_is_not_inherited_by_cli_child -- --exact --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test process_control_env -- --ignored`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test process_control_env`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --release --test process_control_env`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- pre-commit Rust formatting, documentation, Clippy, file-size, and commit-message hooks

Closes #28388
