### PR TITLE
feat(connectors): enable direct okou oauth callback for cloudflare

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
@@ -32,6 +32,8 @@ const OKOU_API_ORIGIN = "https://api.okou.ai";
 const WEB_ORIGIN = "https://www.vm0.ai";
 const LOCAL_ORIGIN = "http://localhost:3000";
 const LOCAL_WEB_ORIGIN = "https://www.vm0.ai:8443";
+const CLOUDFLARE_OAUTH_TOKEN_URL = "https://dash.cloudflare.com/oauth2/token";
+const CLOUDFLARE_USERINFO_URL = "https://dash.cloudflare.com/oauth2/userinfo";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_OPENID_USERINFO_URL =
   "https://openidconnect.googleapis.com/v1/userinfo";
@@ -492,13 +494,76 @@ describe("POST /api/zero/connectors/:connectorSlug/oauth/start", () => {
     await rejectProviderAuthorization(authorizationUrl);
   });
 
-  it("moves api-origin callbacks to the App once the connector is enabled", async () => {
-    mockEnv("APP_URL", "https://app.vm0.test");
+  it("uses the direct Okou App callback for Cloudflare and reuses its exact redirect URI", async () => {
+    const tokenBodies: URLSearchParams[] = [];
+    server.use(
+      http.post(CLOUDFLARE_OAUTH_TOKEN_URL, async ({ request }) => {
+        tokenBodies.push(new URLSearchParams(await request.text()));
+        return HttpResponse.json({
+          access_token: "cloudflare-test-token",
+          refresh_token: "cloudflare-refresh-token",
+          expires_in: 3600,
+          scope: "offline_access",
+        });
+      }),
+      http.get(CLOUDFLARE_USERINFO_URL, () => {
+        return HttpResponse.json({
+          sub: "cloudflare-user-123",
+          email: "cloudflare@example.test",
+          name: "Cloudflare Test User",
+        });
+      }),
+    );
+    mockEnv("APP_URL", "https://app.vm0.ai");
     mockAuthenticatedSession();
 
     const response = await requestOauthStart("cloudflare", {
       headers: authHeaders(),
-      origin: WEB_ORIGIN,
+      origin: OKOU_API_ORIGIN,
+      callbackTarget: "app",
+    });
+
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    expect(`${authorizationUrl.origin}${authorizationUrl.pathname}`).toBe(
+      "https://dash.cloudflare.com/oauth2/auth",
+    );
+    expect(authorizationUrl.searchParams.get("client_id")).toBe(
+      "cloudflare-test-client-id",
+    );
+    const redirectUri = authorizationUrl.searchParams.get("redirect_uri");
+    expect(redirectUri).toBe(
+      "https://app.okou.ai/connectors/cloudflare/callback",
+    );
+    expectCloudflareAuthorizationScopes(authorizationUrl);
+    const state = expectOkouOauthState(authorizationUrl);
+
+    const app = createApp({ signal: context.signal, routes: TEST_APP_ROUTES });
+    const callback = await app.request(
+      `${OKOU_API_ORIGIN}/api/connectors/cloudflare/callback?${new URLSearchParams(
+        {
+          code: "cloudflare-authorization-code",
+          state,
+        },
+      )}`,
+      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+    );
+
+    expect(callback.status).toBe(307);
+    const callbackLocation = new URL(callback.headers.get("location") ?? "");
+    expect(callbackLocation.origin).toBe("https://app.okou.ai");
+    expect(callbackLocation.pathname).toBe("/connector/success");
+    expect(tokenBodies).toHaveLength(1);
+    expect(tokenBodies[0]?.get("redirect_uri")).toBe(redirectUri);
+  });
+
+  it("keeps the VM0 App callback for Cloudflare", async () => {
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    mockAuthenticatedSession();
+
+    const response = await requestOauthStart("cloudflare", {
+      headers: authHeaders(),
+      origin: API_ORIGIN,
       callbackTarget: "app",
     });
 
@@ -511,10 +576,28 @@ describe("POST /api/zero/connectors/:connectorSlug/oauth/start", () => {
       "cloudflare-test-client-id",
     );
     expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
-      "https://app.vm0.test/connectors/cloudflare/callback",
+      "https://app.vm0.ai/connectors/cloudflare/callback",
     );
     expectCloudflareAuthorizationScopes(authorizationUrl);
     expectOauthState(authorizationUrl);
+    await rejectProviderAuthorization(authorizationUrl);
+  });
+
+  it("keeps an omitted Cloudflare callback target on the existing API callback", async () => {
+    mockAuthenticatedSession();
+
+    const response = await requestOauthStart("cloudflare", {
+      headers: authHeaders(),
+      origin: OKOU_API_ORIGIN,
+    });
+
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      `${API_ORIGIN}/api/connectors/cloudflare/callback`,
+    );
+    expectCloudflareAuthorizationScopes(authorizationUrl);
+    expectOkouOauthState(authorizationUrl);
     await rejectProviderAuthorization(authorizationUrl);
   });
 

--- a/turbo/packages/connectors/src/__tests__/app-oauth-callback.test.ts
+++ b/turbo/packages/connectors/src/__tests__/app-oauth-callback.test.ts
@@ -4,6 +4,7 @@ import { getConnectorAuthProviderRegistrationCapabilities } from "../auth-provid
 import { isConnectorDirectOkouOauthCallbackReady } from "../app-oauth-callback";
 
 const DIRECT_OKOU_READY_CONNECTORS = [
+  "cloudflare",
   "gmail",
   "google-ads",
   "google-analytics",

--- a/turbo/packages/connectors/src/app-oauth-callback.ts
+++ b/turbo/packages/connectors/src/app-oauth-callback.ts
@@ -8,6 +8,7 @@ const LEGACY_CALLBACK_CONNECTOR_SLUGS: ReadonlySet<string> = new Set(["slack"]);
 // every provider is ready, unlisted connectors must keep their VM0 App callback.
 const DIRECT_OKOU_OAUTH_CALLBACK_READY_CONNECTOR_SLUGS: ReadonlySet<string> =
   new Set([
+    "cloudflare",
     "gmail",
     "google-ads",
     "google-analytics",


### PR DESCRIPTION
## summary

- add only `cloudflare` to the direct Okou OAuth callback readiness set introduced by #28408
- verify trusted Okou App starts use `https://app.okou.ai/connectors/cloudflare/callback`
- preserve the VM0 App callback and omitted-target API callback while proving token exchange reuses the exact persisted redirect URI
- extend the exact readiness-set regression from the prior 17 connectors to those 17 plus Cloudflare

## dependency and rebase

- #28408 merged to `main` as `5beedda00ed8e28df54f293b0190fb7592756f73`
- rebased onto the latest `main` at `1e4bdf3432ab0e27ae70da59abacdf4d74c14b60`
- final diff is one commit across three files and contains only the Cloudflare readiness increment and focused regressions

## safety

- no provider-console, credential, scope, CORS, or connector configuration changes
- no changes to Slack, Teams, Feishu, OpenID, device-auth, or custom connector flows
- no migration, callback UI, or generic callback/state redesign

## validation

- `git diff --check`
- actual incremental diff reviewed against #28412: three files, only Cloudflare readiness and focused regressions
- Prettier 3.8.1 formatting was applied to the focused route test; repository dependency installation and dependency-based local lint, type checks, and tests were delegated to PR CI at the user's direction because npm registry access was unavailable in the implementation run
- all 94 PR checks on `62af93db556a084ba694cbe799d700e848e775a9` passed, including format, ESLint, Knip, type checks, all API and app test shards, connectors tests, security gates, runner E2E, and Playwright E2E
- no full local Vitest suite or dev server was run

## rollout

Production E2E verification remains pending until the normal release reaches production. After release, verify both the direct Okou Cloudflare flow and the retained VM0 Cloudflare flow complete successfully.

Closes #28412
Depends on #28408
Refs #28381
