### PR TITLE
feat(connectors): enable direct okou oauth callback for notion

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
@@ -37,6 +37,7 @@ const CLOUDFLARE_USERINFO_URL = "https://dash.cloudflare.com/oauth2/userinfo";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_OPENID_USERINFO_URL =
   "https://openidconnect.googleapis.com/v1/userinfo";
+const NOTION_OAUTH_TOKEN_URL = "https://api.notion.com/v1/oauth/token";
 const AIRTABLE_OAUTH_TOKEN_URL = "https://airtable.com/oauth2/v1/token";
 const AIRTABLE_WHOAMI_URL = "https://api.airtable.com/v0/meta/whoami";
 const AUTH_REQUEST_USER_ID_PREFIX = "user_zero_connectors_oauth_start_";
@@ -473,6 +474,104 @@ describe("POST /api/zero/connectors/:connectorSlug/oauth/start", () => {
     expect(callbackLocation.pathname).toBe("/connector/success");
     expect(tokenBodies).toHaveLength(1);
     expect(tokenBodies[0]?.get("redirect_uri")).toBe(redirectUri);
+  });
+
+  it("uses the direct Okou App callback for Notion and reuses its exact redirect URI", async () => {
+    const tokenBodies: unknown[] = [];
+    server.use(
+      http.post(NOTION_OAUTH_TOKEN_URL, async ({ request }) => {
+        tokenBodies.push(await request.json());
+        return HttpResponse.json({
+          access_token: "notion-test-token",
+          refresh_token: "notion-refresh-token",
+          expires_in: 3600,
+          owner: {
+            user: {
+              id: "notion-user-123",
+              name: "Notion Test User",
+              person: { email: "notion@example.test" },
+            },
+          },
+        });
+      }),
+    );
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    mockAuthenticatedSession();
+
+    const response = await requestOauthStart("notion", {
+      callbackTarget: "app",
+      headers: authHeaders(),
+      origin: OKOU_API_ORIGIN,
+    });
+
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    expect(`${authorizationUrl.origin}${authorizationUrl.pathname}`).toBe(
+      "https://api.notion.com/v1/oauth/authorize",
+    );
+    expect(authorizationUrl.searchParams.get("client_id")).toBe(
+      "notion-test-client-id",
+    );
+    const redirectUri = authorizationUrl.searchParams.get("redirect_uri");
+    expect(redirectUri).toBe("https://app.okou.ai/connectors/notion/callback");
+    const state = expectOkouOauthState(authorizationUrl);
+
+    const app = createApp({ signal: context.signal, routes: TEST_APP_ROUTES });
+    const callback = await app.request(
+      `${OKOU_API_ORIGIN}/api/connectors/notion/callback?${new URLSearchParams({
+        code: "notion-authorization-code",
+        state,
+      })}`,
+      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+    );
+
+    expect(callback.status).toBe(307);
+    const callbackLocation = new URL(callback.headers.get("location") ?? "");
+    expect(callbackLocation.origin).toBe("https://app.okou.ai");
+    expect(callbackLocation.pathname).toBe("/connector/success");
+    expect(tokenBodies).toStrictEqual([
+      {
+        grant_type: "authorization_code",
+        code: "notion-authorization-code",
+        redirect_uri: redirectUri,
+      },
+    ]);
+  });
+
+  it("keeps the VM0 App callback for Notion", async () => {
+    mockEnv("APP_URL", "https://app.vm0.ai");
+    mockAuthenticatedSession();
+
+    const response = await requestOauthStart("notion", {
+      callbackTarget: "app",
+      headers: authHeaders(),
+      origin: API_ORIGIN,
+    });
+
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      "https://app.vm0.ai/connectors/notion/callback",
+    );
+    expectOauthState(authorizationUrl);
+    await rejectProviderAuthorization(authorizationUrl);
+  });
+
+  it("keeps an omitted Notion callback target on the existing Web callback", async () => {
+    mockAuthenticatedSession();
+
+    const response = await requestOauthStart("notion", {
+      headers: authHeaders(),
+      origin: OKOU_API_ORIGIN,
+    });
+
+    expect(response.status).toBe(200);
+    const authorizationUrl = await authorizationUrlFromResponse(response);
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      `${WEB_ORIGIN}/api/connectors/notion/callback`,
+    );
+    expectOkouOauthState(authorizationUrl);
+    await rejectProviderAuthorization(authorizationUrl);
   });
 
   it("keeps an Okou start on the VM0 App callback when the provider is not ready", async () => {

--- a/turbo/packages/connectors/src/__tests__/app-oauth-callback.test.ts
+++ b/turbo/packages/connectors/src/__tests__/app-oauth-callback.test.ts
@@ -19,6 +19,7 @@ const DIRECT_OKOU_READY_CONNECTORS = [
   "google-search-console",
   "google-sheets",
   "microsoft-365",
+  "notion",
   "outlook-calendar",
   "outlook-mail",
   "youtube",

--- a/turbo/packages/connectors/src/app-oauth-callback.ts
+++ b/turbo/packages/connectors/src/app-oauth-callback.ts
@@ -23,6 +23,7 @@ const DIRECT_OKOU_OAUTH_CALLBACK_READY_CONNECTOR_SLUGS: ReadonlySet<string> =
     "google-search-console",
     "google-sheets",
     "microsoft-365",
+    "notion",
     "outlook-calendar",
     "outlook-mail",
     "youtube",


### PR DESCRIPTION
## summary

- add only `notion` to the direct Okou OAuth callback readiness set introduced by #28408
- verify trusted Okou App starts use `https://app.okou.ai/connectors/notion/callback`
- preserve the VM0 App callback and omitted-target Web/API callback behavior
- prove the exact redirect URI selected at authorization start is persisted and reused unchanged as the JSON `redirect_uri` during Notion token exchange
- extend the exact readiness-set regression without enabling another connector

## dependency and rebase

- #28408 merged to `main` as `5beedda00ed8e28df54f293b0190fb7592756f73`
- #28412 / #28424 merged next as `0a63071d1a98f7d2e52c89af64185123da81fdaa`
- this branch was rebased after both dependencies onto current `main` at `f4adc23a09`
- the rebased diff preserves the Cloudflare readiness entry and focused regressions
- the final diff contains three files and only the Notion readiness increment plus focused regressions

## safety

- no provider-console, credential, capability, installation-scope, Marketplace, or connector configuration changes
- no changes to generic callback resolution or persisted OAuth state
- no changes to Slack, Teams, Feishu, OpenID, device-auth, or custom connector flows
- no migration, callback UI, or unrelated refactor

## validation

- `npx --yes pnpm@10.33.4 install --frozen-lockfile`
- `npx --yes pnpm@10.33.4 format`
- `npx --yes pnpm@10.33.4 turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks passed)
- `npx --yes pnpm@10.33.4 knip`
- `npx --yes pnpm@10.33.4 turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` (12/12 tasks passed)
- `npx --yes pnpm@10.33.4 --filter @okouai/app run check-types`
- `npx --yes pnpm@10.33.4 --filter api run check-types`
- `npx --yes pnpm@10.33.4 --filter @okouai/connectors exec vitest run src/__tests__/app-oauth-callback.test.ts` (23 tests passed)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test npx --yes pnpm@10.33.4 --filter api exec vitest run src/signals/routes/__tests__/connectors-oauth-start.test.ts` (25 tests passed)
- exact Prettier 3.8.1 check on all three changed files
- `git diff --check`
- actual rebased diff reviewed against every #28423 acceptance criterion: three files, 101 additions, only Notion readiness and focused regressions
- no full local Vitest suite or dev server was run

## rollout

Production E2E verification remains pending until the normal release reaches production. After release:

1. verify an Okou Notion OAuth start uses `https://app.okou.ai/connectors/notion/callback` and completes successfully
2. verify a VM0 Notion OAuth start still uses `https://app.vm0.ai/connectors/notion/callback` and completes successfully

Closes #28423
Refs #28408
Refs #28412
Refs #28424
Refs #28381
