### PR TITLE
fix(runner): defer connector diagnostics until upstream auth errors

### DIFF
--- a/crates/runner/mitm-addon/src/connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/connector_diagnostics.py
@@ -125,8 +125,8 @@ def record_allow_context(
     no-op.
 
     On success, the flow records diagnostic eligibility, active firewall names,
-    and one classification-compatible catalog snapshot. Response and error
-    phases resolve candidates only from that pinned snapshot.
+    and one classification-compatible catalog snapshot. Response phases resolve
+    candidates only from that pinned snapshot.
     """
     if classification.is_asterisk_form:
         return

--- a/crates/runner/mitm-addon/src/connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/connector_diagnostics.py
@@ -24,8 +24,8 @@ Lifecycle:
   streaming. A diagnostic stream suppresses the upstream body and emits its
   replacement content once, except that HEAD remains bodyless.
 - ``response()`` completes streamed replacement or handles buffered 401/403
-  replacement before network logging. ``error()`` may synthesize a diagnostic
-  response unless response headers already installed a replacement.
+  replacement before network logging. ``error()`` preserves connection errors
+  while finalizing any replacement already installed after 401/403 headers.
 - Terminal response, error, and WebSocket cleanup call ``release_flow_state()``
   from exception-safe cleanup to release diagnostic-private state and detach an
   installed diagnostic stream callback.
@@ -119,9 +119,10 @@ def record_allow_context(
     """Pin diagnostic lookup context for an eligible ordinary allow flow.
 
     Request-header callers use this before carrying a streamed ``allow``
-    classification into ``request()``; request callers use it before immediate
-    or deferred diagnostic resolution. A browser flow, existing diagnostic, or
-    asterisk-form target, or incomplete original-URL context is a no-op.
+    classification into ``request()``; request callers use it to defer
+    diagnostic resolution until an upstream response. A browser flow, existing
+    diagnostic, asterisk-form target, or incomplete original-URL context is a
+    no-op.
 
     On success, the flow records diagnostic eligibility, active firewall names,
     and one classification-compatible catalog snapshot. Response and error
@@ -144,48 +145,6 @@ def record_allow_context(
         sorted(_active_firewall_names(vm_info))
     )
     _pin_diagnostic_snapshot(flow, classification)
-
-
-def maybe_make_local_response(
-    flow: http.HTTPFlow,
-    *,
-    original_url: str,
-) -> bool:
-    """Create an immediate diagnostic for an ordinary allow request.
-
-    Call this from the committed request phase after ``record_allow_context()``
-    and only when request streaming has not deferred the decision. It uses the
-    pinned catalog candidate and preserves upstream handling for browser flows,
-    missing candidates, or requests carrying configured or generic auth
-    material.
-
-    Return ``True`` only after installing a local HTTP 424 response, recording
-    failure/timing/firewall metadata, and emitting the diagnostic proxy entry.
-    HEAD keeps the same diagnostic status and metadata without response content.
-    The caller must treat that response as terminal for request dispatch.
-    """
-    if _is_browser_diagnostic_skip(flow):
-        return False
-    candidate = _resolve_candidate(flow, original_url=original_url)
-    if candidate is None:
-        return False
-    if _request_may_have_auth_material(flow, candidate, original_url):
-        return False
-
-    flow_metadata.start_request_timing(flow.metadata)
-    _set_failure_metadata(flow, candidate)
-    flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
-    flow.response = _make_local_response(
-        flow,
-        candidate,
-        upstream_status=0,
-    )
-    _log_proxy_entry(
-        flow,
-        original_url=original_url,
-        upstream_status=0,
-    )
-    return True
 
 
 def maybe_make_firewall_allow_local_response(
@@ -386,42 +345,18 @@ def maybe_replace_response(
     )
 
 
-def maybe_make_error_response(
-    flow: http.HTTPFlow,
-    *,
-    original_url: str,
-) -> None:
-    """Create a connector diagnostic response during the error hook.
+def handle_error(flow: http.HTTPFlow) -> None:
+    """Finalize a response-header diagnostic after a connection error.
 
-    Call this before writing the flow's network-error entry. If response headers
-    already installed diagnostic replacement, it does not create or log another
-    diagnostic and clears trailers when a response exists. Otherwise an
-    eligible non-browser request without auth material receives a local HTTP 424
-    response with upstream status zero and one diagnostic proxy entry. HEAD keeps
-    that response bodyless.
+    Connection errors before an upstream 401/403 remain unchanged. When response
+    headers already established a diagnostic replacement, discard upstream
+    trailers before terminal cleanup detaches the owned stream callback.
     """
-    if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS):
-        if flow.response is not None:
-            flow.response.trailers = None
-        return
-    if _is_browser_diagnostic_skip(flow):
-        return
-    candidate = _resolve_candidate(flow, original_url=original_url)
-    if candidate is None:
-        return
-    if _request_may_have_auth_material(flow, candidate, original_url):
-        return
-    _set_failure_metadata(flow, candidate)
-    flow.response = _make_local_response(
-        flow,
-        candidate,
-        upstream_status=0,
-    )
-    _log_proxy_entry(
-        flow,
-        original_url=original_url,
-        upstream_status=0,
-    )
+    if (
+        flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS)
+        and flow.response is not None
+    ):
+        flow.response.trailers = None
 
 
 def release_flow_state(flow: http.HTTPFlow) -> None:

--- a/crates/runner/mitm-addon/src/connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/connector_diagnostics.py
@@ -124,6 +124,11 @@ def record_allow_context(
     diagnostic, asterisk-form target, or incomplete original-URL context is a
     no-op.
 
+    Catalog matching is only a diagnostic hint, not proof that an ordinary
+    request requires connector credentials. Preserve the original request and
+    wait for an upstream 401/403 to provide the auth-failure signal before
+    resolving an inactive connector candidate.
+
     On success, the flow records diagnostic eligibility, active firewall names,
     and one classification-compatible catalog snapshot. Response phases resolve
     candidates only from that pinned snapshot.

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1459,15 +1459,6 @@ async def request(flow: http.HTTPFlow) -> None:
 
         if classification.kind == "allow":
             connector_diagnostics.record_allow_context(flow, classification)
-            if request_streaming.streamed_request_size(flow) is None:
-                original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
-                if isinstance(
-                    original_url, str
-                ) and connector_diagnostics.maybe_make_local_response(
-                    flow,
-                    original_url=original_url,
-                ):
-                    return
             flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
             return
 
@@ -1875,7 +1866,7 @@ def _handle_error(flow: http.HTTPFlow) -> None:
     original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
     firewall_action = flow_metadata.firewall_action(flow.metadata)
 
-    connector_diagnostics.maybe_make_error_response(flow, original_url=original_url)
+    connector_diagnostics.handle_error(flow)
 
     request_size = _request_size(flow)
     error_msg = flow.error.msg if flow.error else "unknown error"

--- a/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
@@ -129,7 +129,7 @@ def test_unchanged_cache_reuses_compiled_diagnostic_snapshot(tmp_path, mitm_ctx)
 
 
 @pytest.mark.parametrize("terminal_hook", ["response", "stream", "error"])
-def test_pinned_flow_finishes_with_catalog_a_after_atomic_b_replacement(
+def test_pinned_flow_uses_catalog_a_for_auth_error_and_releases_on_connection_error(
     tmp_path,
     real_flow,
     mitm_ctx,
@@ -175,12 +175,16 @@ def test_pinned_flow_finishes_with_catalog_a_after_atomic_b_replacement(
                 streamed_body = stream_result
             mitm_addon.response(flow)
 
-    if streamed_body is not None:
+    if terminal_hook == "error":
+        assert flow.response is None
+        assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
+    elif streamed_body is not None:
         assert json.loads(streamed_body)["connector"] == "catalog-a"
     else:
         assert _response_connector(flow) == "catalog-a"
     _assert_connector_diagnostic_state_released(flow)
-    _assert_catalog_a_public_diagnostic_metadata(flow)
+    if terminal_hook != "error":
+        _assert_catalog_a_public_diagnostic_metadata(flow)
     if diagnostic_stream is not None:
         assert flow.response is not None
         assert flow.response.stream is False
@@ -242,6 +246,18 @@ async def test_later_flow_observes_atomic_catalog_replacement(
             version="catalog-b",
         )
         await mitm_addon.request(second_flow)
+        first_flow.response = tutils.tresp(
+            status_code=401,
+            headers=header_map({"content-type": "text/plain"}),
+            content=b"first upstream auth error",
+        )
+        second_flow.response = tutils.tresp(
+            status_code=401,
+            headers=header_map({"content-type": "text/plain"}),
+            content=b"second upstream auth error",
+        )
+        mitm_addon.response(first_flow)
+        mitm_addon.response(second_flow)
 
     assert _response_connector(first_flow) == "catalog-a"
     assert _response_connector(second_flow) == "catalog-b"
@@ -481,6 +497,13 @@ async def test_unavailable_flow_stays_unavailable_after_cache_recovers(
         )
         mitm_addon.response(unavailable_flow)
         await mitm_addon.request(recovered_flow)
+        assert recovered_flow.response is None
+        recovered_flow.response = tutils.tresp(
+            status_code=401,
+            headers=header_map({"content-type": "text/plain"}),
+            content=b"upstream auth error",
+        )
+        mitm_addon.response(recovered_flow)
 
     assert unavailable_flow.response.status_code == 401
     assert unavailable_flow.response.content == b"upstream auth error"

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -110,7 +110,7 @@ class TestErrorHandler:
         assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
         assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION not in flow.metadata
 
-    async def test_connector_candidate_error_gets_local_diagnostic_response(
+    async def test_connector_candidate_error_keeps_original_connection_error(
         self, tmp_path, real_flow, mitm_ctx
     ):
         reg_path = write_connector_diagnostic_capture_registry(tmp_path)
@@ -123,102 +123,22 @@ class TestErrorHandler:
         )
 
         with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-            record_connector_diagnostic_requestheaders_context(flow)
+            await mitm_addon.request(flow)
+            assert flow.response is None
             flow.error = Error("connection reset by peer")
             mitm_addon.error(flow)
 
-        assert flow.response is not None
-        assert flow.response.status_code == 424
-        content = flow.response.content
-        assert content is not None
-        body = json.loads(content)
-        assert body["error"] == "connector_not_configured_for_run"
-        assert body["connector"] == "fal"
-        assert body["envNames"] == ["FAL_TOKEN"]
-        assert body["base"] == "https://fal.run"
-        assert body["upstreamStatus"] == 0
-
+        assert flow.response is None
         [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert entry["status"] == 0
         assert entry["error"] == "connection reset by peer"
-        assert entry["firewall_error"] == "connector_not_configured_for_run"
-        assert entry["connector_diagnostic_slug"] == "fal"
-        assert entry["connector_diagnostic_env_names"] == ["FAL_TOKEN"]
-        assert entry["connector_diagnostic_base"] == "https://fal.run"
+        assert "firewall_error" not in entry
+        assert "connector_diagnostic_slug" not in entry
 
-        proxy_entries = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
-        assert proxy_entries[0]["type"] == "connector_diagnostic"
-        assert proxy_entries[0]["upstream_status"] == 0
-        assert proxy_entries[1]["type"] == "connection_error"
+        [proxy_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+        assert proxy_entry["type"] == "connection_error"
 
-    async def test_connector_candidate_error_gets_diagnostic_without_network_log(
-        self, tmp_path, real_flow, mitm_ctx
-    ):
-        reg_path = write_connector_diagnostic_capture_registry(tmp_path)
-        flow = real_flow(
-            with_response=False,
-            client_ip="10.200.0.5",
-            host="fal.run",
-            path="/fal-ai/nano-banana-pro",
-            method="POST",
-        )
-
-        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-            record_connector_diagnostic_requestheaders_context(flow)
-            flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
-            flow.metadata.pop(metadata_keys.NETWORK_LOG_TARGET)
-            flow.error = Error("connection reset by peer")
-            mitm_addon.error(flow)
-
-        assert flow.response is not None
-        assert flow.response.status_code == 424
-        content = flow.response.content
-        assert content is not None
-        body = json.loads(content)
-        assert body["error"] == "connector_not_configured_for_run"
-        assert body["connector"] == "fal"
-        assert not (tmp_path / "net.jsonl").exists()
-
-        [connector_entry, connection_entry] = read_jsonl_entries_after_flush(
-            tmp_path / "proxy.jsonl"
-        )
-        assert connector_entry["type"] == "connector_diagnostic"
-        assert connection_entry["type"] == "connection_error"
-
-    async def test_head_connector_candidate_error_gets_bodyless_diagnostic(
-        self, tmp_path, real_flow, mitm_ctx
-    ):
-        reg_path = write_connector_diagnostic_capture_registry(tmp_path)
-        flow = real_flow(
-            with_response=False,
-            client_ip="10.200.0.5",
-            host="fal.run",
-            path="/fal-ai/nano-banana-pro",
-            method="HEAD",
-        )
-
-        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-            record_connector_diagnostic_requestheaders_context(flow)
-            flow.error = Error("connection reset by peer")
-            mitm_addon.error(flow)
-
-        assert flow.response is not None
-        assert flow.response.status_code == 424
-        assert flow.response.raw_content == b""
-        assert flow.response.headers["Content-Type"] == "application/json"
-        assert flow.response.headers.get_all("Content-Length") == []
-        assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG] == "fal"
-        [network_entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
-        assert network_entry["response_size"] == 0
-        assert network_entry["error"] == "connection reset by peer"
-        assert "response_body" not in network_entry
-        [connector_entry, connection_entry] = read_jsonl_entries_after_flush(
-            tmp_path / "proxy.jsonl"
-        )
-        assert connector_entry["type"] == "connector_diagnostic"
-        assert connection_entry["type"] == "connection_error"
-
-    def test_streamed_connector_candidate_error_before_request_gets_diagnostic(
+    def test_streamed_connector_candidate_error_before_request_keeps_original_error(
         self, tmp_path, real_flow, mitm_ctx
     ):
         reg_path = write_connector_diagnostic_capture_registry(tmp_path)
@@ -235,21 +155,13 @@ class TestErrorHandler:
             flow.error = Error("connection reset by peer")
             mitm_addon.error(flow)
 
-        assert flow.response is not None
-        assert flow.response.status_code == 424
-        content = flow.response.content
-        assert content is not None
-        body = json.loads(content)
-        assert body["error"] == "connector_not_configured_for_run"
-        assert body["connector"] == "fal"
-
+        assert flow.response is None
         [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert entry["status"] == 0
         assert entry["request_size"] == len(request_chunk)
         assert entry["error"] == "connection reset by peer"
-        assert entry["firewall_error"] == "connector_not_configured_for_run"
-        assert entry["connector_diagnostic_slug"] == "fal"
-        assert entry["connector_diagnostic_env_names"] == ["FAL_TOKEN"]
+        assert "firewall_error" not in entry
+        assert "connector_diagnostic_slug" not in entry
         assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
         assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
@@ -4,14 +4,12 @@ import json
 
 import pytest
 
-import connector_diagnostics
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import request_classification
 import request_streaming
 import upstream_destination_binding
 from tests.connector_diagnostic_helpers import (
-    write_connector_diagnostic_capture_registry,
     write_connector_diagnostic_catalog_cache,
     write_shared_base_diagnostic_catalog,
 )
@@ -21,35 +19,6 @@ from tests.request_handler_helpers import (
     _vm_without_firewalls,
     _write_registry,
 )
-
-
-def _assert_fal_local_connector_diagnostic(flow):
-    assert flow.response is not None
-    assert flow.response.status_code == 424
-    content = flow.response.content
-    assert content is not None
-    body = json.loads(content)
-    assert body == {
-        "error": "connector_not_configured_for_run",
-        "connector": "fal",
-        "reason": "not_configured_for_run",
-        "message": (
-            "fal is not configured for this run. FAL_TOKEN is unavailable, "
-            "so credentials cannot be injected."
-        ),
-        "envNames": ["FAL_TOKEN"],
-        "base": "https://fal.run",
-        "upstreamStatus": 0,
-    }
-    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
-    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://fal.run"
-    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "fal"
-    assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == ""
-    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "connector_not_configured_for_run"
-    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG] == "fal"
-    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_REASON] == "not_configured_for_run"
-    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_ENV_NAMES] == ["FAL_TOKEN"]
-    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_BASE] == "https://fal.run"
 
 
 def _write_shared_base_active_firewall_registry(
@@ -410,7 +379,7 @@ async def test_shared_base_requestheaders_diagnoses_before_stream_safe_auth(
     assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata
 
 
-async def test_inactive_builtin_connector_url_without_auth_gets_local_diagnostic(
+async def test_inactive_builtin_connector_url_without_auth_allows_upstream(
     tmp_path, real_flow, mitm_ctx
 ):
     write_connector_diagnostic_catalog_cache(tmp_path)
@@ -421,159 +390,8 @@ async def test_inactive_builtin_connector_url_without_auth_gets_local_diagnostic
         host="fal.run",
         path="/fal-ai/nano-banana-pro",
         method="POST",
-    )
-
-    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        await mitm_addon.request(flow)
-        mitm_addon.response(flow)
-
-    _assert_fal_local_connector_diagnostic(flow)
-    [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
-    assert entry["action"] == "ALLOW"
-    assert entry["status"] == 424
-    assert entry["firewall_error"] == "connector_not_configured_for_run"
-    assert entry["connector_diagnostic_slug"] == "fal"
-    [proxy_entry, http_error_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
-    assert proxy_entry["type"] == "connector_diagnostic"
-    assert proxy_entry["connector"] == "fal"
-    assert proxy_entry["upstream_status"] == 0
-    assert http_error_entry["type"] == "http_error"
-    assert http_error_entry["status"] == 424
-
-
-async def test_inactive_builtin_connector_head_diagnostic_is_bodyless(
-    tmp_path, real_flow, mitm_ctx
-):
-    reg_path = write_connector_diagnostic_capture_registry(tmp_path)
-    flow = real_flow(
-        with_response=False,
-        client_ip="10.200.0.5",
-        host="fal.run",
-        path="/fal-ai/nano-banana-pro",
-        method="HEAD",
-    )
-
-    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        await mitm_addon.request(flow)
-        mitm_addon.response(flow)
-
-    assert flow.response is not None
-    assert flow.response.status_code == 424
-    assert flow.response.raw_content == b""
-    assert flow.response.headers["Content-Type"] == "application/json"
-    assert flow.response.headers.get_all("Content-Length") == []
-    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG] == "fal"
-    [network_entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
-    assert network_entry["response_size"] == 0
-    assert "response_body" not in network_entry
-    [connector_entry, http_error_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
-    assert connector_entry["type"] == "connector_diagnostic"
-    assert http_error_entry["type"] == "http_error"
-
-
-@pytest.mark.parametrize(
-    ("path", "request_header_pairs"),
-    [
-        ("/fal-ai/nano-banana-pro", [("Authorization", "Bearer ")]),
-        ("/fal-ai/nano-banana-pro", [("Authorization", "Key ")]),
-        ("/fal-ai/nano-banana-pro", [("Proxy-Authorization", "Basic proxy-secret")]),
-        ("/fal-ai/nano-banana-pro?api_key=", []),
-        ("/fal-ai/nano-banana-pro?&&api_key&api_key=+&&", []),
-    ],
-)
-async def test_inactive_builtin_connector_url_with_empty_auth_gets_local_diagnostic(
-    tmp_path, real_flow, mitm_ctx, headers, path, request_header_pairs
-):
-    write_connector_diagnostic_catalog_cache(tmp_path)
-    reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
-    flow = real_flow(
-        with_response=False,
-        client_ip="10.200.0.5",
-        host="fal.run",
-        path=path,
-        method="POST",
-        request_headers=headers(
-            ("Host", "fal.run"),
-            *request_header_pairs,
-        ),
-    )
-
-    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        await mitm_addon.request(flow)
-
-    _assert_fal_local_connector_diagnostic(flow)
-
-
-@pytest.mark.parametrize(
-    ("query", "expect_diagnostic"),
-    [
-        (
-            "&".join(["x"] * connector_diagnostics.MAX_CONNECTOR_DIAGNOSTIC_QUERY_FIELDS),
-            True,
-        ),
-        (
-            "&".join(["x"] * (connector_diagnostics.MAX_CONNECTOR_DIAGNOSTIC_QUERY_FIELDS + 1)),
-            False,
-        ),
-        (
-            "noise="
-            + "x"
-            * (connector_diagnostics.MAX_CONNECTOR_DIAGNOSTIC_QUERY_CHARACTERS - len("noise=")),
-            True,
-        ),
-        (
-            "noise="
-            + "x"
-            * (connector_diagnostics.MAX_CONNECTOR_DIAGNOSTIC_QUERY_CHARACTERS - len("noise=") + 1),
-            False,
-        ),
-    ],
-    ids=["field-limit", "over-field-limit", "character-limit", "over-character-limit"],
-)
-async def test_inactive_builtin_connector_query_inspection_boundaries(
-    tmp_path,
-    real_flow,
-    mitm_ctx,
-    query,
-    expect_diagnostic,
-):
-    write_connector_diagnostic_catalog_cache(tmp_path)
-    reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
-    flow = real_flow(
-        with_response=False,
-        client_ip="10.200.0.5",
-        host="fal.run",
-        path=f"/fal-ai/nano-banana-pro?{query}",
-        method="POST",
-    )
-
-    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        await mitm_addon.request(flow)
-
-    if expect_diagnostic:
-        _assert_fal_local_connector_diagnostic(flow)
-    else:
-        assert flow.response is None
-        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
-        assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
-
-
-async def test_inactive_builtin_connector_stops_at_auth_before_field_limit(
-    tmp_path,
-    real_flow,
-    mitm_ctx,
-):
-    write_connector_diagnostic_catalog_cache(tmp_path)
-    reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
-    trailing_query = "&".join(
-        ["x"] * (connector_diagnostics.MAX_CONNECTOR_DIAGNOSTIC_QUERY_FIELDS + 1)
-    )
-    flow = real_flow(
-        with_response=False,
-        client_ip="10.200.0.5",
-        host="fal.run",
-        path=f"/fal-ai/nano-banana-pro?api_key=user-token&{trailing_query}",
-        method="POST",
+        request_body=b'{"prompt":"original"}',
+        request_content_type="application/json",
     )
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
@@ -581,129 +399,11 @@ async def test_inactive_builtin_connector_stops_at_auth_before_field_limit(
 
     assert flow.response is None
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
-
-
-@pytest.mark.parametrize(
-    "query",
-    [
-        "API%5fKEY=user+token",
-        "api_key=&noise=x&api_key=user-token",
-        "api_key=user=token",
-        "api_key=%ZZ",
-    ],
-    ids=["percent-plus", "duplicate", "first-equals", "invalid-percent"],
-)
-async def test_inactive_builtin_connector_encoded_query_auth_allows_upstream(
-    tmp_path,
-    real_flow,
-    mitm_ctx,
-    query,
-):
-    write_connector_diagnostic_catalog_cache(tmp_path)
-    reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
-    flow = real_flow(
-        with_response=False,
-        client_ip="10.200.0.5",
-        host="fal.run",
-        path=f"/fal-ai/nano-banana-pro?{query}",
-        method="POST",
-    )
-
-    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        await mitm_addon.request(flow)
-
-    assert flow.response is None
-    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
-
-
-async def test_inactive_builtin_connector_url_with_user_auth_allows_upstream(
-    tmp_path, real_flow, mitm_ctx, headers
-):
-    write_connector_diagnostic_catalog_cache(tmp_path)
-    reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
-    flow = real_flow(
-        with_response=False,
-        client_ip="10.200.0.5",
-        host="fal.run",
-        path="/fal-ai/nano-banana-pro",
-        method="POST",
-        request_headers=headers(
-            ("Host", "fal.run"),
-            ("Authorization", "Key user-provided"),
-        ),
-    )
-
-    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        await mitm_addon.request(flow)
-
-    assert flow.response is None
-    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
-    assert metadata_keys.FIREWALL_BASE not in flow.metadata
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
-
-
-@pytest.mark.parametrize(
-    ("path", "request_header_pairs"),
-    [
-        ("/items", [("X-Workspace-Session", "user-provided")]),
-        ("/items?workspace_session=user-provided", []),
-        ("/items?WORKSPACE%5FSESSION=user+provided", []),
-    ],
-    ids=["configured-header", "configured-query", "encoded-configured-query"],
-)
-async def test_inactive_connector_url_with_configured_auth_allows_upstream(
-    tmp_path,
-    real_flow,
-    mitm_ctx,
-    headers,
-    path,
-    request_header_pairs,
-):
-    write_connector_diagnostic_catalog_cache(
-        tmp_path,
-        firewalls={
-            "configured-auth": {
-                "name": "configured-auth",
-                "apis": [
-                    {
-                        "base": "https://configured.example.com",
-                        "hostPolicy": {
-                            "kind": "providerOwned",
-                            "exactHosts": ["configured.example.com"],
-                        },
-                        "auth": {
-                            "headers": {
-                                "X-Workspace-Session": "${{ secrets.WORKSPACE_TOKEN }}",
-                            },
-                            "query": {
-                                "workspace_session": "${{ secrets.WORKSPACE_TOKEN }}",
-                            },
-                        },
-                        "permissions": [{"name": "read", "rules": ["GET /items"]}],
-                    }
-                ],
-            }
-        },
-    )
-    reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
-    flow = real_flow(
-        with_response=False,
-        client_ip="10.200.0.5",
-        host="configured.example.com",
-        path=path,
-        request_headers=headers(
-            ("Host", "configured.example.com"),
-            *request_header_pairs,
-        ),
-    )
-
-    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        await mitm_addon.request(flow)
-
-    assert flow.response is None
-    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.request.method == "POST"
+    assert flow.request.host == "fal.run"
+    assert flow.request.path == "/fal-ai/nano-banana-pro"
+    assert flow.request.raw_content == b'{"prompt":"original"}'
+    assert "Authorization" not in flow.request.headers
     assert metadata_keys.FIREWALL_BASE not in flow.metadata
     assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
 

--- a/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
@@ -3,6 +3,7 @@
 import json
 import urllib.parse
 
+import pytest
 from mitmproxy.test import tutils
 
 import connector_diagnostics
@@ -36,7 +37,13 @@ def _drain_connector_diagnostic_response_stream(flow, *, upstream_chunk: bytes =
     return diagnostic_body
 
 
-async def test_replaces_unauthenticated_connector_401_body(tmp_path, real_flow, mitm_ctx):
+@pytest.mark.parametrize("upstream_status", [401, 403])
+async def test_replaces_unauthenticated_connector_auth_error_body(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    upstream_status,
+):
     reg_path = write_connector_diagnostic_capture_registry(tmp_path)
     flow = real_flow(
         with_response=False,
@@ -47,19 +54,21 @@ async def test_replaces_unauthenticated_connector_401_body(tmp_path, real_flow, 
     )
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        record_connector_diagnostic_requestheaders_context(flow)
+        await mitm_addon.request(flow)
+        assert flow.response is None
+        assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
         flow.metadata[metadata_keys.ORIGINAL_URL] = (
             "https://fal.run/fal-ai/nano-banana-pro?debug=secret#fragment"
         )
         flow.response = tutils.tresp(
-            status_code=401,
+            status_code=upstream_status,
             headers=header_map({"content-type": "text/plain", "content-length": "8"}),
             content=b"upstream",
         )
         flow.metadata[metadata_keys.RESPONSE_STREAM_STATE] = {"total_bytes": 8}
         mitm_addon.response(flow)
 
-    assert flow.response.status_code == 401
+    assert flow.response.status_code == upstream_status
     assert flow.response.headers["content-type"] == "application/json"
     content = flow.response.content
     assert content is not None
@@ -74,11 +83,11 @@ async def test_replaces_unauthenticated_connector_401_body(tmp_path, real_flow, 
         ),
         "envNames": ["FAL_TOKEN"],
         "base": "https://fal.run",
-        "upstreamStatus": 401,
+        "upstreamStatus": upstream_status,
     }
     [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
     assert entry["action"] == "ALLOW"
-    assert entry["status"] == 401
+    assert entry["status"] == upstream_status
     assert entry["firewall_error"] == "connector_not_configured_for_run"
     assert entry["connector_diagnostic_slug"] == "fal"
     assert entry["connector_diagnostic_reason"] == "not_configured_for_run"
@@ -89,7 +98,7 @@ async def test_replaces_unauthenticated_connector_401_body(tmp_path, real_flow, 
     proxy_entry = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")[0]
     assert proxy_entry["type"] == "connector_diagnostic"
     assert proxy_entry["connector"] == "fal"
-    assert proxy_entry["upstream_status"] == 401
+    assert proxy_entry["upstream_status"] == upstream_status
     assert proxy_entry["url"] == "https://fal.run/fal-ai/nano-banana-pro"
     assert proxy_entry["message"].endswith(f": {proxy_entry['url']}")
     serialized_proxy_entry = json.dumps(proxy_entry)
@@ -323,6 +332,181 @@ def test_responseheaders_preserves_upstream_for_query_over_inspection_limit(
     assert flow.response.content == b"upstream"
     [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
     assert "firewall_error" not in entry
+
+
+@pytest.mark.parametrize(
+    ("query", "expect_diagnostic"),
+    [
+        (
+            "&".join(["x"] * connector_diagnostics.MAX_CONNECTOR_DIAGNOSTIC_QUERY_FIELDS),
+            True,
+        ),
+        (
+            "&".join(["x"] * (connector_diagnostics.MAX_CONNECTOR_DIAGNOSTIC_QUERY_FIELDS + 1)),
+            False,
+        ),
+        (
+            "noise="
+            + "x"
+            * (connector_diagnostics.MAX_CONNECTOR_DIAGNOSTIC_QUERY_CHARACTERS - len("noise=")),
+            True,
+        ),
+        (
+            "noise="
+            + "x"
+            * (connector_diagnostics.MAX_CONNECTOR_DIAGNOSTIC_QUERY_CHARACTERS - len("noise=") + 1),
+            False,
+        ),
+    ],
+    ids=["field-limit", "over-field-limit", "character-limit", "over-character-limit"],
+)
+async def test_query_inspection_boundaries_control_connector_401_diagnostic(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    query,
+    expect_diagnostic,
+):
+    reg_path = write_connector_diagnostic_capture_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="fal.run",
+        path=f"/fal-ai/nano-banana-pro?{query}",
+        method="POST",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+        assert flow.response is None
+        flow.response = tutils.tresp(
+            status_code=401,
+            headers=header_map({"content-type": "text/plain"}),
+            content=b"upstream",
+        )
+        mitm_addon.response(flow)
+
+    assert flow.response.status_code == 401
+    content = flow.response.content
+    assert content is not None
+    if expect_diagnostic:
+        assert json.loads(content)["error"] == "connector_not_configured_for_run"
+        assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG] == "fal"
+    else:
+        assert content == b"upstream"
+        assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "API%5fKEY=user+token",
+        "api_key=&noise=x&api_key=user-token",
+        "api_key=user=token",
+        "api_key=%ZZ",
+        "api_key=user-token&"
+        + "&".join(["x"] * (connector_diagnostics.MAX_CONNECTOR_DIAGNOSTIC_QUERY_FIELDS + 1)),
+    ],
+    ids=["percent-plus", "duplicate", "first-equals", "invalid-percent", "auth-before-limit"],
+)
+async def test_encoded_query_auth_preserves_connector_401(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    query,
+):
+    reg_path = write_connector_diagnostic_capture_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="fal.run",
+        path=f"/fal-ai/nano-banana-pro?{query}",
+        method="POST",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+        assert flow.response is None
+        flow.response = tutils.tresp(
+            status_code=401,
+            headers=header_map({"content-type": "text/plain"}),
+            content=b"upstream auth error",
+        )
+        mitm_addon.response(flow)
+
+    assert flow.response.status_code == 401
+    assert flow.response.content == b"upstream auth error"
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
+
+
+@pytest.mark.parametrize(
+    ("path", "request_header_pairs"),
+    [
+        ("/items", [("X-Workspace-Session", "user-provided")]),
+        ("/items?workspace_session=user-provided", []),
+        ("/items?WORKSPACE%5FSESSION=user+provided", []),
+    ],
+    ids=["configured-header", "configured-query", "encoded-configured-query"],
+)
+async def test_configured_auth_preserves_connector_401(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    headers,
+    path,
+    request_header_pairs,
+):
+    write_connector_diagnostic_catalog_cache(
+        tmp_path,
+        firewalls={
+            "configured-auth": {
+                "name": "configured-auth",
+                "apis": [
+                    {
+                        "base": "https://configured.example.com",
+                        "hostPolicy": {
+                            "kind": "providerOwned",
+                            "exactHosts": ["configured.example.com"],
+                        },
+                        "auth": {
+                            "headers": {
+                                "X-Workspace-Session": "${{ secrets.WORKSPACE_TOKEN }}",
+                            },
+                            "query": {
+                                "workspace_session": "${{ secrets.WORKSPACE_TOKEN }}",
+                            },
+                        },
+                        "permissions": [{"name": "read", "rules": ["GET /items"]}],
+                    }
+                ],
+            }
+        },
+    )
+    reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="configured.example.com",
+        path=path,
+        request_headers=headers(
+            ("Host", "configured.example.com"),
+            *request_header_pairs,
+        ),
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+        assert flow.response is None
+        flow.response = tutils.tresp(
+            status_code=401,
+            headers=header_map({"content-type": "text/plain"}),
+            content=b"upstream auth error",
+        )
+        mitm_addon.response(flow)
+
+    assert flow.response.status_code == 401
+    assert flow.response.content == b"upstream auth error"
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
 
 
 async def test_restores_connector_diagnostic_body_when_headers_end_stream(
@@ -983,7 +1167,14 @@ async def test_cached_connector_candidate_keeps_specific_query_auth_hint(
     assert "firewall_error" not in entry
 
 
-async def test_preserves_successful_connector_response_body(tmp_path, real_flow, mitm_ctx, headers):
+@pytest.mark.parametrize("status_code", [200, 404, 500])
+async def test_preserves_non_auth_connector_response(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    status_code,
+):
+    write_connector_diagnostic_catalog_cache(tmp_path)
     reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
     flow = real_flow(
         with_response=False,
@@ -991,24 +1182,33 @@ async def test_preserves_successful_connector_response_body(tmp_path, real_flow,
         host="fal.run",
         path="/fal-ai/nano-banana-pro",
         method="POST",
-        request_headers=headers(
-            ("Host", "fal.run"),
-            ("Authorization", "Key user-provided"),
-        ),
     )
+    upstream_body = f"upstream-{status_code}".encode()
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
         await mitm_addon.request(flow)
+        assert flow.response is None
         flow.response = tutils.tresp(
-            status_code=200,
-            headers=header_map({"content-type": "application/json"}),
-            content=b'{"ok":true}',
+            status_code=status_code,
+            headers=header_map(
+                {
+                    "content-type": "text/plain",
+                    "x-upstream-result": "preserved",
+                }
+            ),
+            content=upstream_body,
         )
         mitm_addon.response(flow)
 
-    assert flow.response.content == b'{"ok":true}'
+    assert flow.response.status_code == status_code
+    assert flow.response.content == upstream_body
+    assert flow.response.headers["x-upstream-result"] == "preserved"
+    assert metadata_keys.FIREWALL_ERROR not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_SLUG not in flow.metadata
     [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
-    assert entry["status"] == 200
+    assert entry["status"] == status_code
+    assert "firewall_error" not in entry
+    assert "connector_diagnostic_slug" not in entry
 
 
 async def test_preserves_browser_403_body_for_connector_candidate(


### PR DESCRIPTION
## Summary

- forward ordinary allow requests to upstream instead of returning an eager inactive-connector 424
- preserve successful, non-auth HTTP, and connection-error outcomes unchanged
- replace only eligible upstream 401/403 responses with `connector_not_configured_for_run`
- retain bounded auth detection and request-pinned catalog snapshot behavior at response time

## Explicit exclusions

- active connector `/firewall/auth` failures remain authoritative local responses
- shared-base unknown-endpoint diagnostics remain request-time checks because they prevent cross-connector credential injection after an active connector base match

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest --basetemp /workspaces/vm8/codex-work/pytest/issue-28444-full-3 tests/` (6432 passed)

Closes #28444
