### PR TITLE
perf(api): remove speculative queue scan lock

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -11115,7 +11115,7 @@ describe("CHAT-02: shared user message queue", () => {
     await cancelChatRun(actor, promoted.runId);
   }, 90_000);
 
-  it("serializes a terminal drain against an idle queue-first send", async () => {
+  it("serializes a terminal drain against an inline queue-first send", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     if (!actor.orgId) {
       throw new Error("Expected an org-scoped actor for queue serialization");
@@ -11127,14 +11127,6 @@ describe("CHAT-02: shared user message queue", () => {
       prompt: "terminal drain race anchor",
     });
     const anchorClaim = await claimChatRun(runnerGroup, anchor.runId);
-
-    // Hold the real org admission lock after the inline send has persisted its
-    // queue-first row. This lets both the inline path and terminal callback
-    // drain reach the final atomic launch boundary before either can claim it.
-    const admissionLock = await holdOrgAdmissionLockFixture({
-      orgId: actor.orgId,
-      signal: context.signal,
-    });
 
     await webhooks.requestAgentEvents(
       {
@@ -11156,6 +11148,24 @@ describe("CHAT-02: shared user message queue", () => {
     );
     await flushWaitUntilForTest();
 
+    const terminalPrompt = "terminal drain owns the queue head";
+    const terminalMessageId = randomUUID();
+    const queued = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: anchor.threadId,
+        prompt: terminalPrompt,
+        clientEventId: terminalMessageId,
+      },
+      [201],
+    );
+    expect(queued.body).toMatchObject({ runId: null });
+
+    const admissionLock = await holdOrgAdmissionLockFixture({
+      orgId: actor.orgId,
+      signal: context.signal,
+    });
     onTestFinished(async () => {
       admissionLock.release();
       await admissionLock.done;
@@ -11164,20 +11174,19 @@ describe("CHAT-02: shared user message queue", () => {
     await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
       lastEventSequence: 0,
     });
-    // Completion starts both the thread-message drain and the org run-queue
-    // drain concurrently. Wait until either has reached admission, then let
-    // the inline send persist its queue-first row and join the same boundary.
-    await expect.poll(admissionLock.waiterCount).toBeGreaterThanOrEqual(1);
+    // The terminal drain owns the existing queue head and reaches final run
+    // admission before the inline send joins the same boundary.
+    await expect.poll(admissionLock.waiterCount).toBe(1);
 
-    const prompt = "terminal drain and inline send share one claim";
-    const messageId = randomUUID();
+    const inlinePrompt = "inline send waits behind the terminal drain";
+    const inlineMessageId = randomUUID();
     const send = chat.requestSendEvent(
       actor,
       {
         agentId,
         threadId: anchor.threadId,
-        prompt,
-        clientEventId: messageId,
+        prompt: inlinePrompt,
+        clientEventId: inlineMessageId,
       },
       [201],
     );
@@ -11185,56 +11194,65 @@ describe("CHAT-02: shared user message queue", () => {
       .poll(async () => {
         const messages = await chat.listThreadEvents(actor, anchor.threadId);
         return messages.events.some((message) => {
-          return message.id === messageId;
+          return message.id === inlineMessageId;
         });
       })
       .toBe(true);
-    // One terminal drain is already pinned above. The persisted inline send
-    // adds the second contender; sibling completion work may be serialized
-    // before this boundary and is not required for the single-claim race.
-    await expect
-      .poll(admissionLock.waiterCount, { timeout: 10_000 })
-      .toBeGreaterThanOrEqual(2);
+    await expect.poll(admissionLock.waiterCount).toBe(2);
     admissionLock.release();
 
     const sent = await send;
     await admissionLock.done;
     await flushWaitUntilForTest();
-    if (sent.status !== 201 || sent.body.runId === null) {
-      throw new Error("Expected one race winner to own the queued message");
-    }
+    expect(sent.body).toMatchObject({ runId: null });
 
     const messages = await chat.listThreadEvents(actor, anchor.threadId);
     const claimed = userMessages(messages.events).filter((message) => {
       return (
-        message.revokesEventId === messageId && message.runId !== undefined
+        message.revokesEventId === terminalMessageId &&
+        message.runId !== undefined
       );
     });
     expect(claimed).toHaveLength(1);
-    expect(claimed[0]?.runId).toBe(sent.body.runId);
-    const queued = userMessages(messages.events).find((message) => {
-      return message.id === messageId;
-    });
-    if (!queued) {
-      throw new Error("Expected the queued message");
+    const claimedRunId = claimed[0]?.runId;
+    if (!claimedRunId) {
+      throw new Error("Expected the terminal drain to own the queue head");
     }
-    expect(queued.runId).toBeUndefined();
+    const inline = userMessages(messages.events).find((message) => {
+      return message.id === inlineMessageId;
+    });
+    if (!inline) {
+      throw new Error("Expected the inline queued message");
+    }
+    expect(inline.runId).toBeUndefined();
 
     const runList = await api.listAgentRuns(actor, {
       status: "queued,pending,running,completed,failed,timeout,cancelled",
       limit: 100,
     });
     const candidates = runList.runs.filter((run) => {
-      return run.prompt === prompt;
+      return run.prompt === terminalPrompt || run.prompt === inlinePrompt;
     });
     expect(candidates).toStrictEqual([
       expect.objectContaining({
-        id: sent.body.runId,
+        id: claimedRunId,
+        prompt: terminalPrompt,
         status: expect.stringMatching(/^(queued|pending|running)$/),
       }),
     ]);
 
-    await cancelChatRun(actor, sent.body.runId);
+    const recalled = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: anchor.threadId,
+        revokesEventId: inlineMessageId,
+        clientEventId: randomUUID(),
+      },
+      [201],
+    );
+    expect(recalled.body).toMatchObject({ runId: null });
+    await cancelChatRun(actor, claimedRunId);
   }, 90_000);
 
   it("preserves an appended claim when recall races the queue drain", async () => {
@@ -11263,9 +11281,9 @@ describe("CHAT-02: shared user message queue", () => {
     );
     expect(queued.body).toMatchObject({ runId: null });
 
-    // Pin both completion-triggered drains at run admission, then make the
-    // claim and recall queue behind the exact message row in a test-owned
-    // order.
+    // Pin the completion-triggered queue-first drain at run admission, then
+    // make the claim and recall queue behind the exact message row in a
+    // test-owned order.
     const admissionLock = await holdOrgAdmissionLockFixture({
       orgId: actor.orgId,
       signal: context.signal,
@@ -11288,7 +11306,7 @@ describe("CHAT-02: shared user message queue", () => {
     await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
       lastEventSequence: 0,
     });
-    await expect.poll(admissionLock.waiterCount).toBe(2);
+    await expect.poll(admissionLock.waiterCount).toBe(1);
     admissionLock.release();
     await admissionLock.done;
     await expect.poll(eventQueueLock.directBlockedWaiterCount).toBe(1);
@@ -11385,8 +11403,8 @@ describe("CHAT-02: shared user message queue", () => {
       signal: context.signal,
     });
 
-    // Stage the completion-triggered drains at org admission, then let recall
-    // append before either drain can claim the queued message.
+    // Stage the completion-triggered queue-first drain at org admission, then
+    // let recall append before it can claim the queued message.
     onTestFinished(async () => {
       admissionLock.release();
       await admissionLock.done;
@@ -11398,7 +11416,7 @@ describe("CHAT-02: shared user message queue", () => {
     await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
       lastEventSequence: 0,
     });
-    await expect.poll(admissionLock.waiterCount).toBe(2);
+    await expect.poll(admissionLock.waiterCount).toBe(1);
 
     const recalled = await chat.requestSendEvent(
       actor,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -6248,6 +6248,49 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     await api.requestCancelRun(actor, second.runId, [200]);
   });
 
+  it("does not serialize an empty org queue drain with run admission", async () => {
+    const api = createRunsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    if (!actor.orgId) {
+      throw new Error("Expected an organization for queue drain admission");
+    }
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "cancel without an organization queue entry",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(run.status).toBe("pending");
+
+    const admissionLockRequest = holdOrgAdmissionLock(context, actor.orgId);
+    onTestFinished(async () => {
+      const cleanupResults = await Promise.allSettled([
+        releaseOrgAdmissionLock(context),
+        admissionLockRequest,
+      ]);
+      const cleanupFailure = cleanupResults.find((result) => {
+        return result.status === "rejected";
+      });
+      if (cleanupFailure?.status === "rejected") {
+        throw cleanupFailure.reason;
+      }
+    });
+    await expect
+      .poll(async () => {
+        return (await readOrgAdmissionLockState(context)).held;
+      })
+      .toBe(true);
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+    await flushWaitUntilForTest();
+
+    await expect(readOrgAdmissionLockState(context)).resolves.toStrictEqual({
+      held: true,
+      waiting: false,
+    });
+    await releaseOrgAdmissionLock(context);
+    await admissionLockRequest;
+  });
+
   it("queues runs over the concurrency limit and promotes them after cancellation", async () => {
     const api = createRunsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/services/run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/run-queue.service.ts
@@ -220,28 +220,24 @@ async function loadDrainCandidates(
   db: Db,
   orgId: string,
 ): Promise<readonly QueueCandidate[]> {
-  return await db.transaction(async (tx) => {
-    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${orgId}))`);
+  const concurrency = await effectiveOrgConcurrencyState(db, orgId);
+  if (concurrency.activeRunCount >= concurrency.limit) {
+    return [];
+  }
 
-    const concurrency = await effectiveOrgConcurrencyState(tx, orgId);
-    if (concurrency.activeRunCount >= concurrency.limit) {
-      return [];
-    }
-
-    return await tx
-      .select({
-        runId: agentRunQueue.runId,
-        userId: agentRunQueue.userId,
-        createdAt: agentRunQueue.createdAt,
-        encryptedParams: agentRunQueue.encryptedParams,
-        runStatus: agentRuns.status,
-        chatThreadId: agentRuns.chatThreadId,
-      })
-      .from(agentRunQueue)
-      .leftJoin(agentRuns, eq(agentRunQueue.runId, agentRuns.id))
-      .where(eq(agentRunQueue.orgId, orgId))
-      .orderBy(agentRunQueue.createdAt);
-  });
+  return await db
+    .select({
+      runId: agentRunQueue.runId,
+      userId: agentRunQueue.userId,
+      createdAt: agentRunQueue.createdAt,
+      encryptedParams: agentRunQueue.encryptedParams,
+      runStatus: agentRuns.status,
+      chatThreadId: agentRuns.chatThreadId,
+    })
+    .from(agentRunQueue)
+    .leftJoin(agentRuns, eq(agentRunQueue.runId, agentRuns.id))
+    .where(eq(agentRunQueue.orgId, orgId))
+    .orderBy(agentRunQueue.createdAt);
 }
 
 async function promoteQueuedCandidate(
@@ -422,9 +418,9 @@ async function promoteQueuedCandidateWithSideEffects(
  * can claim it. A queued run without that payload violates the owning writer's
  * invariant and fails before any state transition.
  *
- * Acquires `pg_advisory_xact_lock(hashtext(orgId))` — same hash key as
- * web's `drainOrgQueue` so the two backends serialize correctly on the
- * same org during rollout.
+ * Candidate discovery is an unlocked snapshot. Final promotion acquires
+ * `pg_advisory_xact_lock(hashtext(orgId))` and revalidates concurrency and
+ * queue ownership before changing state.
  *
  * Returns the number of runs transitioned (0 if queue empty or
  * concurrency full).


### PR DESCRIPTION
## Summary

- make organization queue candidate discovery an unlocked read path
- keep final queued-run promotion as the authoritative organization-locked concurrency and state transition
- cover empty-queue cancellation through the public API while the real PostgreSQL admission key is held
- update existing chat queue race tests to synchronize only on authoritative admission contenders

## Problem

Every completion, cancellation, or recovery drain currently joins `pg_advisory_xact_lock(hashtext(orgId))` once to scan candidates, including when the organization queue is empty. If a candidate exists, the code releases that lock before payload decryption and later reacquires the same key for promotion, where it repeats concurrency, run-status, and queue ownership validation.

The first lock therefore does not reserve capacity or preserve promotion priority, but it adds one speculative participant to the same organization convoy as agent successor launches.

## Change

`loadDrainCandidates()` now performs its existing capacity precheck and ordered candidate read without a transaction or organization advisory lock. The precheck remains a best-effort optimization to avoid unnecessary payload decryption when the organization is already full.

`promoteQueuedCandidate()` is unchanged. It remains the sole authority and continues to:

- acquire the shared organization advisory key;
- reload the effective concurrency limit and active count;
- lock and revalidate the run and queue row;
- atomically transition queued to pending and persist the runner job.

Existing chat queue race tests now count only the final admission contenders that still own serialization. The terminal-versus-inline test stages a real queued head before completion so it continues to exercise an actual two-way claim race without depending on the removed empty organization scan.

This removes one exclusive lock entrant per drain attempt. It does not claim an exact latency reduction because current telemetry cannot attribute queue scan and promotion lock-holder roles.

## Compatibility and risk

- No schema, API contract, persisted payload, Runner protocol, feature switch, or agent-specific admission behavior changes.
- Old API scans may still take the key during rollout; all old/new state-changing launches and promotions keep the same authority and table representation.
- A concurrent launch may consume capacity after the unlocked precheck, causing payload decryption before promotion returns `full`. This race already exists after the current scan transaction releases its lock; final promotion still prevents over-admission.
- Rollback is a code revert with no data cleanup.

## Explicit exclusions

- no durable admission slot or reservation architecture
- no launch critical-section mega-query
- no new lock telemetry or production latency claim
- no weakening of queue-first, billing, concurrency, or durability semantics

## Validation

- `pnpm exec prettier --write apps/api/src/signals/services/run-queue.service.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "does not serialize an empty org queue drain with run admission"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (169 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t "serializes a terminal drain|preserves an appended claim|lets recall win"` (3 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts` (114 passed)
- `pnpm knip`
- pre-commit hook: repository-wide `pnpm check-types` (14 tasks passed)

Closes #28414

Parent objective: #24203
