### PR TITLE
fix(db): align checkpoint storage reference semantics

### DIFF
--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
@@ -114,6 +114,42 @@ const CHECKPOINT_TRANSITION_PARTITIONS = [
 type CheckpointTransitionPartition =
   (typeof CHECKPOINT_TRANSITION_PARTITIONS)[number];
 
+const CHECKPOINT_STORAGE_REFERENCE_REASONS = [
+  "malformedRoot",
+  "malformedMount",
+  "requiredStorageMissing",
+  "optionalStorageMissing",
+  "storageIdentityMismatch",
+  "requiredVersionMissing",
+  "optionalVersionMissing",
+  "crossStorageVersionOwnerMismatch",
+] as const;
+
+export type CheckpointStorageReferenceReason =
+  (typeof CHECKPOINT_STORAGE_REFERENCE_REASONS)[number];
+
+// A hard runtime failure always takes precedence over an accepted optional
+// Storage absence. This order makes each checkpoint's primary reason stable
+// even when different mounts contribute overlapping reasons.
+const CHECKPOINT_STORAGE_REFERENCE_PRIMARY_REASON_PRIORITY = [
+  "malformedRoot",
+  "malformedMount",
+  "requiredStorageMissing",
+  "storageIdentityMismatch",
+  "requiredVersionMissing",
+  "optionalVersionMissing",
+  "crossStorageVersionOwnerMismatch",
+  "optionalStorageMissing",
+] as const satisfies readonly CheckpointStorageReferenceReason[];
+
+const CHECKPOINT_STORAGE_REFERENCE_PRIMARY_PARTITIONS = [
+  "liveCatalogExact",
+  ...CHECKPOINT_STORAGE_REFERENCE_PRIMARY_REASON_PRIORITY,
+] as const;
+
+type CheckpointStorageReferencePrimaryPartition =
+  (typeof CHECKPOINT_STORAGE_REFERENCE_PRIMARY_PARTITIONS)[number];
+
 /** Safe digests of the six #26938-approved compose-only artifact IDs. */
 export const APPROVED_ARTIFACT_MEMBER_DIGESTS = [
   "113ad6becc69859c5d32951a5f1a1f0fa4ba80c0d3db8844aa7d03917265220a",
@@ -505,6 +541,60 @@ const PREFLIGHT_V7_OUTPUT_ALLOWLIST = [
   ),
   ...comparisonOutputPaths("checkpoints.transition.sessionReferenceClosure"),
   ...comparisonOutputPaths("checkpoints.transition.storageReferenceClosure"),
+  ...setOutputPaths(
+    "checkpoints.transition.storageReferences.strictLiveCatalogValid",
+  ),
+  ...setOutputPaths(
+    "checkpoints.transition.storageReferences.strictLiveCatalogInvalid",
+  ),
+  ...setOutputPaths("checkpoints.transition.storageReferences.runtimeValid"),
+  ...setOutputPaths("checkpoints.transition.storageReferences.runtimeInvalid"),
+  ...setOutputPaths(
+    "checkpoints.transition.storageReferences.acceptedOptionalStorageMissing",
+  ),
+  ...setOutputPaths(
+    "checkpoints.transition.storageReferences.overlappingReasons",
+  ),
+  ...CHECKPOINT_STORAGE_REFERENCE_PRIMARY_PARTITIONS.flatMap((partition) => {
+    return setOutputPaths(
+      `checkpoints.transition.storageReferences.primaryPartitions.${partition}`,
+    );
+  }),
+  ...CHECKPOINT_STORAGE_REFERENCE_REASONS.flatMap((reason) => {
+    return setOutputPaths(
+      `checkpoints.transition.storageReferences.reasonMembers.${reason}`,
+    );
+  }),
+  ...comparisonOutputPaths(
+    "checkpoints.transition.storageReferences.primaryCardinalityClosure",
+  ),
+  ...comparisonOutputPaths(
+    "checkpoints.transition.storageReferences.primaryDisjointnessClosure",
+  ),
+  ...comparisonOutputPaths(
+    "checkpoints.transition.storageReferences.primaryUnionClosure",
+  ),
+  ...comparisonOutputPaths(
+    "checkpoints.transition.storageReferences.reasonUnionClosure",
+  ),
+  ...comparisonOutputPaths(
+    "checkpoints.transition.storageReferences.reasonOverlapClosure",
+  ),
+  ...comparisonOutputPaths(
+    "checkpoints.transition.storageReferences.runtimeCardinalityClosure",
+  ),
+  ...comparisonOutputPaths(
+    "checkpoints.transition.storageReferences.runtimeDisjointnessClosure",
+  ),
+  ...comparisonOutputPaths(
+    "checkpoints.transition.storageReferences.runtimeUnionClosure",
+  ),
+  ...comparisonOutputPaths(
+    "checkpoints.transition.storageReferences.runtimeSemanticsClosure",
+  ),
+  ...comparisonOutputPaths(
+    "checkpoints.transition.storageReferences.acceptedOptionalStorageMissingClosure",
+  ),
   ...setOutputPaths("checkpoints.transition.acceptedV6LegacySnapshotEvidence"),
   ...comparisonOutputPaths("checkpoints.transition.legacySnapshotLineage"),
   ...setOutputPaths("checkpoints.transition.legacySnapshotGrowth"),
@@ -563,6 +653,7 @@ export interface CheckpointInventoryRow
   readonly conversationReferenceValid: boolean;
   readonly sessionReferenceValid: boolean;
   readonly storageReferenceValid: boolean;
+  readonly storageReferenceReasons: readonly CheckpointStorageReferenceReason[];
 }
 
 interface CheckpointCoreInventoryRow
@@ -595,6 +686,9 @@ interface StorageReferenceVersionRow extends QueryResultRow {
 export interface CheckpointStorageReferenceValidation {
   readonly checkpointCount: number;
   readonly invalidCheckpointIds: ReadonlySet<string>;
+  readonly reasonCheckpointIds: Readonly<
+    Record<CheckpointStorageReferenceReason, ReadonlySet<string>>
+  >;
   readonly expandedMountCount: number;
 }
 
@@ -1680,6 +1774,265 @@ function classifyRuns(
   };
 }
 
+function classifyCheckpointStorageReferences(
+  rows: readonly CheckpointInventoryRow[],
+) {
+  const primaryMembers = Object.fromEntries(
+    CHECKPOINT_STORAGE_REFERENCE_PRIMARY_PARTITIONS.map((partition) => {
+      return [partition, [] as CheckpointInventoryRow[]] as const;
+    }),
+  ) as Record<
+    CheckpointStorageReferencePrimaryPartition,
+    CheckpointInventoryRow[]
+  >;
+  const reasonMembers = Object.fromEntries(
+    CHECKPOINT_STORAGE_REFERENCE_REASONS.map((reason) => {
+      return [reason, [] as CheckpointInventoryRow[]] as const;
+    }),
+  ) as Record<CheckpointStorageReferenceReason, CheckpointInventoryRow[]>;
+  const strictLiveCatalogValid: CheckpointInventoryRow[] = [];
+  const strictLiveCatalogInvalid: CheckpointInventoryRow[] = [];
+  const runtimeValid: CheckpointInventoryRow[] = [];
+  const runtimeInvalid: CheckpointInventoryRow[] = [];
+  const acceptedOptionalStorageMissing: CheckpointInventoryRow[] = [];
+  const overlappingReasons: CheckpointInventoryRow[] = [];
+
+  for (const row of rows) {
+    const reasons = new Set(row.storageReferenceReasons);
+    for (const reason of CHECKPOINT_STORAGE_REFERENCE_REASONS) {
+      if (reasons.has(reason)) reasonMembers[reason].push(row);
+    }
+    if (reasons.size > 1) overlappingReasons.push(row);
+    if (reasons.size === 0) {
+      strictLiveCatalogValid.push(row);
+      primaryMembers.liveCatalogExact.push(row);
+    } else {
+      strictLiveCatalogInvalid.push(row);
+      const primaryReason =
+        CHECKPOINT_STORAGE_REFERENCE_PRIMARY_REASON_PRIORITY.find((reason) => {
+          return reasons.has(reason);
+        });
+      if (primaryReason === undefined) {
+        throw new SanitizedPreflightError("probe.inventory");
+      }
+      primaryMembers[primaryReason].push(row);
+    }
+
+    const runtimeReferenceValid = [...reasons].every((reason) => {
+      return reason === "optionalStorageMissing";
+    });
+    if (runtimeReferenceValid) {
+      runtimeValid.push(row);
+      if (reasons.size > 0) acceptedOptionalStorageMissing.push(row);
+    } else {
+      runtimeInvalid.push(row);
+    }
+  }
+
+  const checkpointIds = rows.map((row) => {
+    return row.id;
+  });
+  const primaryAssignments =
+    CHECKPOINT_STORAGE_REFERENCE_PRIMARY_PARTITIONS.flatMap((partition) => {
+      return primaryMembers[partition].map((row) => {
+        return row.id;
+      });
+    });
+  const primaryAssignmentCounts = new Map<string, number>();
+  for (const checkpointId of primaryAssignments) {
+    increment(primaryAssignmentCounts, checkpointId);
+  }
+  const duplicatePrimaryAssignments = [...primaryAssignmentCounts]
+    .filter(([, count]) => {
+      return count > 1;
+    })
+    .map(([checkpointId]) => {
+      return checkpointId;
+    });
+  const reasonUnion = [
+    ...new Set(
+      CHECKPOINT_STORAGE_REFERENCE_REASONS.flatMap((reason) => {
+        return reasonMembers[reason].map((row) => {
+          return row.id;
+        });
+      }),
+    ),
+  ];
+  const reasonAssignmentCounts = new Map<string, number>();
+  for (const reason of CHECKPOINT_STORAGE_REFERENCE_REASONS) {
+    for (const row of reasonMembers[reason]) {
+      increment(reasonAssignmentCounts, row.id);
+    }
+  }
+  const overlappingReasonAssignments = [...reasonAssignmentCounts]
+    .filter(([, count]) => {
+      return count > 1;
+    })
+    .map(([checkpointId]) => {
+      return checkpointId;
+    });
+  const runtimeAssignments = [...runtimeValid, ...runtimeInvalid].map((row) => {
+    return row.id;
+  });
+  const runtimeAssignmentCounts = new Map<string, number>();
+  for (const checkpointId of runtimeAssignments) {
+    increment(runtimeAssignmentCounts, checkpointId);
+  }
+  const duplicateRuntimeAssignments = [...runtimeAssignmentCounts]
+    .filter(([, count]) => {
+      return count > 1;
+    })
+    .map(([checkpointId]) => {
+      return checkpointId;
+    });
+  const actualRuntimeValidIds = rows
+    .filter((row) => {
+      return row.storageReferenceValid;
+    })
+    .map((row) => {
+      return row.id;
+    });
+  const acceptedOptionalExpected = runtimeValid
+    .filter((row) => {
+      return row.storageReferenceReasons.length > 0;
+    })
+    .map((row) => {
+      return row.id;
+    });
+
+  const primaryCardinalityClosure = cardinalityComparison(
+    "checkpoints:transition:storage-references:primary-cardinality-closure:v7",
+    checkpointIds,
+    primaryAssignments,
+  );
+  const primaryDisjointnessClosure = comparison(
+    "checkpoints:transition:storage-references:primary-disjointness-closure:v7",
+    [],
+    duplicatePrimaryAssignments,
+  );
+  const primaryUnionClosure = comparison(
+    "checkpoints:transition:storage-references:primary-union-closure:v7",
+    checkpointIds,
+    primaryAssignments,
+  );
+  const reasonUnionClosure = comparison(
+    "checkpoints:transition:storage-references:reason-union-closure:v7",
+    strictLiveCatalogInvalid.map((row) => {
+      return row.id;
+    }),
+    reasonUnion,
+  );
+  const reasonOverlapClosure = comparison(
+    "checkpoints:transition:storage-references:reason-overlap-closure:v7",
+    overlappingReasons.map((row) => {
+      return row.id;
+    }),
+    overlappingReasonAssignments,
+  );
+  const runtimeCardinalityClosure = cardinalityComparison(
+    "checkpoints:transition:storage-references:runtime-cardinality-closure:v7",
+    checkpointIds,
+    runtimeAssignments,
+  );
+  const runtimeDisjointnessClosure = comparison(
+    "checkpoints:transition:storage-references:runtime-disjointness-closure:v7",
+    [],
+    duplicateRuntimeAssignments,
+  );
+  const runtimeUnionClosure = comparison(
+    "checkpoints:transition:storage-references:runtime-union-closure:v7",
+    checkpointIds,
+    runtimeAssignments,
+  );
+  const runtimeSemanticsClosure = comparison(
+    "checkpoints:transition:storage-references:runtime-semantics-closure:v7",
+    runtimeValid.map((row) => {
+      return row.id;
+    }),
+    actualRuntimeValidIds,
+  );
+  const acceptedOptionalStorageMissingClosure = comparison(
+    "checkpoints:transition:storage-references:accepted-optional-storage-missing-closure:v7",
+    acceptedOptionalExpected,
+    acceptedOptionalStorageMissing.map((row) => {
+      return row.id;
+    }),
+  );
+
+  return {
+    output: {
+      strictLiveCatalogValid: recordSet(
+        "checkpoints:transition:storage-references:strict-live-catalog-valid:v7",
+        strictLiveCatalogValid,
+      ),
+      strictLiveCatalogInvalid: recordSet(
+        "checkpoints:transition:storage-references:strict-live-catalog-invalid:v7",
+        strictLiveCatalogInvalid,
+      ),
+      runtimeValid: recordSet(
+        "checkpoints:transition:storage-references:runtime-valid:v7",
+        runtimeValid,
+      ),
+      runtimeInvalid: recordSet(
+        "checkpoints:transition:storage-references:runtime-invalid:v7",
+        runtimeInvalid,
+      ),
+      acceptedOptionalStorageMissing: recordSet(
+        "checkpoints:transition:storage-references:accepted-optional-storage-missing:v7",
+        acceptedOptionalStorageMissing,
+      ),
+      overlappingReasons: recordSet(
+        "checkpoints:transition:storage-references:overlapping-reasons:v7",
+        overlappingReasons,
+      ),
+      primaryPartitions: Object.fromEntries(
+        CHECKPOINT_STORAGE_REFERENCE_PRIMARY_PARTITIONS.map((partition) => {
+          return [
+            partition,
+            recordSet(
+              `checkpoints:transition:storage-references:primary:${partition}:v7`,
+              primaryMembers[partition],
+            ),
+          ];
+        }),
+      ) as Record<CheckpointStorageReferencePrimaryPartition, SetFingerprint>,
+      reasonMembers: Object.fromEntries(
+        CHECKPOINT_STORAGE_REFERENCE_REASONS.map((reason) => {
+          return [
+            reason,
+            recordSet(
+              `checkpoints:transition:storage-references:reason:${reason}:v7`,
+              reasonMembers[reason],
+            ),
+          ];
+        }),
+      ) as Record<CheckpointStorageReferenceReason, SetFingerprint>,
+      primaryCardinalityClosure,
+      primaryDisjointnessClosure,
+      primaryUnionClosure,
+      reasonUnionClosure,
+      reasonOverlapClosure,
+      runtimeCardinalityClosure,
+      runtimeDisjointnessClosure,
+      runtimeUnionClosure,
+      runtimeSemanticsClosure,
+      acceptedOptionalStorageMissingClosure,
+    },
+    closures: [
+      primaryCardinalityClosure,
+      primaryDisjointnessClosure,
+      primaryUnionClosure,
+      reasonUnionClosure,
+      reasonOverlapClosure,
+      runtimeCardinalityClosure,
+      runtimeDisjointnessClosure,
+      runtimeUnionClosure,
+      runtimeSemanticsClosure,
+      acceptedOptionalStorageMissingClosure,
+    ],
+  };
+}
+
 function classifyCheckpoints(
   rows: readonly CheckpointInventoryRow[],
   versionIds: ReadonlySet<string>,
@@ -1820,6 +2173,7 @@ function classifyCheckpoints(
     checkpointIds,
     referenceMembers("storageReferenceValid"),
   );
+  const storageReferences = classifyCheckpointStorageReferences(rows);
   const referencesValid = (row: CheckpointInventoryRow): boolean => {
     return (
       row.runReferenceValid &&
@@ -1862,6 +2216,7 @@ function classifyCheckpoints(
     partitionCardinalityClosure,
     partitionDisjointnessClosure,
     partitionUnionClosure,
+    ...storageReferences.closures,
   ];
   if (
     closureResults.some((closure) => {
@@ -1945,6 +2300,7 @@ function classifyCheckpoints(
       conversationReferenceClosure,
       sessionReferenceClosure,
       storageReferenceClosure,
+      storageReferences: storageReferences.output,
       acceptedV6LegacySnapshotEvidence: ACCEPTED_V6_CHECKPOINT_LINEAGE_EVIDENCE,
       legacySnapshotLineage,
       legacySnapshotGrowth: recordSet(
@@ -2279,12 +2635,6 @@ interface ValidCheckpointStorageMount {
   readonly missingRootPolicy?: "fail" | "preserveParentVersion";
 }
 
-interface StorageReferenceIdentity {
-  readonly orgId: string;
-  readonly userId: string;
-  readonly name: string;
-}
-
 function isJsonObject(
   value: unknown,
 ): value is Readonly<Record<string, unknown>> {
@@ -2332,19 +2682,50 @@ function isValidCheckpointStorageMount(
   );
 }
 
-function hasValidCheckpointStorageReferences(
+function storageReferenceLookupKey(mount: ValidCheckpointStorageMount): string {
+  return frameTuple([mount.orgId, mount.userId, mount.name]);
+}
+
+function checkpointStorageMountReferenceReason(
   mount: ValidCheckpointStorageMount,
-  storageIdentities: ReadonlyMap<string, StorageReferenceIdentity>,
+  storageIdsByLookup: ReadonlyMap<string, string>,
   storageVersionOwners: ReadonlyMap<string, string>,
-): boolean {
-  const storage = storageIdentities.get(mount.storageId);
-  return (
-    storage !== undefined &&
-    storage.orgId === mount.orgId &&
-    storage.userId === mount.userId &&
-    storage.name === mount.name &&
-    storageVersionOwners.get(mount.version) === mount.storageId
+): CheckpointStorageReferenceReason | null {
+  const liveStorageId = storageIdsByLookup.get(
+    storageReferenceLookupKey(mount),
   );
+  if (liveStorageId === undefined) {
+    return mount.optional === true
+      ? "optionalStorageMissing"
+      : "requiredStorageMissing";
+  }
+  // The runtime resolves by (orgId, userId, name), then verifies the persisted
+  // immutable identity. A same-key replacement must fail even when optional.
+  if (liveStorageId !== mount.storageId) return "storageIdentityMismatch";
+
+  const versionStorageId = storageVersionOwners.get(mount.version);
+  if (versionStorageId === undefined) {
+    // Checkpoint mounts carry exact pinned versions. The runtime's
+    // isMissingStorageError does not accept its "version ... not found"
+    // failure, so optional does not weaken this closure.
+    return mount.optional === true
+      ? "optionalVersionMissing"
+      : "requiredVersionMissing";
+  }
+  return versionStorageId === mount.storageId
+    ? null
+    : "crossStorageVersionOwnerMismatch";
+}
+
+function emptyCheckpointStorageReferenceReasonSets(): Record<
+  CheckpointStorageReferenceReason,
+  Set<string>
+> {
+  return Object.fromEntries(
+    CHECKPOINT_STORAGE_REFERENCE_REASONS.map((reason) => {
+      return [reason, new Set<string>()] as const;
+    }),
+  ) as Record<CheckpointStorageReferenceReason, Set<string>>;
 }
 
 const STORAGE_REFERENCE_CURSOR_BATCH_SIZE = 512;
@@ -2399,7 +2780,7 @@ export async function validateCheckpointStorageReferences(
   signal: AbortSignal | undefined,
   expectedCheckpointIds: ReadonlySet<string>,
 ): Promise<CheckpointStorageReferenceValidation> {
-  const storageIdentities = new Map<string, StorageReferenceIdentity>();
+  const storageIdsByLookup = new Map<string, string>();
   const storageVersionOwners = new Map<string, string>();
   await streamCursorRows<StorageReferenceIdentityRow>(
     client,
@@ -2407,11 +2788,10 @@ export async function validateCheckpointStorageReferences(
     "checkpointStorageIdentities",
     STORAGE_REFERENCE_IDENTITY_QUERY,
     (row) => {
-      storageIdentities.set(row.id, {
-        orgId: row.orgId,
-        userId: row.userId,
-        name: row.name,
-      });
+      storageIdsByLookup.set(
+        frameTuple([row.orgId, row.userId, row.name]),
+        row.id,
+      );
     },
   );
   await streamCursorRows<StorageReferenceVersionRow>(
@@ -2425,6 +2805,7 @@ export async function validateCheckpointStorageReferences(
   );
 
   const invalidCheckpointIds = new Set<string>();
+  const reasonCheckpointIds = emptyCheckpointStorageReferenceReasonSets();
   let expandedMountCount = 0;
   const checkpointCount = await streamCursorRows<CheckpointStorageReferenceRow>(
     client,
@@ -2437,30 +2818,45 @@ export async function validateCheckpointStorageReferences(
       }
       if (row.storageMountsNull) return;
       if (!Array.isArray(row.storageMounts)) {
+        reasonCheckpointIds.malformedRoot.add(row.id);
         invalidCheckpointIds.add(row.id);
         return;
       }
-      let valid = true;
+      const checkpointReasons = new Set<CheckpointStorageReferenceReason>();
       for (const mount of row.storageMounts) {
         expandedMountCount += 1;
-        if (
-          !isValidCheckpointStorageMount(mount) ||
-          !hasValidCheckpointStorageReferences(
-            mount,
-            storageIdentities,
-            storageVersionOwners,
-          )
-        ) {
-          valid = false;
+        if (!isValidCheckpointStorageMount(mount)) {
+          checkpointReasons.add("malformedMount");
+          continue;
         }
+        const reason = checkpointStorageMountReferenceReason(
+          mount,
+          storageIdsByLookup,
+          storageVersionOwners,
+        );
+        if (reason !== null) checkpointReasons.add(reason);
       }
-      if (!valid) invalidCheckpointIds.add(row.id);
+      for (const reason of checkpointReasons) {
+        reasonCheckpointIds[reason].add(row.id);
+      }
+      if (
+        [...checkpointReasons].some((reason) => {
+          return reason !== "optionalStorageMissing";
+        })
+      ) {
+        invalidCheckpointIds.add(row.id);
+      }
     },
   );
   if (checkpointCount !== expectedCheckpointIds.size) {
     throw new SanitizedPreflightError("probe.inventory");
   }
-  return { checkpointCount, invalidCheckpointIds, expandedMountCount };
+  return {
+    checkpointCount,
+    invalidCheckpointIds,
+    reasonCheckpointIds,
+    expandedMountCount,
+  };
 }
 
 async function collectDatabaseInventory(
@@ -2695,6 +3091,13 @@ async function collectDatabaseInventory(
           !checkpointStorageReferenceValidation.invalidCheckpointIds.has(
             row.id,
           ),
+        storageReferenceReasons: CHECKPOINT_STORAGE_REFERENCE_REASONS.filter(
+          (reason) => {
+            return checkpointStorageReferenceValidation.reasonCheckpointIds[
+              reason
+            ].has(row.id);
+          },
+        ),
       };
     },
   );

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
@@ -86,6 +86,10 @@ const STORAGE_PLAN_EXPANDED_MOUNT_COUNT =
   STORAGE_PLAN_CHECKPOINT_COUNT * STORAGE_PLAN_MOUNTS_PER_CHECKPOINT;
 const STORAGE_PLAN_STORAGE_COUNT = 12_730;
 const STORAGE_PLAN_VERSION_COUNT = 23_717;
+const STORAGE_PLAN_OPTIONAL_MISSING_INTERVAL = 5;
+const STORAGE_PLAN_OPTIONAL_MISSING_CHECKPOINT_COUNT = Math.floor(
+  STORAGE_PLAN_CHECKPOINT_COUNT / STORAGE_PLAN_OPTIONAL_MISSING_INTERVAL,
+);
 const STORAGE_PLAN_MAX_OLD_SPACE_MIB = 256;
 const STORAGE_PLAN_MAX_HEAP_GROWTH_BYTES = 192 * 1024 * 1024;
 const ACTIVITY_TIME_ZONES = ["UTC", "Asia/Shanghai"] as const;
@@ -676,7 +680,7 @@ function checkpointRow(
   snapshot: unknown,
   overrides: Partial<PreflightInventory["checkpoints"][number]> = {},
 ): PreflightInventory["checkpoints"][number] {
-  return {
+  const row = {
     id,
     runId,
     snapshot,
@@ -685,8 +689,16 @@ function checkpointRow(
     conversationReferenceValid: true,
     sessionReferenceValid: true,
     storageReferenceValid: true,
+    storageReferenceReasons: [],
     ...overrides,
   };
+  return row.storageReferenceValid ||
+    Object.hasOwn(overrides, "storageReferenceReasons")
+    ? row
+    : {
+        ...row,
+        storageReferenceReasons: ["requiredStorageMissing"],
+      };
 }
 
 function acceptedV3DomainProjection(
@@ -3908,6 +3920,57 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
     4,
   );
 
+  const runtimeStorageSource = await fs.readFile(
+    path.join(
+      repositoryRoot,
+      "turbo/apps/api/src/signals/services/agent-run-storage.service.ts",
+    ),
+    "utf8",
+  );
+  const persistedResolverStart = runtimeStorageSource.indexOf(
+    "async function resolvePersistedStorageMounts(",
+  );
+  const persistedResolverEnd = runtimeStorageSource.indexOf(
+    "async function buildEntriesFromPersistedStorageMounts(",
+  );
+  assert.ok(
+    persistedResolverStart >= 0 &&
+      persistedResolverEnd > persistedResolverStart,
+  );
+  const persistedResolverSource = runtimeStorageSource.slice(
+    persistedResolverStart,
+    persistedResolverEnd,
+  );
+  assert.match(
+    persistedResolverSource,
+    /storageIndexKey\(lookup\.orgId, lookup\.userId, lookup\.name\)/u,
+  );
+  assert.match(
+    persistedResolverSource,
+    /if \(!storage\) \{[\s\S]*if \(mount\.optional\) \{[\s\S]*continue;[\s\S]*not found in database/u,
+  );
+  assert.ok(
+    persistedResolverSource.indexOf("storage.storageId !== mount.storageId") <
+      persistedResolverSource.indexOf("resolveStorageVersion("),
+  );
+  const missingClassifierStart = runtimeStorageSource.indexOf(
+    "function isMissingStorageError(",
+  );
+  const missingClassifierEnd = runtimeStorageSource.indexOf(
+    "function volumeStorageName(",
+  );
+  assert.ok(
+    missingClassifierStart >= 0 &&
+      missingClassifierEnd > missingClassifierStart,
+  );
+  const missingClassifierSource = runtimeStorageSource.slice(
+    missingClassifierStart,
+    missingClassifierEnd,
+  );
+  assert.match(missingClassifierSource, /not found in database/u);
+  assert.match(missingClassifierSource, /has no HEAD version/u);
+  assert.equal(/version .* not found/u.test(missingClassifierSource), false);
+
   const historicalClassifierPath = path.join(
     repositoryRoot,
     "turbo/apps/api/src/signals/services/historical-product-builder.ts",
@@ -4738,10 +4801,11 @@ async function testDatabaseBoundariesForTimeZone(
         "exact",
       );
 
-      const storageReferenceIsValid = async (
+      const storageReferenceClassification = async (
         storageMounts: unknown,
         writeSqlNull = false,
-      ): Promise<boolean> => {
+        expectPriorParity = true,
+      ) => {
         await client.query(
           `UPDATE "checkpoints"
            SET "storage_mounts" = CASE
@@ -4782,11 +4846,21 @@ async function testDatabaseBoundariesForTimeZone(
           const streamedValid = !validation.invalidCheckpointIds.has(
             latestContinuation.checkpointId,
           );
-          assert.equal(streamedValid, priorValid);
-          return streamedValid;
+          if (expectPriorParity) assert.equal(streamedValid, priorValid);
+          return { priorValid, streamedValid, validation };
         } finally {
           await client.query("ROLLBACK");
         }
+      };
+      const storageReferenceIsValid = async (
+        storageMounts: unknown,
+        writeSqlNull = false,
+      ): Promise<boolean> => {
+        const classification = await storageReferenceClassification(
+          storageMounts,
+          writeSqlNull,
+        );
+        return classification.streamedValid;
       };
       for (const validMounts of [
         [],
@@ -4813,9 +4887,23 @@ async function testDatabaseBoundariesForTimeZone(
         assert.equal(await storageReferenceIsValid(validMounts), true);
       }
       assert.equal(await storageReferenceIsValid(null, true), true);
-      assert.equal(await storageReferenceIsValid({}), false);
+      const malformedRoot = await storageReferenceClassification({});
+      assert.equal(malformedRoot.streamedValid, false);
+      assert.equal(
+        malformedRoot.validation.reasonCheckpointIds.malformedRoot.has(
+          latestContinuation.checkpointId,
+        ),
+        true,
+      );
       assert.equal(await storageReferenceIsValid(null), false);
-      assert.equal(await storageReferenceIsValid([null]), false);
+      const malformedMount = await storageReferenceClassification([null]);
+      assert.equal(malformedMount.streamedValid, false);
+      assert.equal(
+        malformedMount.validation.reasonCheckpointIds.malformedMount.has(
+          latestContinuation.checkpointId,
+        ),
+        true,
+      );
 
       const requiredStorageMountKeys = [
         "orgId",
@@ -4886,11 +4974,15 @@ async function testDatabaseBoundariesForTimeZone(
          )`,
         [otherStorageVersionId, otherStorageId, storageMount.userId],
       );
+      const crossStorageVersion = await storageReferenceClassification([
+        { ...storageMount, version: otherStorageVersionId },
+      ]);
+      assert.equal(crossStorageVersion.streamedValid, false);
       assert.equal(
-        await storageReferenceIsValid([
-          { ...storageMount, version: otherStorageVersionId },
-        ]),
-        false,
+        crossStorageVersion.validation.reasonCheckpointIds.crossStorageVersionOwnerMismatch.has(
+          latestContinuation.checkpointId,
+        ),
+        true,
       );
 
       await client.query(
@@ -4911,6 +5003,267 @@ async function testDatabaseBoundariesForTimeZone(
           },
         });
       gatePresent(missingStorageVersion, "checkpoints.storage_reference");
+      await client.query(
+        `UPDATE "checkpoints" SET "storage_mounts" = $1::jsonb
+         WHERE "id" = $2`,
+        [JSON.stringify([storageMount]), latestContinuation.checkpointId],
+      );
+
+      const deletedStorageId = "00000000-0000-4000-8000-000000027652";
+      const replacementStorageId = "00000000-0000-4000-8000-000000027653";
+      const deletedStorageVersionId = "c".repeat(64);
+      const deletedStorageMount = {
+        ...storageMount,
+        name: "deleted-checkpoint-storage",
+        storageId: deletedStorageId,
+        version: deletedStorageVersionId,
+      } as const;
+      await client.query(
+        `INSERT INTO "storages" (
+           "id", "user_id", "name", "org_id", "s3_prefix"
+         ) VALUES ($1, $2, $3, $4, 'deleted-checkpoint-storage-prefix')`,
+        [
+          deletedStorageId,
+          deletedStorageMount.userId,
+          deletedStorageMount.name,
+          deletedStorageMount.orgId,
+        ],
+      );
+      await client.query(
+        `INSERT INTO "storage_versions" (
+           "id", "storage_id", "s3_key", "archive_size", "created_by"
+         ) VALUES ($1, $2, 'deleted-checkpoint-storage-key', 0, $3)`,
+        [deletedStorageVersionId, deletedStorageId, deletedStorageMount.userId],
+      );
+      const deletedStorage = await client.query(
+        `DELETE FROM "storages" WHERE "id" = $1`,
+        [deletedStorageId],
+      );
+      assert.equal(deletedStorage.rowCount, 1);
+
+      const optionalDeletedStorage = await storageReferenceClassification(
+        [{ ...deletedStorageMount, optional: true }],
+        false,
+        false,
+      );
+      assert.equal(optionalDeletedStorage.priorValid, false);
+      assert.equal(optionalDeletedStorage.streamedValid, true);
+      assert.equal(
+        optionalDeletedStorage.validation.reasonCheckpointIds.optionalStorageMissing.has(
+          latestContinuation.checkpointId,
+        ),
+        true,
+      );
+      const optionalDeletedStoragePreflight =
+        await executeAgentComposeConsolidationPreflight({
+          connectionString: testUrl,
+          repositoryRoot,
+          classification: {
+            ...executionOptions,
+            expectedDanglingHeadCount: 1,
+          },
+        });
+      assert.equal(
+        optionalDeletedStoragePreflight.checkpoints.transition
+          .storageReferenceClosure.classification,
+        "exact",
+      );
+      assert.equal(
+        optionalDeletedStoragePreflight.checkpoints.transition
+          .legacySnapshotLineage.classification,
+        "exact",
+      );
+      assert.equal(
+        optionalDeletedStoragePreflight.checkpoints.transition.storageReferences
+          .strictLiveCatalogInvalid.count,
+        1,
+      );
+      assert.equal(
+        optionalDeletedStoragePreflight.checkpoints.transition.storageReferences
+          .runtimeInvalid.count,
+        0,
+      );
+      assert.equal(
+        optionalDeletedStoragePreflight.checkpoints.transition.storageReferences
+          .acceptedOptionalStorageMissing.count,
+        1,
+      );
+      assert.equal(
+        optionalDeletedStoragePreflight.checkpoints.transition.storageReferences
+          .primaryPartitions.optionalStorageMissing.count,
+        1,
+      );
+
+      const requiredDeletedStorage = await storageReferenceClassification([
+        { ...deletedStorageMount, optional: false },
+      ]);
+      assert.equal(requiredDeletedStorage.streamedValid, false);
+      assert.equal(
+        requiredDeletedStorage.validation.reasonCheckpointIds.requiredStorageMissing.has(
+          latestContinuation.checkpointId,
+        ),
+        true,
+      );
+      const requiredDeletedStoragePreflight =
+        await executeAgentComposeConsolidationPreflight({
+          connectionString: testUrl,
+          repositoryRoot,
+          classification: {
+            ...executionOptions,
+            expectedDanglingHeadCount: 1,
+          },
+        });
+      gatePresent(
+        requiredDeletedStoragePreflight,
+        "checkpoints.storage_reference",
+      );
+      gatePresent(
+        requiredDeletedStoragePreflight,
+        "checkpoints.legacy_snapshot_lineage",
+      );
+
+      await client.query(
+        `INSERT INTO "storages" (
+           "id", "user_id", "name", "org_id", "s3_prefix"
+         ) VALUES ($1, $2, $3, $4, 'replacement-checkpoint-storage-prefix')`,
+        [
+          replacementStorageId,
+          deletedStorageMount.userId,
+          deletedStorageMount.name,
+          deletedStorageMount.orgId,
+        ],
+      );
+      const sameKeyReplacement = await storageReferenceClassification([
+        { ...deletedStorageMount, optional: true },
+      ]);
+      assert.equal(sameKeyReplacement.streamedValid, false);
+      assert.equal(
+        sameKeyReplacement.validation.reasonCheckpointIds.storageIdentityMismatch.has(
+          latestContinuation.checkpointId,
+        ),
+        true,
+      );
+      await client.query(`DELETE FROM "storages" WHERE "id" = $1`, [
+        replacementStorageId,
+      ]);
+
+      const deletedPinnedVersionId = "b".repeat(64);
+      await client.query(
+        `INSERT INTO "storage_versions" (
+           "id", "storage_id", "s3_key", "archive_size", "created_by"
+         ) VALUES ($1, $2, 'deleted-pinned-version-key', 0, $3)`,
+        [deletedPinnedVersionId, storageId, storageMount.userId],
+      );
+      await client.query(`DELETE FROM "storage_versions" WHERE "id" = $1`, [
+        deletedPinnedVersionId,
+      ]);
+      const optionalDeletedVersion = await storageReferenceClassification([
+        {
+          ...storageMount,
+          version: deletedPinnedVersionId,
+          optional: true,
+        },
+      ]);
+      assert.equal(optionalDeletedVersion.streamedValid, false);
+      assert.equal(
+        optionalDeletedVersion.validation.reasonCheckpointIds.optionalVersionMissing.has(
+          latestContinuation.checkpointId,
+        ),
+        true,
+      );
+      const requiredDeletedVersion = await storageReferenceClassification([
+        {
+          ...storageMount,
+          version: deletedPinnedVersionId,
+          optional: false,
+        },
+      ]);
+      assert.equal(requiredDeletedVersion.streamedValid, false);
+      assert.equal(
+        requiredDeletedVersion.validation.reasonCheckpointIds.requiredVersionMissing.has(
+          latestContinuation.checkpointId,
+        ),
+        true,
+      );
+
+      const requiredAbsentStorageMount = {
+        ...deletedStorageMount,
+        name: "required-deleted-checkpoint-storage",
+        storageId: "00000000-0000-4000-8000-000000027654",
+        optional: false,
+      } as const;
+      const multiReason = await storageReferenceClassification(
+        [
+          { ...deletedStorageMount, optional: true },
+          requiredAbsentStorageMount,
+          { ...storageMount, version: otherStorageVersionId },
+        ],
+        false,
+        false,
+      );
+      assert.equal(multiReason.streamedValid, false);
+      assert.equal(
+        multiReason.validation.reasonCheckpointIds.optionalStorageMissing.has(
+          latestContinuation.checkpointId,
+        ),
+        true,
+      );
+      assert.equal(
+        multiReason.validation.reasonCheckpointIds.requiredStorageMissing.has(
+          latestContinuation.checkpointId,
+        ),
+        true,
+      );
+      assert.equal(
+        multiReason.validation.reasonCheckpointIds.crossStorageVersionOwnerMismatch.has(
+          latestContinuation.checkpointId,
+        ),
+        true,
+      );
+      const multiReasonPreflight =
+        await executeAgentComposeConsolidationPreflight({
+          connectionString: testUrl,
+          repositoryRoot,
+          classification: {
+            ...executionOptions,
+            expectedDanglingHeadCount: 1,
+          },
+        });
+      const multiReasonEvidence =
+        multiReasonPreflight.checkpoints.transition.storageReferences;
+      assert.equal(
+        multiReasonEvidence.primaryPartitions.requiredStorageMissing.count,
+        1,
+      );
+      assert.equal(
+        multiReasonEvidence.reasonMembers.optionalStorageMissing.count,
+        1,
+      );
+      assert.equal(
+        multiReasonEvidence.reasonMembers.requiredStorageMissing.count,
+        1,
+      );
+      assert.equal(
+        multiReasonEvidence.reasonMembers.crossStorageVersionOwnerMismatch
+          .count,
+        1,
+      );
+      assert.equal(multiReasonEvidence.acceptedOptionalStorageMissing.count, 0);
+      assert.equal(multiReasonEvidence.overlappingReasons.count, 1);
+      for (const closure of [
+        multiReasonEvidence.primaryCardinalityClosure,
+        multiReasonEvidence.primaryDisjointnessClosure,
+        multiReasonEvidence.primaryUnionClosure,
+        multiReasonEvidence.reasonUnionClosure,
+        multiReasonEvidence.reasonOverlapClosure,
+        multiReasonEvidence.runtimeCardinalityClosure,
+        multiReasonEvidence.runtimeDisjointnessClosure,
+        multiReasonEvidence.runtimeUnionClosure,
+        multiReasonEvidence.runtimeSemanticsClosure,
+        multiReasonEvidence.acceptedOptionalStorageMissingClosure,
+      ]) {
+        assert.equal(closure.classification, "exact");
+      }
       await client.query(
         `UPDATE "checkpoints" SET "storage_mounts" = $1::jsonb
          WHERE "id" = $2`,
@@ -5361,15 +5714,32 @@ async function seedStoragePlanCheckpoints(client: Client): Promise<void> {
          jsonb_build_object(
            'orgId', 'storage-plan-org',
            'userId', 'storage-plan-user',
-           'name', 'storage-plan-' || "mount"."storageOrdinal",
-           'storageId', format(
-             '10000000-0000-4000-8000-%s',
-             lpad("mount"."storageOrdinal"::text, 12, '0')
-           ),
+           'name', CASE
+             WHEN
+               "checkpoint"."ordinal" % $5::integer = 0 AND
+               "mount"."ordinal" = 1
+               THEN 'storage-plan-deleted'
+             ELSE 'storage-plan-' || "mount"."storageOrdinal"
+           END,
+           'storageId', CASE
+             WHEN
+               "checkpoint"."ordinal" % $5::integer = 0 AND
+               "mount"."ordinal" = 1
+               THEN '19999999-0000-4000-8000-000000000001'
+             ELSE format(
+               '10000000-0000-4000-8000-%s',
+               lpad("mount"."storageOrdinal"::text, 12, '0')
+             )
+           END,
            'version', lpad(to_hex("mount"."versionOrdinal"), 64, '0'),
            'mountPath',
              '/home/oai/share/storage-plan-' || "mount"."storageOrdinal",
-           'optional', "mount"."ordinal" % 2 = 0,
+           'optional',
+             "mount"."ordinal" % 2 = 0 OR
+             (
+               "checkpoint"."ordinal" % $5::integer = 0 AND
+               "mount"."ordinal" = 1
+             ),
            'writeback', "mount"."ordinal" % 3 = 0,
            'instructionsTargetFilename', 'AGENTS.md',
            'missingRootPolicy', CASE
@@ -5408,6 +5778,7 @@ async function seedStoragePlanCheckpoints(client: Client): Promise<void> {
       STORAGE_PLAN_MOUNTS_PER_CHECKPOINT,
       STORAGE_PLAN_VERSION_COUNT,
       STORAGE_PLAN_STORAGE_COUNT,
+      STORAGE_PLAN_OPTIONAL_MISSING_INTERVAL,
     ],
   );
 }
@@ -5442,6 +5813,20 @@ async function assertStoragePlanProfile(
       STORAGE_PLAN_EXPANDED_MOUNT_COUNT,
     );
     assert.deepEqual([...measured.value.invalidCheckpointIds], []);
+    assert.equal(
+      measured.value.reasonCheckpointIds.optionalStorageMissing.size,
+      STORAGE_PLAN_OPTIONAL_MISSING_CHECKPOINT_COUNT,
+    );
+    assert.equal(
+      Object.entries(measured.value.reasonCheckpointIds)
+        .filter(([reason]) => {
+          return reason !== "optionalStorageMissing";
+        })
+        .every(([, ids]) => {
+          return ids.size === 0;
+        }),
+      true,
+    );
     assert.ok(
       elapsedMs < 30_000,
       `${profile.name} must complete the full streamed closure within 30s`,
@@ -5505,6 +5890,8 @@ async function assertStoragePlanProfile(
           profile: profile.name,
           checkpointCount: measured.value.checkpointCount,
           expandedMountCount: measured.value.expandedMountCount,
+          optionalMissingCheckpointCount:
+            measured.value.reasonCheckpointIds.optionalStorageMissing.size,
           elapsedMs: Math.ceil(elapsedMs),
           baselineHeapBytes: measured.baselineHeapBytes,
           peakHeapBytes: measured.peakHeapBytes,


### PR DESCRIPTION
Issue #28080
Parent #26938

## Summary

- align the protected checkpoint Storage-reference closure with the established `resolvePersistedStorageMounts` lookup authority: only an optional mount with no live `(orgId, userId, name)` Storage is accepted
- keep malformed mounts, required absence, same-key/different-ID replacement, missing exact pinned versions (including optional), and cross-Storage version ownership fail closed
- expose bounded, domain-separated reason fingerprints with deterministic primary partitions, explicit overlap evidence, and cardinality/disjointness/union/runtime-semantics closures
- preserve the three 512-row cursor scans, full-population repeatable-read/read-only validation, 1-second lock timeout, 30-second statement timeout, redacted v7 output, existing gates, and survivor lineage

No application runtime, checkpoint writer, schema, migration, workflow, release, or fallback behavior changes. Issue #28080 remains open for controller-owned production acceptance.

## Focused verification

- Prettier check on both changed files
- DB package TypeScript check
- focused static preflight validator, including migration 0949 safety, output allowlist/redaction, runtime caller contract, and workflow failure shape
- JSONB contract lint, Oxlint, type-aware Oxlint, and ESLint
- disposable PostgreSQL 18 integration matrix covering optional/required deleted Storage, optional/required deleted exact version, same-key replacement, malformed shape, identity mismatch, cross-Storage owner, multi-reason determinism/closures, pre-cutover lineage, and UTC/Asia-Shanghai invariance
- production-scale fixture: 139,811 checkpoints, 279,622 expanded mounts, and 27,962 optional-missing checkpoints under both planner profiles; 4,351/4,186 ms elapsed, 62,475,720/82,659,360-byte peak heap growth, 241,690,864/242,947,456-byte peak heap, and single-scan plan execution totals of 178/49 ms

Full local Vitest was intentionally not run; repository-wide coverage remains with PR CI.
