### PR TITLE
feat(connectors): route ready oauth callbacks directly to okou

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
@@ -2,11 +2,13 @@ import { randomUUID } from "node:crypto";
 
 import type { ConnectorAuthMethodId } from "@okouai/api-contracts/contracts/connector-identity";
 import { connectorOauthStartResponseSchema } from "@okouai/api-contracts/contracts/connector-schemas";
+import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createApp } from "../../../app-factory";
 import { testContext } from "../../../__tests__/test-context";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
 import { clearMockNow } from "../../../lib/time";
 import {
   API_TEST_CONNECTOR_CATALOG,
@@ -30,6 +32,11 @@ const OKOU_API_ORIGIN = "https://api.okou.ai";
 const WEB_ORIGIN = "https://www.vm0.ai";
 const LOCAL_ORIGIN = "http://localhost:3000";
 const LOCAL_WEB_ORIGIN = "https://www.vm0.ai:8443";
+const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_OPENID_USERINFO_URL =
+  "https://openidconnect.googleapis.com/v1/userinfo";
+const AIRTABLE_OAUTH_TOKEN_URL = "https://airtable.com/oauth2/v1/token";
+const AIRTABLE_WHOAMI_URL = "https://api.airtable.com/v0/meta/whoami";
 const AUTH_REQUEST_USER_ID_PREFIX = "user_zero_connectors_oauth_start_";
 const YOUTUBE_OAUTH_SCOPES = [
   "https://www.googleapis.com/auth/youtube",
@@ -141,6 +148,12 @@ function expectOauthState(authorizationUrl: URL): string {
   return state!;
 }
 
+function expectOkouOauthState(authorizationUrl: URL): string {
+  const state = authorizationUrl.searchParams.get("state");
+  expect(state).toMatch(/^okou\.[0-9a-f]{64}$/u);
+  return state!;
+}
+
 async function rejectProviderAuthorization(
   authorizationUrl: URL,
 ): Promise<void> {
@@ -178,12 +191,12 @@ describe("POST /api/zero/connectors/:connectorSlug/oauth/start", () => {
     expectOauthState(authorizationUrl);
   });
 
-  it("starts YouTube OAuth without a feature switch", async () => {
+  it("keeps an omitted callback target on the existing Web callback", async () => {
     mockAuthenticatedSession();
 
     const response = await requestOauthStart("youtube", {
       headers: authHeaders(),
-      origin: API_ORIGIN,
+      origin: OKOU_API_ORIGIN,
     });
 
     expect(response.status).toBe(200);
@@ -202,7 +215,7 @@ describe("POST /api/zero/connectors/:connectorSlug/oauth/start", () => {
     ).toStrictEqual([...YOUTUBE_OAUTH_SCOPES]);
     expect(authorizationUrl.searchParams.get("access_type")).toBe("offline");
     expect(authorizationUrl.searchParams.get("prompt")).toBe("consent");
-    expectOauthState(authorizationUrl);
+    expectOkouOauthState(authorizationUrl);
     await rejectProviderAuthorization(authorizationUrl);
   });
 
@@ -247,8 +260,27 @@ describe("POST /api/zero/connectors/:connectorSlug/oauth/start", () => {
     await rejectProviderAuthorization(authorizationUrl);
   });
 
-  it("uses App callbacks for allowlisted connectors", async () => {
-    mockEnv("APP_URL", "https://app.vm0.test");
+  it("uses the direct Okou App callback for a ready Google connector", async () => {
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    mockAuthenticatedSession();
+
+    const response = await requestOauthStart("google-maps", {
+      callbackTarget: "app",
+      headers: authHeaders(),
+      origin: OKOU_API_ORIGIN,
+    });
+
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      "https://app.okou.ai/connectors/google-maps/callback",
+    );
+    expectOkouOauthState(authorizationUrl);
+    await rejectProviderAuthorization(authorizationUrl);
+  });
+
+  it("keeps the VM0 App callback for a ready Google connector", async () => {
+    mockEnv("APP_URL", "https://app.vm0.ai");
     mockAuthenticatedSession();
 
     const response = await requestOauthStart("google-maps", {
@@ -260,8 +292,9 @@ describe("POST /api/zero/connectors/:connectorSlug/oauth/start", () => {
     expect(response.status).toBe(200);
     const authorizationUrl = await authorizationUrlFromResponse(response);
     expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
-      "https://app.vm0.test/connectors/google-maps/callback",
+      "https://app.vm0.ai/connectors/google-maps/callback",
     );
+    expectOauthState(authorizationUrl);
     await rejectProviderAuthorization(authorizationUrl);
   });
 
@@ -283,7 +316,7 @@ describe("POST /api/zero/connectors/:connectorSlug/oauth/start", () => {
       expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
         connectorSlug === "slack"
           ? `${WEB_ORIGIN}/api/connectors/slack/callback`
-          : "https://app.vm0.ai/connectors/google-maps/callback",
+          : `https://app.${publicBrand === "okou" ? "okou" : "vm0"}.ai/connectors/google-maps/callback`,
       );
       const state = authorizationUrl.searchParams.get("state") ?? "";
 
@@ -322,12 +355,32 @@ describe("POST /api/zero/connectors/:connectorSlug/oauth/start", () => {
     expect(vm0.location.pathname).toBe("/connector/error");
   });
 
-  it("stores provider PKCE context for server-side OAuth handoff", async () => {
+  it("reuses the persisted exact redirect URI for a PKCE token exchange", async () => {
+    const tokenBodies: URLSearchParams[] = [];
+    server.use(
+      http.post(AIRTABLE_OAUTH_TOKEN_URL, async ({ request }) => {
+        tokenBodies.push(new URLSearchParams(await request.text()));
+        return HttpResponse.json({
+          access_token: "airtable-test-token",
+          refresh_token: "airtable-refresh-token",
+          expires_in: 3600,
+          scope: "data.records:read",
+        });
+      }),
+      http.get(AIRTABLE_WHOAMI_URL, () => {
+        return HttpResponse.json({
+          id: "airtable-user-123",
+          email: "airtable@example.test",
+        });
+      }),
+    );
+    mockEnv("APP_URL", "https://app.vm0.ai");
     mockAuthenticatedSession();
 
     const response = await requestOauthStart("airtable", {
+      callbackTarget: "app",
       headers: authHeaders(),
-      origin: API_ORIGIN,
+      origin: OKOU_API_ORIGIN,
     });
 
     expect(response.status).toBe(200);
@@ -338,35 +391,104 @@ describe("POST /api/zero/connectors/:connectorSlug/oauth/start", () => {
     expect(authorizationUrl.searchParams.get("client_id")).toBe(
       "airtable-test-client-id",
     );
-    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
-      `${WEB_ORIGIN}/api/connectors/airtable/callback`,
-    );
+    const redirectUri = authorizationUrl.searchParams.get("redirect_uri");
+    expect(redirectUri).toBe("https://app.vm0.ai/connectors/airtable/callback");
     expect(authorizationUrl.searchParams.get("code_challenge")).toMatch(
       /^[A-Za-z0-9_-]+$/,
     );
     expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe(
       "S256",
     );
-    expectOauthState(authorizationUrl);
-    await rejectProviderAuthorization(authorizationUrl);
+    const state = expectOkouOauthState(authorizationUrl);
+
+    const app = createApp({ signal: context.signal, routes: TEST_APP_ROUTES });
+    const callback = await app.request(
+      `${OKOU_API_ORIGIN}/api/connectors/airtable/callback?${new URLSearchParams(
+        {
+          code: "airtable-authorization-code",
+          state,
+        },
+      )}`,
+      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+    );
+
+    expect(callback.status).toBe(307);
+    expect(new URL(callback.headers.get("location") ?? "").origin).toBe(
+      "https://app.okou.ai",
+    );
+    expect(tokenBodies).toHaveLength(1);
+    expect(tokenBodies[0]?.get("redirect_uri")).toBe(redirectUri);
+    expect(tokenBodies[0]?.get("code_verifier")).toMatch(/^[A-Za-z0-9_-]+$/u);
   });
 
-  it("uses App callbacks by default outside the legacy callback list", async () => {
-    mockEnv("APP_URL", "https://app.vm0.test");
+  it("reuses the direct Okou redirect URI for a Google token exchange", async () => {
+    const tokenBodies: URLSearchParams[] = [];
+    server.use(
+      http.post(GOOGLE_OAUTH_TOKEN_URL, async ({ request }) => {
+        tokenBodies.push(new URLSearchParams(await request.text()));
+        return HttpResponse.json({
+          access_token: "gmail-test-token",
+          refresh_token: "gmail-refresh-token",
+          expires_in: 3600,
+          scope: "https://www.googleapis.com/auth/gmail.modify",
+        });
+      }),
+      http.get(GOOGLE_OPENID_USERINFO_URL, () => {
+        return HttpResponse.json({
+          sub: "gmail-user-123",
+          email: "gmail@example.test",
+          name: "Gmail Test User",
+        });
+      }),
+    );
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    mockAuthenticatedSession();
+
+    const response = await requestOauthStart("gmail", {
+      callbackTarget: "app",
+      headers: authHeaders(),
+      origin: OKOU_API_ORIGIN,
+    });
+
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    const redirectUri = authorizationUrl.searchParams.get("redirect_uri");
+    expect(redirectUri).toBe("https://app.okou.ai/connectors/gmail/callback");
+    const state = expectOkouOauthState(authorizationUrl);
+
+    const app = createApp({ signal: context.signal, routes: TEST_APP_ROUTES });
+    const callback = await app.request(
+      `${OKOU_API_ORIGIN}/api/connectors/gmail/callback?${new URLSearchParams({
+        code: "gmail-authorization-code",
+        state,
+      })}`,
+      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+    );
+
+    expect(callback.status).toBe(307);
+    const callbackLocation = new URL(callback.headers.get("location") ?? "");
+    expect(callbackLocation.origin).toBe("https://app.okou.ai");
+    expect(callbackLocation.pathname).toBe("/connector/success");
+    expect(tokenBodies).toHaveLength(1);
+    expect(tokenBodies[0]?.get("redirect_uri")).toBe(redirectUri);
+  });
+
+  it("keeps an Okou start on the VM0 App callback when the provider is not ready", async () => {
+    mockEnv("APP_URL", "https://app.vm0.ai");
     mockAuthenticatedSession();
 
     const response = await requestOauthStart("test-oauth", {
       headers: authHeaders(),
-      origin: API_ORIGIN,
+      origin: OKOU_API_ORIGIN,
       callbackTarget: "app",
     });
 
     expect(response.status).toBe(200);
     const authorizationUrl = await authorizationUrlFromResponse(response);
     expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
-      "https://app.vm0.test/connectors/test-oauth/callback",
+      "https://app.vm0.ai/connectors/test-oauth/callback",
     );
-    expectOauthState(authorizationUrl);
+    expectOkouOauthState(authorizationUrl);
     await rejectProviderAuthorization(authorizationUrl);
   });
 
@@ -397,12 +519,12 @@ describe("POST /api/zero/connectors/:connectorSlug/oauth/start", () => {
   });
 
   it("keeps denylisted callbacks on the legacy path", async () => {
-    mockEnv("APP_URL", "https://app.vm0.test");
+    mockEnv("APP_URL", "https://app.vm0.ai");
     mockAuthenticatedSession();
 
     const response = await requestOauthStart("slack", {
       headers: authHeaders(),
-      origin: WEB_ORIGIN,
+      origin: OKOU_API_ORIGIN,
       callbackTarget: "app",
     });
 
@@ -411,7 +533,7 @@ describe("POST /api/zero/connectors/:connectorSlug/oauth/start", () => {
     expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
       `${WEB_ORIGIN}/api/connectors/slack/callback`,
     );
-    expectOauthState(authorizationUrl);
+    expectOkouOauthState(authorizationUrl);
     await rejectProviderAuthorization(authorizationUrl);
   });
 

--- a/turbo/apps/api/src/signals/routes/connector-oauth-origin.ts
+++ b/turbo/apps/api/src/signals/routes/connector-oauth-origin.ts
@@ -2,7 +2,12 @@ import {
   connectorAuthCodeGrantCallbackOrigin,
   connectorOpenIdAuthGrantCallbackOrigin,
 } from "@okouai/connectors/connector-auth-method";
-import { isConnectorAppOauthCallbackEnabled } from "@okouai/connectors/app-oauth-callback";
+import {
+  isConnectorAppOauthCallbackEnabled,
+  isConnectorDirectOkouOauthCallbackReady,
+} from "@okouai/connectors/app-oauth-callback";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 import type {
   ConnectorAuthMethodRuntimeConfig,
   ConnectorBrowserAuthCallbackOrigin,
@@ -36,6 +41,7 @@ export function getConnectorOAuthCallbackUrlForMethod(args: {
   readonly method: ConnectorAuthMethodRuntimeConfig;
   readonly connectorSlug: string;
   readonly callbackTarget: "app" | undefined;
+  readonly publicBrand: PublicBrand;
 }): string {
   if (args.method.grant.kind !== "auth-code") {
     throw new Error("Auth-code connector method required");
@@ -47,9 +53,15 @@ export function getConnectorOAuthCallbackUrlForMethod(args: {
     args.callbackTarget === "app" &&
     isConnectorAppOauthCallbackEnabled(args.connectorSlug)
   ) {
+    const configuredAppUrl = env("APP_URL");
+    const callbackAppUrl =
+      args.publicBrand === "okou" &&
+      isConnectorDirectOkouOauthCallbackReady(args.connectorSlug)
+        ? appUrlForPublicBrand(configuredAppUrl, "okou")
+        : configuredAppUrl;
     return new URL(
       `/connectors/${encodeURIComponent(args.connectorSlug)}/callback`,
-      env("APP_URL"),
+      callbackAppUrl,
     ).toString();
   }
   return new URL(

--- a/turbo/apps/api/src/signals/routes/connectors.ts
+++ b/turbo/apps/api/src/signals/routes/connectors.ts
@@ -510,6 +510,7 @@ const startConnectorOauthInner$ = command(
       method,
       connectorSlug: resolved.connectorSlug,
       callbackTarget: bodyResult.data.callbackTarget,
+      publicBrand,
     });
     const prepared = prepareConnectorAuthCodeStartWithMethod({
       method,

--- a/turbo/packages/connectors/src/__tests__/app-oauth-callback.test.ts
+++ b/turbo/packages/connectors/src/__tests__/app-oauth-callback.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { isConnectorDirectOkouOauthCallbackReady } from "../app-oauth-callback";
+
+const DIRECT_OKOU_READY_CONNECTORS = [
+  "gmail",
+  "google-ads",
+  "google-analytics",
+  "google-calendar",
+  "google-cloud",
+  "google-contacts",
+  "google-docs",
+  "google-drive",
+  "google-forms",
+  "google-maps",
+  "google-meet",
+  "google-search-console",
+  "google-sheets",
+  "microsoft-365",
+  "outlook-calendar",
+  "outlook-mail",
+  "youtube",
+] as const;
+
+describe("direct Okou OAuth callback readiness", () => {
+  it.each(DIRECT_OKOU_READY_CONNECTORS)(
+    "marks %s as direct-ready",
+    (connectorSlug) => {
+      expect(isConnectorDirectOkouOauthCallbackReady(connectorSlug)).toBe(true);
+    },
+  );
+
+  it.each(["github", "slack", "test-oauth"])(
+    "keeps %s on its existing callback",
+    (connectorSlug) => {
+      expect(isConnectorDirectOkouOauthCallbackReady(connectorSlug)).toBe(
+        false,
+      );
+    },
+  );
+});

--- a/turbo/packages/connectors/src/__tests__/app-oauth-callback.test.ts
+++ b/turbo/packages/connectors/src/__tests__/app-oauth-callback.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { getConnectorAuthProviderRegistrationCapabilities } from "../auth-providers/connector-auth";
 import { isConnectorDirectOkouOauthCallbackReady } from "../app-oauth-callback";
 
 const DIRECT_OKOU_READY_CONNECTORS = [
@@ -23,6 +24,25 @@ const DIRECT_OKOU_READY_CONNECTORS = [
 ] as const;
 
 describe("direct Okou OAuth callback readiness", () => {
+  it("contains exactly the ready executable auth-code connectors", () => {
+    const directReadyConnectors = new Set(
+      getConnectorAuthProviderRegistrationCapabilities()
+        .filter((capability) => {
+          return (
+            capability.contract.grant.kind === "auth-code" &&
+            isConnectorDirectOkouOauthCallbackReady(capability.connectorSlug)
+          );
+        })
+        .map((capability) => {
+          return capability.connectorSlug;
+        }),
+    );
+
+    expect(directReadyConnectors).toStrictEqual(
+      new Set(DIRECT_OKOU_READY_CONNECTORS),
+    );
+  });
+
   it.each(DIRECT_OKOU_READY_CONNECTORS)(
     "marks %s as direct-ready",
     (connectorSlug) => {

--- a/turbo/packages/connectors/src/app-oauth-callback.ts
+++ b/turbo/packages/connectors/src/app-oauth-callback.ts
@@ -4,8 +4,36 @@ export const CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY =
 
 const LEGACY_CALLBACK_CONNECTOR_SLUGS: ReadonlySet<string> = new Set(["slack"]);
 
+// Add a connector only after its provider accepts the direct Okou App callback.
+const DIRECT_OKOU_OAUTH_CALLBACK_READY_CONNECTOR_SLUGS: ReadonlySet<string> =
+  new Set([
+    "gmail",
+    "google-ads",
+    "google-analytics",
+    "google-calendar",
+    "google-cloud",
+    "google-contacts",
+    "google-docs",
+    "google-drive",
+    "google-forms",
+    "google-maps",
+    "google-meet",
+    "google-search-console",
+    "google-sheets",
+    "microsoft-365",
+    "outlook-calendar",
+    "outlook-mail",
+    "youtube",
+  ]);
+
 export function isConnectorAppOauthCallbackEnabled(
   connectorSlug: string,
 ): boolean {
   return !LEGACY_CALLBACK_CONNECTOR_SLUGS.has(connectorSlug);
+}
+
+export function isConnectorDirectOkouOauthCallbackReady(
+  connectorSlug: string,
+): boolean {
+  return DIRECT_OKOU_OAUTH_CALLBACK_READY_CONNECTOR_SLUGS.has(connectorSlug);
 }

--- a/turbo/packages/connectors/src/app-oauth-callback.ts
+++ b/turbo/packages/connectors/src/app-oauth-callback.ts
@@ -4,7 +4,8 @@ export const CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY =
 
 const LEGACY_CALLBACK_CONNECTOR_SLUGS: ReadonlySet<string> = new Set(["slack"]);
 
-// Add a connector only after its provider accepts the direct Okou App callback.
+// Provider allowlists roll out independently of the API. Until #28381 confirms
+// every provider is ready, unlisted connectors must keep their VM0 App callback.
 const DIRECT_OKOU_OAUTH_CALLBACK_READY_CONNECTOR_SLUGS: ReadonlySet<string> =
   new Set([
     "gmail",


### PR DESCRIPTION
## summary

- add an independent direct-Okou readiness gate containing exactly the 14 Google and 3 Microsoft connectors whose shared provider clients are ready
- use the trusted persisted public brand to select `app.okou.ai` only for ready App-targeted starts, while preserving VM0, unready-provider, omitted-target, and Slack legacy behavior
- keep authorization and token exchange on the same persisted exact redirect URI, with regression coverage for Google and PKCE exchanges

## safety and compatibility

- the existing generic App callback gate is unchanged
- existing VM0 and `app.vm0.ai` callbacks remain in use for VM0 starts and unready providers
- dedicated Slack, Teams, and Feishu OAuth flows, OpenID, device auth, and custom connectors are untouched
- no database schema or migration changes
- Microsoft readiness is based on Yuma's owner confirmation that the production Entra OAuth App configuration is complete; this PR did not independently reopen the Entra console
- production OAuth verification remains pending the normal release

## Fallbacks

- `app-oauth-callback.ts:isConnectorDirectOkouOauthCallbackReady` and `connector-oauth-origin.ts:getConnectorOAuthCallbackUrlForMethod` keep an Okou App start on the configured VM0 callback when the connector's external provider is not in the ready set. Surface: external OAuth provider configuration; there is no DB/API, runner/sandbox, or old-client version-skew window. Remove the gate only after #28381 records provider readiness for the full inventory and confirms the direct callback can be universal.

## validation

- `pnpm -F @okouai/connectors exec vitest run src/__tests__/app-oauth-callback.test.ts` — 21 passed
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-oauth-start.test.ts` with a migrated temporary PostgreSQL database — 20 passed
- `pnpm -F @okouai/connectors check-types`
- `pnpm -F api check-types`
- `pnpm -F @okouai/connectors lint`
- `pnpm -F api lint` — passed with existing repository warnings
- targeted Prettier check and `git diff --check`

The full local Vitest suite and dev server were not run, per the issue scope.

Closes #28402
Refs #28381
