### PR TITLE
fix(ci): prevent clerk e2e quota exhaustion

### DIFF
--- a/.github/scripts/tests/clerk-test-resource-workflow-test.sh
+++ b/.github/scripts/tests/clerk-test-resource-workflow-test.sh
@@ -122,10 +122,12 @@ fi
 ruby -ryaml - \
   "${repo_root}/.github/workflows/turbo.yml" \
   "${repo_root}/.github/workflows/cleanup.yml" \
-  "${repo_root}/.github/workflows/cleanup-stale.yml" <<'RUBY'
+  "${repo_root}/.github/workflows/cleanup-stale.yml" \
+  "${repo_root}/.github/workflows/cleanup-clerk-test-resources.yml" <<'RUBY'
 turbo = YAML.load_file(ARGV.fetch(0))
 cleanup = YAML.load_file(ARGV.fetch(1))
 stale = YAML.load_file(ARGV.fetch(2))
+scheduled_clerk = YAML.load_file(ARGV.fetch(3))
 
 turbo_jobs = turbo.fetch("jobs")
 browser = turbo_jobs.fetch("cli-e2e-02-browser")
@@ -247,14 +249,33 @@ unless closed_pr_step.fetch("run").end_with?("clerk-test-resources.ts cleanup-jo
 end
 
 stale_jobs = stale.fetch("jobs")
-stale_cleanup = stale_jobs.fetch("cleanup-clerk-test-resources")
-unless stale_cleanup.dig("permissions", "contents") == "read"
+if stale_jobs.key?("cleanup-clerk-test-resources")
+  raise "general stale maintenance must not own frequent Clerk cleanup"
+end
+scheduled_triggers = scheduled_clerk.fetch(true)
+unless scheduled_triggers.fetch("schedule") == [{ "cron" => "*/30 * * * *" }]
+  raise "stale Clerk cleanup must run every 30 minutes"
+end
+manual_dispatch = scheduled_triggers.fetch("workflow_dispatch")
+dry_run_input = manual_dispatch.fetch("inputs").fetch("dry-run")
+unless dry_run_input.fetch("type") == "boolean" && dry_run_input.fetch("default") == false
+  raise "manual stale Clerk cleanup must expose a disabled boolean dry-run input"
+end
+scheduled_concurrency = scheduled_clerk.fetch("concurrency")
+unless scheduled_concurrency.fetch("group") == "cleanup-clerk-test-resources" &&
+    scheduled_concurrency.fetch("cancel-in-progress") == false
+  raise "stale Clerk cleanup executions must serialize without cancellation"
+end
+scheduled_jobs = scheduled_clerk.fetch("jobs")
+scheduled_cleanup = scheduled_jobs.fetch("cleanup-clerk-test-resources")
+unless scheduled_cleanup.dig("permissions", "contents") == "read"
   raise "stale Clerk cleanup must use read-only repository permissions"
 end
-if stale_jobs.key?("cleanup-clerk-test-users") || stale_jobs.key?("cleanup-clerk-empty-orgs")
+if scheduled_jobs.key?("cleanup-clerk-test-users") ||
+    scheduled_jobs.key?("cleanup-clerk-empty-orgs")
   raise "legacy Clerk cleanup jobs must be removed"
 end
-stale_checkout = stale_cleanup.fetch("steps").find do |step|
+stale_checkout = scheduled_cleanup.fetch("steps").find do |step|
   step.fetch("uses", "").start_with?("actions/checkout@")
 end
 raise "missing trusted checkout for stale Clerk cleanup" unless stale_checkout
@@ -262,35 +283,23 @@ unless stale_checkout.dig("with", "ref") == "${{ github.event.repository.default
     stale_checkout.dig("with", "persist-credentials") == false
   raise "stale Clerk cleanup must execute credential-free default-branch code"
 end
-stale_non_runner_step = stale_cleanup.fetch("steps").find do |step|
-  step["name"] == "Delete stale non-runner Clerk test resources"
+stale_step = scheduled_cleanup.fetch("steps").find do |step|
+  step["name"] == "Delete stale Clerk test resources"
 end
-stale_runner_step = stale_cleanup.fetch("steps").find do |step|
-  step["name"] == "Delete stale runner Clerk test resources"
-end
-raise "missing non-runner stale Clerk cleanup command" unless stale_non_runner_step
-raise "missing runner stale Clerk cleanup command" unless stale_runner_step
-unless stale_non_runner_step.fetch("run").include?(
-    "cleanup-stale browser,playwright,paid-onboarding --older-than-hours 6",
-  ) && stale_non_runner_step.dig("env", "DRY_RUN") == "${{ env.DRY_RUN }}"
-  raise "non-runner Clerk resources must retain the six-hour stale policy"
-end
-unless stale_runner_step.fetch("run").include?(
-    "cleanup-stale runner,runner-real-codex,runner-real-claude,runner-mock-claude --older-than-hours 30",
-  ) && stale_runner_step.dig("env", "DRY_RUN") == "${{ env.DRY_RUN }}"
-  raise "runner resources must outlive the one-day token artifact"
-end
-runner_token_upload = turbo_jobs.fetch("cli-e2e-03-runner-prepare").fetch("steps").find do |step|
-  step["name"] == "Upload runner E2E API tokens"
-end
-raise "missing runner token artifact upload" unless runner_token_upload
-artifact_retention_hours = runner_token_upload.dig("with", "retention-days").to_i * 24
-runner_stale_hours = stale_runner_step.fetch("run")[/--older-than-hours (\d+)/, 1]&.to_i
-unless runner_stale_hours && runner_stale_hours > artifact_retention_hours
-  raise "runner stale cleanup must start after token artifact expiry"
+raise "missing unified stale Clerk cleanup command" unless stale_step
+expected_roles = "browser,playwright,paid-onboarding,runner,runner-real-codex,runner-real-claude,runner-mock-claude"
+unless stale_step.fetch("run").include?(
+    "cleanup-stale #{expected_roles} --older-than-hours 0.5",
+  ) && stale_step.dig("env", "CLERK_SECRET_KEY") == "${{ secrets.CLERK_SECRET_KEY }}" &&
+    stale_step.dig("env", "DRY_RUN") == "${{ env.DRY_RUN }}"
+  raise "stale Clerk cleanup must use every marked role and a 30-minute cutoff"
 end
 
-cleanup_sources = [File.read(ARGV.fetch(1)), File.read(ARGV.fetch(2))].join("\n")
+cleanup_sources = [
+  File.read(ARGV.fetch(1)),
+  File.read(ARGV.fetch(2)),
+  File.read(ARGV.fetch(3)),
+].join("\n")
 if cleanup_sources.include?("api.clerk.com") ||
     cleanup_sources.include?("memberships?limit=1")
   raise "untested legacy Clerk deletion logic remains in maintenance workflows"

--- a/.github/scripts/tests/clerk-test-resource-workflow-test.sh
+++ b/.github/scripts/tests/clerk-test-resource-workflow-test.sh
@@ -261,6 +261,9 @@ dry_run_input = manual_dispatch.fetch("inputs").fetch("dry-run")
 unless dry_run_input.fetch("type") == "boolean" && dry_run_input.fetch("default") == false
   raise "manual stale Clerk cleanup must expose a disabled boolean dry-run input"
 end
+unless scheduled_clerk.dig("env", "DRY_RUN") == "${{ inputs.dry-run || false }}"
+  raise "stale Clerk cleanup must forward the manual dry-run input"
+end
 scheduled_concurrency = scheduled_clerk.fetch("concurrency")
 unless scheduled_concurrency.fetch("group") == "cleanup-clerk-test-resources" &&
     scheduled_concurrency.fetch("cancel-in-progress") == false
@@ -283,10 +286,13 @@ unless stale_checkout.dig("with", "ref") == "${{ github.event.repository.default
     stale_checkout.dig("with", "persist-credentials") == false
   raise "stale Clerk cleanup must execute credential-free default-branch code"
 end
-stale_step = scheduled_cleanup.fetch("steps").find do |step|
-  step["name"] == "Delete stale Clerk test resources"
+stale_steps = scheduled_cleanup.fetch("steps").select do |step|
+  step.fetch("run", "").include?("clerk-test-resources.ts cleanup-stale")
 end
-raise "missing unified stale Clerk cleanup command" unless stale_step
+unless stale_steps.length == 1
+  raise "stale Clerk cleanup must use one inventory pass"
+end
+stale_step = stale_steps.fetch(0)
 expected_roles = "browser,playwright,paid-onboarding,runner,runner-real-codex,runner-real-claude,runner-mock-claude"
 unless stale_step.fetch("run").include?(
     "cleanup-stale #{expected_roles} --older-than-hours 0.5",

--- a/.github/workflows/cleanup-clerk-test-resources.yml
+++ b/.github/workflows/cleanup-clerk-test-resources.yml
@@ -1,0 +1,45 @@
+name: Cleanup Clerk Test Resources
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry-run mode (no actual deletions)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: cleanup-clerk-test-resources
+  cancel-in-progress: false
+
+env:
+  DRY_RUN: ${{ inputs.dry-run || false }}
+
+jobs:
+  cleanup-clerk-test-resources:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+      - name: Install pnpm
+        run: corepack enable pnpm
+      - name: Install E2E dependencies
+        run: cd e2e && pnpm install --frozen-lockfile
+      - name: Delete stale Clerk test resources
+        run: >-
+          cd e2e && pnpm exec tsx playwright/clerk-test-resources.ts
+          cleanup-stale
+          browser,playwright,paid-onboarding,runner,runner-real-codex,runner-real-claude,runner-mock-claude
+          --older-than-hours 0.5
+        env:
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          DRY_RUN: ${{ env.DRY_RUN }}

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -443,38 +443,6 @@ jobs:
           echo "Cleaned: $CLEANED"
           echo "Failures: $FAILED"
 
-  cleanup-clerk-test-resources:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          persist-credentials: false
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: 22
-      - name: Install pnpm
-        run: corepack enable pnpm
-      - name: Install E2E dependencies
-        run: cd e2e && pnpm install --frozen-lockfile
-      - name: Delete stale non-runner Clerk test resources
-        run: >-
-          cd e2e && pnpm exec tsx playwright/clerk-test-resources.ts
-          cleanup-stale browser,playwright,paid-onboarding --older-than-hours 6
-        env:
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          DRY_RUN: ${{ env.DRY_RUN }}
-      - name: Delete stale runner Clerk test resources
-        run: >-
-          cd e2e && pnpm exec tsx playwright/clerk-test-resources.ts
-          cleanup-stale runner,runner-real-codex,runner-real-claude,runner-mock-claude
-          --older-than-hours 30
-        env:
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          DRY_RUN: ${{ env.DRY_RUN }}
-
   cleanup-git-branches:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- move stale Clerk E2E resource cleanup out of the daily general maintenance workflow
- run one ownership-scoped cleanup every 30 minutes for all seven test roles after a 30-minute retention window
- serialize scheduled and manual cleanup executions without cancelling active deletion
- update the workflow contract for trigger isolation, permissions, trusted checkout, role scope, cutoff, and dry-run wiring

## Why

Runner E2E preparation reached the Clerk instance's 500-user quota and failed twice with HTTP 403. The prior once-daily fallback retained non-runner resources for 6 hours and runner resources for 30 hours, so a successful cleanup shortly before the incident could free only one user while CI created enough recent identities to refill the quota.

## Behavior and compatibility

- immediate browser, Playwright, runner-generation, successful-run, and closed-PR cleanup is unchanged
- only strictly parsed `vm0-e2e.ai` users and `vm0CiTest` organizations are eligible
- failed runner credentials remain reusable for approximately 30–60 minutes plus scheduler delay; older token artifacts can outlive their Clerk identities and require fresh preparation
- Clerk user and organization POST retry behavior is unchanged
- unrelated Neon, deployment, metal-runner, and branch cleanup remains daily/manual
- no production API, database, persisted state, runner protocol, test selection, or timeout change

## Validation

- `bash .github/scripts/tests/clerk-test-resource-workflow-test.sh`
- `bash -n .github/scripts/tests/clerk-test-resource-workflow-test.sh`
- `shellcheck .github/scripts/tests/clerk-test-resource-workflow-test.sh`
- `bash .github/scripts/check-workflow-shell-compatibility.sh`
- `bash .github/scripts/tests/check-workflow-shell-compatibility-test.sh`
- `cd turbo && pnpm exec prettier --check ../.github/workflows/cleanup-clerk-test-resources.yml ../.github/workflows/cleanup-stale.yml`
- `actionlint`
- `git diff --check`

Closes #28441
