### PR TITLE
test(api): isolate runtime-sync claim boundary

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 
+import type { ConnectorRuntimeTargetRegistration } from "@okouai/api-contracts/contracts/runners";
 import type {
   TestRuntimeStateActionBody,
   TestRuntimeStateActionResponse,
@@ -317,6 +318,18 @@ export async function mutateRunnerJobConnectorPermissionBaseline(
     action: "mutate-runner-job-connector-permission-baseline",
     run_id: runId,
     mode,
+  });
+}
+
+export async function setRunnerJobConnectorRuntimeTargets(
+  context: TestContext,
+  runId: string,
+  connectorRuntimeTargets: readonly ConnectorRuntimeTargetRegistration[],
+): Promise<void> {
+  await postAction(context, {
+    action: "set-runner-job-connector-runtime-targets",
+    run_id: runId,
+    connector_runtime_targets: [...connectorRuntimeTargets],
   });
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -137,6 +137,7 @@ import {
   seedVm0ManagedModelKey as seedVm0ManagedModelKeyState,
   setAgentComposeVersionlessFixture,
   setCustomConnectorAuthTemplateFixture,
+  setRunnerJobConnectorRuntimeTargets,
   setRunnerJobContextProfileAsPreviousApi,
 } from "./helpers/runtime-state";
 import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
@@ -10197,32 +10198,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
   it("hands off more than one runtime-sync batch without truncation", async () => {
     const api = createRunsApi(context);
     const { actor, agentId } = await entitledRunActor();
-    if (!actor.orgId) {
-      throw new Error("Expected a custom connector actor with an organization");
-    }
-    const suffix = randomUUID().slice(0, 8);
     const connectorCount = CONNECTOR_RUNTIME_SYNC_TARGETS_MAX + 1;
-    const runtimeConnectors = Array.from(
-      { length: connectorCount },
-      (_unused, sequence) => {
-        return {
-          id: randomUUID(),
-          slug: `_bdd-batch-${suffix}-${sequence}`,
-          displayName: `BDD Runtime Batch ${sequence}`,
-          prefixTemplate: `https://batch-${sequence}-${suffix}.example.test/api/`,
-        };
-      },
-    );
-    await seedCustomConnectorRuntimeConnectors(context, {
-      orgId: actor.orgId,
-      userId: actor.userId,
-      agentId,
-      customConnectors: runtimeConnectors,
-    });
-    const createdIds = runtimeConnectors.map((connector) => {
-      return connector.id;
-    });
-
     const run = await api.createRun(actor, {
       agentId,
       prompt: "use more than one connector runtime sync batch",
@@ -10231,6 +10207,20 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     onTestFinished(async () => {
       await api.requestCancelRun(actor, run.runId, [200]);
     });
+    const createdIds = Array.from({ length: connectorCount }, () => {
+      return randomUUID();
+    });
+    await setRunnerJobConnectorRuntimeTargets(
+      context,
+      run.runId,
+      createdIds.map((customConnectorId) => {
+        return {
+          kind: "custom",
+          customConnectorId,
+          baseUrlVars: {},
+        };
+      }),
+    );
     const claim = await api.claimRunnerJob(run.runId);
     const expectedIds = [...createdIds].sort();
     expect(

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -549,6 +549,34 @@ type ConnectorPermissionBaselineMutationAction = Extract<
   { action: "mutate-runner-job-connector-permission-baseline" }
 >;
 
+type ConnectorRuntimeTargetsMutationAction = Extract<
+  TestRuntimeStateActionBody,
+  { action: "set-runner-job-connector-runtime-targets" }
+>;
+
+async function setRunnerJobConnectorRuntimeTargets(
+  db: Db,
+  body: ConnectorRuntimeTargetsMutationAction,
+  signal: AbortSignal,
+): Promise<void> {
+  const [updated] = await db
+    .update(runnerJobQueue)
+    .set({
+      executionContext: sql`jsonb_set(
+        ${runnerJobQueue.executionContext},
+        '{connectorRuntimeTargets}',
+        ${JSON.stringify(body.connector_runtime_targets)}::jsonb,
+        true
+      )`,
+    })
+    .where(eq(runnerJobQueue.runId, body.run_id))
+    .returning({ runId: runnerJobQueue.runId });
+  signal.throwIfAborted();
+  if (!updated) {
+    throw new Error("Expected a queued runner job for runtime targets");
+  }
+}
+
 async function mutateRunnerJobConnectorPermissionBaseline(
   db: Db,
   body: ConnectorPermissionBaselineMutationAction,
@@ -1503,6 +1531,10 @@ const postRuntimeStateAction$ = command(
           body.mode,
           signal,
         );
+        return { status: 200 as const, body: { ok: true as const } };
+      }
+      case "set-runner-job-connector-runtime-targets": {
+        await setRunnerJobConnectorRuntimeTargets(db, body, signal);
         return { status: 200 as const, body: { ok: true as const } };
       }
       case "hold-org-admission-lock": {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -247,7 +247,7 @@ function uniqueConnectorRuntimeTargets(
   }
 }
 
-const connectorRuntimeTargetsSchema = z
+export const connectorRuntimeTargetsSchema = z
   .array(connectorRuntimeTargetRegistrationSchema)
   .superRefine(uniqueConnectorRuntimeTargets);
 

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { initContract } from "./base";
+import { connectorRuntimeTargetsSchema } from "./runners";
 
 const c = initContract();
 
@@ -81,6 +82,11 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
       "inconsistent",
       "incomplete",
     ]),
+  }),
+  z.object({
+    action: z.literal("set-runner-job-connector-runtime-targets"),
+    run_id: z.uuid(),
+    connector_runtime_targets: connectorRuntimeTargetsSchema,
   }),
   z.object({
     action: z.literal("remove-run-canonical-storage-state"),


### PR DESCRIPTION
## Summary

- replace the runtime-sync batch boundary test's 771 connector fixture rows with a targeted queued-job state setup
- validate injected targets with the canonical runner contract before storing them in PostgreSQL
- keep exercising the real run creation, runner claim, stored-context parsing, and response serialization paths

## Scope

This changes test infrastructure and the flaky integration test only. It does not change production run admission, connector materialization, runtime-sync batching, or timeout configuration.

Closes #28428

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts apps/api/src/signals/routes/test-runtime-state.ts packages/api-contracts/src/contracts/runners.ts packages/api-contracts/src/contracts/test-runtime-state.ts`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/api-contracts test -- --silent=passed-only` (590 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --silent=passed-only` (168 passed)
- focused target test, three consecutive runs (3/3 passed; 238-294 ms test time)
- `pnpm knip`
- pre-commit hook, including repository-wide Turbo typecheck (14/14 tasks passed)

The local API shard also completed `run-lifecycle.bdd.test.ts` with all 168 tests passing. Its process exited on the unrelated `workflow-automations.test.ts` Calendar watch fixture because persistent local test state contained three invalid watches; no modified file participates in that failure.
