### PR TITLE
fix(connectors): handle removed catalog references

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -1497,6 +1497,13 @@ describe("CHAT-02: thread connector account selection", () => {
       { apiKey: "retired-thread-openai-key" },
       agentId,
     );
+    const runtimeConnection = await connectors.connectManualGrant(
+      actor,
+      "runtime",
+      "api-token",
+      { apiKey: "retired-thread-runtime-key" },
+      agentId,
+    );
     const thread = await chat.createThread(actor, {
       agentId,
       title: "Retired catalog connector thread",
@@ -1508,6 +1515,17 @@ describe("CHAT-02: thread connector account selection", () => {
         body: {
           connectionId: connection.id,
           target: { kind: "builtin", connectorSlug: "openai" },
+        },
+      }),
+      [200],
+    );
+    await accept(
+      chatThreadConnectorSelectionsClient().update({
+        headers: sessionHeaders(actor),
+        params: { id: thread.id },
+        body: {
+          connectionId: runtimeConnection.id,
+          target: { kind: "builtin", connectorSlug: "runtime" },
         },
       }),
       [200],
@@ -1539,6 +1557,66 @@ describe("CHAT-02: thread connector account selection", () => {
     expect(
       claimed.claim.secretConnectorMetadataMap?.OPENAI_TOKEN,
     ).toBeUndefined();
+
+    const selections = await accept(
+      chatThreadConnectorSelectionsClient().get({
+        headers: sessionHeaders(actor),
+        params: { id: thread.id },
+      }),
+      [200],
+    );
+    expect(selections.body.selections).toStrictEqual([
+      {
+        connectionId: runtimeConnection.id,
+        target: { kind: "builtin", connectorSlug: "runtime" },
+      },
+    ]);
+    await accept(
+      chatThreadConnectorSelectionsClient().update({
+        headers: sessionHeaders(actor),
+        params: { id: thread.id },
+        body: {
+          connectionId: connection.id,
+          target: { kind: "builtin", connectorSlug: "openai" },
+        },
+      }),
+      [400],
+    );
+    await accept(
+      chatThreadsClient().create({
+        headers: sessionHeaders(actor),
+        body: {
+          agentId,
+          model: "claude-sonnet-5",
+          connectorSelections: [
+            {
+              connectionId: connection.id,
+              target: { kind: "builtin", connectorSlug: "openai" },
+            },
+          ],
+        },
+      }),
+      [400],
+    );
+    await accept(
+      chatThreadConnectorSelectionsClient().clear({
+        headers: sessionHeaders(actor),
+        params: { id: thread.id },
+        body: { kind: "builtin", connectorSlug: "openai" },
+      }),
+      [204],
+    );
+    await installApiTestConnectorCatalog();
+    const restoredSelections = await accept(
+      chatThreadConnectorSelectionsClient().get({
+        headers: sessionHeaders(actor),
+        params: { id: thread.id },
+      }),
+      [200],
+    );
+    expect(restoredSelections.body.selections).toStrictEqual(
+      selections.body.selections,
+    );
     await cancelChatRun(actor, run.runId, claimed.sandboxHeaders);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -2898,6 +2898,127 @@ describe("connector catalog valid lifecycle", () => {
     await runs.requestCancelRun(actor, run.runId, [200]);
   }, 15_000);
 
+  it("omits and clears permission grants for a removed catalog connector", async () => {
+    const removedConnectorSlug = "external-removed-permissions";
+    const currentConnectorSlug = "external-current-permissions";
+    configureSource();
+    const removedRelease = buildRelease({
+      version: "2026-07-15.external-removed-permissions",
+      connectorSlug: removedConnectorSlug,
+      label: "External Removed Permissions",
+      generatedFirewall: true,
+    });
+    serveObjects(catalogObjects([removedRelease], removedRelease));
+    await syncCatalog();
+
+    const actor = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    const agent = await bdd.createAgent(actor, {
+      displayName: "Removed catalog permission agent",
+      visibility: "private",
+    });
+    onTestFinished(async () => {
+      context.mocks.s3.send.mockResolvedValue({ Contents: [] });
+      await bdd.deleteVersionFreeAgent(actor, agent.agentId);
+    });
+    zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const client = setupApp({ context, routes: userPermissionGrantsRoutes })(
+      zeroUserPermissionGrantsContract,
+    );
+    await accept(
+      client.apply({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentId: agent.agentId,
+          connectorSlug: removedConnectorSlug,
+          mode: "replace",
+          grants: [{ permission: "items.read", action: "deny" }],
+        },
+      }),
+      [200],
+    );
+
+    const currentRelease = buildRelease({
+      version: "2026-07-15.external-current-permissions",
+      connectorSlug: currentConnectorSlug,
+      label: "External Current Permissions",
+      generatedFirewall: true,
+    });
+    serveObjects(
+      catalogObjects([removedRelease, currentRelease], currentRelease),
+    );
+    await syncCatalog();
+    await accept(
+      client.apply({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentId: agent.agentId,
+          connectorSlug: currentConnectorSlug,
+          mode: "replace",
+          grants: [{ permission: "items.read", action: "allow" }],
+        },
+      }),
+      [200],
+    );
+
+    const listed = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+        query: { agentId: agent.agentId },
+      }),
+      [200],
+    );
+    expect(listed.body).toStrictEqual([
+      expect.objectContaining({
+        connectorSlug: currentConnectorSlug,
+        permission: "items.read",
+        action: "allow",
+      }),
+    ]);
+
+    const rejected = await accept(
+      client.apply({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentId: agent.agentId,
+          connectorSlug: removedConnectorSlug,
+          mode: "replace",
+          grants: [{ permission: "items.read", action: "deny" }],
+        },
+      }),
+      [400],
+    );
+    expect(rejected.body.error.message).toBe(
+      `Unknown connector slug: ${removedConnectorSlug}`,
+    );
+    const cleared = await accept(
+      client.apply({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          agentId: agent.agentId,
+          connectorSlug: removedConnectorSlug,
+          mode: "replace",
+          grants: [],
+        },
+      }),
+      [200],
+    );
+    expect(cleared.body).toStrictEqual([]);
+
+    serveObjects(
+      catalogObjects([removedRelease, currentRelease], removedRelease),
+    );
+    await syncCatalog();
+    const restored = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+        query: { agentId: agent.agentId },
+      }),
+      [200],
+    );
+    expect(restored.body).toStrictEqual([]);
+  });
+
   it("wakes claimed runs when a custom permission bundle changes", async () => {
     const connectorSlug = "external-custom-permissions";
     configureSource();
@@ -3940,7 +4061,7 @@ describe("connector catalog valid lifecycle", () => {
     );
   });
 
-  it("uses one external release for readiness status and connector metadata", async () => {
+  it("uses the active external release for workflow connector readiness", async () => {
     mockGmailConnectorOAuth({ email: "readiness@example.test" });
     configureSource();
     const connectedRelease = buildRelease({
@@ -4168,6 +4289,48 @@ describe("connector catalog valid lifecycle", () => {
       },
     ]);
     expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeReadiness);
+
+    const removedRelease = buildRelease({
+      version: "2026-07-15.external-readiness-removed",
+      connectorSlug: "external-readiness-replacement",
+      label: "External Readiness Replacement",
+    });
+    serveObjects(
+      catalogObjects(
+        [connectedRelease, unavailableRelease, removedRelease],
+        removedRelease,
+      ),
+    );
+    await syncCatalog();
+    const callsBeforeRemovedReadiness = context.mocks.s3.send.mock.calls.length;
+    const removedReadiness = await accept(
+      setupApp({ context, routes: workflowsRoutes })(
+        workflowsDetailContract,
+      ).connectorReadiness({
+        headers,
+        params: { workflowId: workflow.body.id },
+      }),
+      [200],
+    );
+    expect(removedReadiness.body.connectors).toStrictEqual([
+      {
+        connectorSlug: "gmail",
+        label: "gmail",
+        reason: "This workflow has a Gmail event automation.",
+        status: "unavailable",
+      },
+    ]);
+    expect(context.mocks.s3.send).toHaveBeenCalledTimes(
+      callsBeforeRemovedReadiness,
+    );
+
+    serveObjects(
+      catalogObjects(
+        [connectedRelease, unavailableRelease, removedRelease],
+        connectedRelease,
+      ),
+    );
+    await syncCatalog();
   });
 
   it("does not persist an in-flight refresh after the connector is replaced", async () => {

--- a/turbo/apps/api/src/signals/services/chat-thread-connector-selection.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-connector-selection.service.ts
@@ -22,6 +22,11 @@ import {
   loadAgentConnectorScope,
   type AgentConnectorScope,
 } from "./agent-connector-scope.service";
+import {
+  getConnectorRuntimeConnector,
+  loadConnectorRuntimeSnapshot,
+  type ConnectorRuntimeSelection,
+} from "./connector-catalog-runtime.service";
 
 interface OwnedChatThread {
   readonly agentId: string;
@@ -85,6 +90,29 @@ function selectionFromRow(
     connectionId: row.connectorId,
     target: targetFromRow(row),
   };
+}
+
+function targetExistsInCatalog(
+  snapshot: ConnectorRuntimeSelection | undefined,
+  target: ConnectorAccountTarget,
+): boolean {
+  return (
+    target.kind === "custom" ||
+    (snapshot !== undefined &&
+      getConnectorRuntimeConnector(snapshot, target.connectorSlug) !==
+        undefined)
+  );
+}
+
+async function loadSnapshotForBuiltinTargets(
+  db: ReadonlyDb,
+  selections: readonly ConnectorAccountSelection[],
+): Promise<ConnectorRuntimeSelection | undefined> {
+  return selections.some((selection) => {
+    return selection.target.kind === "builtin";
+  })
+    ? await loadConnectorRuntimeSnapshot(db)
+    : undefined;
 }
 
 function targetColumns(target: ConnectorAccountTarget): {
@@ -190,7 +218,11 @@ export async function listChatThreadConnectorSelections(
     return null;
   }
   const rows = await loadSelectionRows(db, args.chatThreadId);
-  return rows.map(selectionFromRow);
+  const selections = rows.map(selectionFromRow);
+  const snapshot = await loadSnapshotForBuiltinTargets(db, selections);
+  return selections.filter((selection) => {
+    return targetExistsInCatalog(snapshot, selection.target);
+  });
 }
 
 export async function prepareChatThreadConnectorSelections(
@@ -217,8 +249,16 @@ export async function prepareChatThreadConnectorSelections(
     return { kind: "ready", selections: [] };
   }
 
+  const selections = [...byTarget.values()];
   const scope = await loadAgentConnectorScope(db, args);
+  const snapshot = await loadSnapshotForBuiltinTargets(db, selections);
   for (const selection of byTarget.values()) {
+    if (!targetExistsInCatalog(snapshot, selection.target)) {
+      return {
+        kind: "invalid",
+        message: "Connector target is unavailable",
+      };
+    }
     if (!targetIsAuthorized(scope, selection.target)) {
       return {
         kind: "invalid",
@@ -230,7 +270,7 @@ export async function prepareChatThreadConnectorSelections(
   const resolutions = await resolveConnectorAccounts(db, {
     orgId: args.orgId,
     userId: args.userId,
-    requests: [...byTarget.values()].map((selection) => {
+    requests: selections.map((selection) => {
       return {
         target: selection.target,
         selection: {

--- a/turbo/apps/api/src/signals/services/user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/user-permission-grants.service.ts
@@ -671,6 +671,9 @@ async function validateApplyUserPermissionGrants(
 ): Promise<ValidationErrorResponse | null> {
   const index = await catalog.loadPermissionIndex(apply.connectorSlug);
   if (!index) {
+    if (apply.mode === "replace" && apply.grants.length === 0) {
+      return null;
+    }
     return validationError(`Unknown connector slug: ${apply.connectorSlug}`);
   }
 
@@ -860,12 +863,17 @@ export const listUserPermissionGrants$ = command(
 
     const grants = await loadActiveUserPermissionGrants(db, scope);
     signal.throwIfAborted();
+    const snapshot =
+      grants.length === 0 ? undefined : await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
     const responseScope = permissionGrantResponseScope(scope);
 
     return {
       kind: "ok" as const,
-      grants: grants.map((grant) => {
-        return formatUserPermissionGrant(grant, responseScope);
+      grants: grants.flatMap((grant) => {
+        return snapshot?.connectors.has(grant.connectorSlug)
+          ? [formatUserPermissionGrant(grant, responseScope)]
+          : [];
       }),
     };
   },

--- a/turbo/apps/api/src/signals/services/workflow-connector-readiness.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-connector-readiness.service.ts
@@ -353,15 +353,12 @@ export const detectWorkflowConnectorReadiness$ = command(
       const catalogEntry = statusBySlug.get(connectorSlug);
       if (!catalogEntry) {
         const fallbackMetadata = automationFallbackMetadata.get(connectorSlug);
-        if (!fallbackMetadata) {
-          throw new Error(
-            `Missing connector catalog metadata: ${connectorSlug}`,
-          );
-        }
         connectors.push({
           connectorSlug,
-          label: fallbackMetadata.label,
-          icon: fallbackMetadata.icon,
+          label: fallbackMetadata?.label ?? connectorSlug,
+          ...(fallbackMetadata === undefined
+            ? {}
+            : { icon: fallbackMetadata.icon }),
           reason,
           status: "unavailable",
         });

--- a/turbo/packages/api-contracts/src/contracts/workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/workflows.ts
@@ -1587,7 +1587,7 @@ export type WorkflowConnectorReadinessStatus = z.infer<
 export const workflowConnectorReadinessEntrySchema = z.object({
   connectorSlug: connectorSlugSchema,
   label: z.string().min(1),
-  icon: publicConnectorCatalogIconSchema,
+  icon: publicConnectorCatalogIconSchema.optional(),
   reason: z.string().min(1),
   status: workflowConnectorReadinessStatusSchema,
 });


### PR DESCRIPTION
## Summary

- Resolve persisted built-in connector references against the current accepted catalog before exposing or accepting thread account selections.
- Omit removed connectors from permission-grant reads, reject new grants for them, and keep empty replace available for explicit cleanup.
- Report workflow requirements for fully removed connectors as unavailable without inventing catalog metadata or returning a server error.

## Scope

- Existing stale rows remain stored until a user explicitly clears them; reads and runtime behavior use the current catalog as authority.
- Custom connectors and current built-in connectors keep their existing behavior.
- No schema migration or background data cleanup is included.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/api-contracts test`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace api --workspace @okouai/api-contracts --workspace @okouai/app`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts` (119/119 in an isolated migrated database)
- Focused regressions for permission grants, chat thread creation, and workflow routes

Closes #28448
