### PR TITLE
feat(api): add managed model provider failure endpoint

### DIFF
--- a/crates/api-contracts/src/generated/routes.rs
+++ b/crates/api-contracts/src/generated/routes.rs
@@ -210,6 +210,39 @@ pub mod runners {
                     }
                 }
             }
+
+            /// Generated route bindings under `runners::runs::by_run_id::model_provider_failures`.
+            pub mod model_provider_failures {
+                /// Report a managed model provider failure for a run.
+                /// Route contract: `POST /api/runners/runs/:runId/model-provider-failures`.
+                pub const REPORT: crate::RouteTemplate = crate::RouteTemplate {
+                    method: crate::Method::Post,
+                    path: "/api/runners/runs/:runId/model-provider-failures",
+                };
+
+                /// Path parameters for `POST /api/runners/runs/:runId/model-provider-failures`.
+                #[derive(Debug, Clone, Copy)]
+                pub struct Params<'a> {
+                    /// Value for the `:runId` path parameter.
+                    pub run_id: &'a str,
+                }
+
+                /// Build the concrete path for `POST /api/runners/runs/:runId/model-provider-failures`.
+                /// Percent-encodes each path parameter as a URL path segment.
+                #[must_use]
+                pub fn path(params: Params<'_>) -> String {
+                    format!(
+                        "/api/runners/runs/{}/model-provider-failures",
+                        crate::route::encode_path_segment(params.run_id),
+                    )
+                }
+
+                /// Build a resolved route for `POST /api/runners/runs/:runId/model-provider-failures`.
+                #[must_use]
+                pub fn route(params: Params<'_>) -> crate::ResolvedRoute {
+                    crate::ResolvedRoute::new(REPORT.method, path(params))
+                }
+            }
         }
     }
 }

--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -111,16 +111,6 @@ pub mod runners {
 
         /// DTOs for reporting bounded managed model provider failures.
         pub mod model_provider_failures {
-            /// Official runner process identity that won the run claim.
-            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-            #[serde(rename_all = "camelCase")]
-            pub struct RequestRunnerIdentity {
-                /// Stable runner process identifier.
-                pub runner_id: String,
-                /// Runner heartbeat generation active when the run was claimed.
-                pub heartbeat_generation: i64,
-            }
-
             /// Bounded provider-independent failure eligible for route cooldown.
             #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
             pub enum RequestFailureKind {
@@ -148,8 +138,6 @@ pub mod runners {
             #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
             #[serde(rename_all = "camelCase")]
             pub struct Request {
-                /// Winning runner identity for the reported run.
-                pub runner_identity: RequestRunnerIdentity,
                 /// Normalized eligible provider failure kind.
                 pub failure_kind: RequestFailureKind,
                 /// Optional bounded provider retry delay in seconds.

--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -108,6 +108,55 @@ pub mod runners {
                 }
             }
         }
+
+        /// DTOs for reporting bounded managed model provider failures.
+        pub mod model_provider_failures {
+            /// Official runner process identity that won the run claim.
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            pub struct RequestRunnerIdentity {
+                /// Stable runner process identifier.
+                pub runner_id: String,
+                /// Runner heartbeat generation active when the run was claimed.
+                pub heartbeat_generation: i64,
+            }
+
+            /// Bounded provider-independent failure eligible for route cooldown.
+            #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+            pub enum RequestFailureKind {
+                /// Provider authentication failed.
+                #[serde(rename = "authentication")]
+                Authentication,
+                /// Provider billing rejected the request.
+                #[serde(rename = "billing")]
+                Billing,
+                /// Provider rate limiting rejected the request.
+                #[serde(rename = "rate_limit")]
+                RateLimit,
+                /// The provider route was unavailable or overloaded.
+                #[serde(rename = "provider_unavailable")]
+                ProviderUnavailable,
+                /// The provider inference request timed out.
+                #[serde(rename = "timeout")]
+                Timeout,
+                /// The provider connection failed.
+                #[serde(rename = "connection")]
+                Connection,
+            }
+
+            /// Request body for reporting a managed model provider failure.
+            #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            pub struct Request {
+                /// Winning runner identity for the reported run.
+                pub runner_identity: RequestRunnerIdentity,
+                /// Normalized eligible provider failure kind.
+                pub failure_kind: RequestFailureKind,
+                /// Optional bounded provider retry delay in seconds.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub retry_after_seconds: Option<i64>,
+            }
+        }
     }
 
     /// Storage manifest DTOs used by runners to mount volumes and artifacts.

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -97,12 +97,6 @@ type RunnerJobClaimRequest = z.infer<
 type RunnerModelProviderFailureRequest = z.infer<
   (typeof runnersModelProviderFailuresContract.report)["body"]
 >;
-type RunnerModelProviderFailureInput = Omit<
-  RunnerModelProviderFailureRequest,
-  "runnerIdentity"
-> & {
-  readonly runnerIdentity?: RunnerModelProviderFailureRequest["runnerIdentity"];
-};
 type RunnerConnectorRuntimeSyncRequest = z.input<
   (typeof runnersConnectorRuntimeSyncContract.sync)["body"]
 >;
@@ -501,13 +495,13 @@ export function createRunsApi(context: TestContext) {
 
     async reportRunnerModelProviderFailure(
       runId: string,
-      body: RunnerModelProviderFailureInput,
+      body: RunnerModelProviderFailureRequest,
     ) {
       const response = await accept(
         runApp(context)(runnersModelProviderFailuresContract).report({
           headers: runnerHeaders(true),
           params: { runId },
-          body: { runnerIdentity: defaultRunnerIdentity, ...body },
+          body,
         }),
         [200],
       );
@@ -518,13 +512,13 @@ export function createRunsApi(context: TestContext) {
       authorization: string | undefined,
       runId: string,
       statuses: readonly (200 | 400 | 401 | 403 | 500)[],
-      body: RunnerModelProviderFailureInput,
+      body: RunnerModelProviderFailureRequest,
     ) {
       return await accept(
         runApp(context)(runnersModelProviderFailuresContract).report({
           headers: authorization === undefined ? {} : { authorization },
           params: { runId },
-          body: { runnerIdentity: defaultRunnerIdentity, ...body },
+          body,
         }),
         statuses,
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -32,6 +32,7 @@ import {
   runnersConnectorRuntimeSyncContract,
   runnersHeartbeatContract,
   runnersJobClaimContract,
+  runnersModelProviderFailuresContract,
   runnersPollContract,
   type CanonicalStorageManifest,
   type StorageManifest,
@@ -93,6 +94,15 @@ interface RunsListQuery {
 type RunnerJobClaimRequest = z.infer<
   (typeof runnersJobClaimContract.claim)["body"]
 >;
+type RunnerModelProviderFailureRequest = z.infer<
+  (typeof runnersModelProviderFailuresContract.report)["body"]
+>;
+type RunnerModelProviderFailureInput = Omit<
+  RunnerModelProviderFailureRequest,
+  "runnerIdentity"
+> & {
+  readonly runnerIdentity?: RunnerModelProviderFailureRequest["runnerIdentity"];
+};
 type RunnerConnectorRuntimeSyncRequest = z.input<
   (typeof runnersConnectorRuntimeSyncContract.sync)["body"]
 >;
@@ -487,6 +497,53 @@ export function createRunsApi(context: TestContext) {
         [200],
       );
       return response.body;
+    },
+
+    async reportRunnerModelProviderFailure(
+      runId: string,
+      body: RunnerModelProviderFailureInput,
+    ) {
+      const response = await accept(
+        runApp(context)(runnersModelProviderFailuresContract).report({
+          headers: runnerHeaders(true),
+          params: { runId },
+          body: { runnerIdentity: defaultRunnerIdentity, ...body },
+        }),
+        [200],
+      );
+      return response.body;
+    },
+
+    async requestRunnerModelProviderFailureAs(
+      authorization: string | undefined,
+      runId: string,
+      statuses: readonly (200 | 400 | 401 | 403 | 500)[],
+      body: RunnerModelProviderFailureInput,
+    ) {
+      return await accept(
+        runApp(context)(runnersModelProviderFailuresContract).report({
+          headers: authorization === undefined ? {} : { authorization },
+          params: { runId },
+          body: { runnerIdentity: defaultRunnerIdentity, ...body },
+        }),
+        statuses,
+      );
+    },
+
+    async requestRawRunnerModelProviderFailure(
+      validAuth: boolean,
+      runId: string,
+      statuses: readonly (200 | 400 | 401 | 403 | 500)[],
+      body: unknown,
+    ) {
+      return await accept(
+        runApp(context)(runnersModelProviderFailuresContract).report({
+          headers: runnerHeaders(validAuth),
+          params: { runId },
+          body: body as RunnerModelProviderFailureRequest,
+        }),
+        statuses,
+      );
     },
 
     async requestReserveRunnerActiveInputsAs<

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -154,14 +154,7 @@ export async function setVm0ManagedCandidateCooldownFixture(
     upstream_model: route.upstream_model,
     unavailable_until: unavailableUntil.toISOString(),
   });
-  onTestFinished(async () => {
-    await postAction(context, {
-      action: "delete-vm0-managed-candidate-cooldown",
-      selected_model: selectedModel,
-      provider_type: route.provider_type,
-      upstream_model: route.upstream_model,
-    });
-  });
+  registerVm0ManagedCandidateCooldownCleanup(context, selectedModel, route);
 }
 
 export function registerVm0ManagedCandidateCooldownCleanup(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -164,6 +164,21 @@ export async function setVm0ManagedCandidateCooldownFixture(
   });
 }
 
+export function registerVm0ManagedCandidateCooldownCleanup(
+  context: TestContext,
+  selectedModel: string,
+  route: ManagedModelRuntimeRouteFixture,
+): void {
+  onTestFinished(async () => {
+    await postAction(context, {
+      action: "delete-vm0-managed-candidate-cooldown",
+      selected_model: selectedModel,
+      provider_type: route.provider_type,
+      upstream_model: route.upstream_model,
+    });
+  });
+}
+
 export async function readBrowserScreenshotSchemaAvailable(
   context: TestContext,
 ): Promise<boolean> {

--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -28,10 +28,6 @@ interface ClaimedVm0Run {
   readonly actor: ReturnType<typeof bdd.user>;
   readonly agentId: string;
   readonly runId: string;
-  readonly runnerIdentity: {
-    readonly runnerId: string;
-    readonly heartbeatGeneration: number;
-  };
   readonly selectedModel: string;
 }
 
@@ -68,7 +64,6 @@ async function createClaimedVm0Run(): Promise<ClaimedVm0Run> {
     actor,
     agentId: agent.agentId,
     runId: run.runId,
-    runnerIdentity,
     selectedModel: keyFixture.selectedModel,
   };
 }
@@ -283,7 +278,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
 
       await expect(
         runs.reportRunnerModelProviderFailure(claimed.runId, {
-          runnerIdentity: claimed.runnerIdentity,
           failureKind: "authentication",
         }),
       ).resolves.toStrictEqual({ outcome: "recorded" });
@@ -351,7 +345,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
 
       await expect(
         runs.reportRunnerModelProviderFailure(claimed.runId, {
-          runnerIdentity: claimed.runnerIdentity,
           failureKind: "rate_limit",
           retryAfterSeconds: 300,
         }),
@@ -361,12 +354,10 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         await expect(
           Promise.all([
             runs.reportRunnerModelProviderFailure(claimed.runId, {
-              runnerIdentity: claimed.runnerIdentity,
               failureKind: "timeout",
               retryAfterSeconds: 1,
             }),
             runs.reportRunnerModelProviderFailure(claimed.runId, {
-              runnerIdentity: claimed.runnerIdentity,
               failureKind: "provider_unavailable",
               retryAfterSeconds: 300,
             }),
@@ -404,7 +395,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     });
   });
 
-  it("rejects untrusted evidence and ignores ineligible runs", async () => {
+  it("rejects untrusted or invalid reports and ignores ineligible runs", async () => {
     const startedAt = Date.UTC(2026, 7, 21, 2, 0, 0);
     await withMockNowForTest(startedAt, async () => {
       const claimed = await createClaimedVm0Run();
@@ -427,7 +418,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         claimed.runId,
         [401],
         {
-          runnerIdentity: claimed.runnerIdentity,
           failureKind: "connection",
         },
       );
@@ -438,7 +428,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         claimed.runId,
         [401],
         {
-          runnerIdentity: claimed.runnerIdentity,
           failureKind: "connection",
         },
       );
@@ -450,43 +439,20 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         claimed.runId,
         [403],
         {
-          runnerIdentity: claimed.runnerIdentity,
           failureKind: "connection",
         },
       );
       expectApiError(patAuth.body);
 
-      await expect(
-        runs.reportRunnerModelProviderFailure(claimed.runId, {
-          runnerIdentity: {
-            ...claimed.runnerIdentity,
-            runnerId: randomUUID(),
-          },
-          failureKind: "connection",
-        }),
-      ).resolves.toStrictEqual({ outcome: "ignored" });
-      await expect(
-        runs.reportRunnerModelProviderFailure(claimed.runId, {
-          runnerIdentity: {
-            ...claimed.runnerIdentity,
-            heartbeatGeneration: claimed.runnerIdentity.heartbeatGeneration + 1,
-          },
-          failureKind: "connection",
-        }),
-      ).resolves.toStrictEqual({ outcome: "ignored" });
-
       for (const body of [
         {
-          runnerIdentity: claimed.runnerIdentity,
           failureKind: "connection",
           selectedModel: claimed.selectedModel,
         },
         {
-          runnerIdentity: claimed.runnerIdentity,
           failureKind: "success",
         },
         {
-          runnerIdentity: claimed.runnerIdentity,
           failureKind: "connection",
           retryAfterSeconds: 301,
         },
@@ -514,7 +480,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
           claimed.runId,
           [400],
           {
-            runnerIdentity: claimed.runnerIdentity,
             failureKind,
           },
         );
@@ -538,7 +503,6 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
       });
       await expect(
         runs.reportRunnerModelProviderFailure(byokRun.runId, {
-          runnerIdentity: byokRunnerIdentity,
           failureKind: "billing",
         }),
       ).resolves.toStrictEqual({ outcome: "ignored" });

--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -1,17 +1,19 @@
 import { randomUUID } from "node:crypto";
 
+import { DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL } from "@okouai/api-contracts/contracts/model-providers";
 import { ALL_RUN_STATUSES } from "@okouai/api-contracts/contracts/runs";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
 import { withMockNowForTest } from "../../../lib/time";
-import { createBddApi } from "./helpers/api-bdd";
+import { createBddApi, expectApiError } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import {
   resolveVm0ManagedModelRouteFixture,
+  registerVm0ManagedCandidateCooldownCleanup,
   seedVm0ManagedModelCandidateKeys,
   seedVm0ManagedModelKey,
   setVm0ManagedCandidateCooldownFixture,
@@ -21,6 +23,55 @@ const context = testContext();
 const bdd = createBddApi(context);
 const chat = createChatFilesBddApi(context);
 const runs = createRunsApi(context);
+
+interface ClaimedVm0Run {
+  readonly actor: ReturnType<typeof bdd.user>;
+  readonly agentId: string;
+  readonly runId: string;
+  readonly runnerIdentity: {
+    readonly runnerId: string;
+    readonly heartbeatGeneration: number;
+  };
+  readonly selectedModel: string;
+}
+
+async function createClaimedVm0Run(): Promise<ClaimedVm0Run> {
+  const keyFixture = await seedVm0ManagedModelCandidateKeys(
+    context,
+    DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+  );
+  const actor = bdd.user();
+  bdd.acceptAgentStorageWrites();
+  runs.acceptStorageDownloads();
+  runs.acceptTelemetryIngest();
+  const runnerGroup = runs.configureRunnerGroup();
+  await runs.grantProEntitlement(actor);
+  await runs.ensureOrgModelProvider(actor);
+  const agent = await bdd.createAgent(actor, {
+    displayName: "BDD managed model failure report agent",
+  });
+  const run = await runs.createRun(actor, {
+    agentId: agent.agentId,
+    prompt: "report a managed model provider failure",
+    modelProvider: "vm0",
+  });
+  const runnerIdentity = {
+    runnerId: randomUUID(),
+    heartbeatGeneration: 7,
+  };
+  await runs.heartbeatRunner(runnerGroup);
+  await runs.claimRunnerJob(run.runId, { runnerIdentity });
+  onTestFinished(async () => {
+    await runs.requestCancelRun(actor, run.runId, [200, 400]);
+  });
+  return {
+    actor,
+    agentId: agent.agentId,
+    runId: run.runId,
+    runnerIdentity,
+    selectedModel: keyFixture.selectedModel,
+  };
+}
 
 describe("POST /api/test/runtime-state/action", () => {
   it("keeps overlapping VM0 managed model-key fixtures independently releasable", async () => {
@@ -207,6 +258,301 @@ describe("POST /api/test/runtime-state/action", () => {
       await expect(
         resolveVm0ManagedModelRouteFixture(context, "claude-fable-5", true),
       ).resolves.toMatchObject({ provider_type: "anthropic-api-key" });
+    });
+  });
+});
+
+describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
+  it("records a bounded cooldown for only the persisted managed route", async () => {
+    const startedAt = Date.UTC(2026, 7, 21, 0, 0, 0);
+    await withMockNowForTest(startedAt, async () => {
+      const claimed = await createClaimedVm0Run();
+      const primary = await resolveVm0ManagedModelRouteFixture(
+        context,
+        claimed.selectedModel,
+        true,
+      );
+      if (!primary) {
+        throw new Error("Expected a managed model primary route");
+      }
+      registerVm0ManagedCandidateCooldownCleanup(
+        context,
+        claimed.selectedModel,
+        primary,
+      );
+
+      await expect(
+        runs.reportRunnerModelProviderFailure(claimed.runId, {
+          runnerIdentity: claimed.runnerIdentity,
+          failureKind: "authentication",
+        }),
+      ).resolves.toStrictEqual({ outcome: "recorded" });
+      await expect(
+        runs.readRun(claimed.actor, claimed.runId),
+      ).resolves.toMatchObject({ status: "running" });
+      await expect(
+        resolveVm0ManagedModelRouteFixture(
+          context,
+          claimed.selectedModel,
+          false,
+        ),
+      ).resolves.toMatchObject({
+        provider_type: primary.provider_type,
+        upstream_model: primary.upstream_model,
+      });
+      await expect(
+        resolveVm0ManagedModelRouteFixture(
+          context,
+          claimed.selectedModel,
+          true,
+        ),
+      ).resolves.not.toMatchObject({
+        provider_type: primary.provider_type,
+        upstream_model: primary.upstream_model,
+      });
+
+      await seedVm0ManagedModelCandidateKeys(context, "deepseek-v4-pro");
+      await expect(
+        resolveVm0ManagedModelRouteFixture(context, "deepseek-v4-pro", true),
+      ).resolves.toMatchObject({ provider_type: "deepseek" });
+
+      await withMockNowForTest(startedAt + 60_000, async () => {
+        await expect(
+          resolveVm0ManagedModelRouteFixture(
+            context,
+            claimed.selectedModel,
+            true,
+          ),
+        ).resolves.toMatchObject({
+          provider_type: primary.provider_type,
+          upstream_model: primary.upstream_model,
+        });
+      });
+    });
+  });
+
+  it("monotonically extends concurrent bounded reports from receipt time", async () => {
+    const startedAt = Date.UTC(2026, 7, 21, 1, 0, 0);
+    await withMockNowForTest(startedAt, async () => {
+      const claimed = await createClaimedVm0Run();
+      const primary = await resolveVm0ManagedModelRouteFixture(
+        context,
+        claimed.selectedModel,
+        true,
+      );
+      if (!primary) {
+        throw new Error("Expected a managed model primary route");
+      }
+      registerVm0ManagedCandidateCooldownCleanup(
+        context,
+        claimed.selectedModel,
+        primary,
+      );
+
+      await expect(
+        runs.reportRunnerModelProviderFailure(claimed.runId, {
+          runnerIdentity: claimed.runnerIdentity,
+          failureKind: "rate_limit",
+          retryAfterSeconds: 300,
+        }),
+      ).resolves.toStrictEqual({ outcome: "recorded" });
+
+      await withMockNowForTest(startedAt + 100_000, async () => {
+        await expect(
+          Promise.all([
+            runs.reportRunnerModelProviderFailure(claimed.runId, {
+              runnerIdentity: claimed.runnerIdentity,
+              failureKind: "timeout",
+              retryAfterSeconds: 1,
+            }),
+            runs.reportRunnerModelProviderFailure(claimed.runId, {
+              runnerIdentity: claimed.runnerIdentity,
+              failureKind: "provider_unavailable",
+              retryAfterSeconds: 300,
+            }),
+          ]),
+        ).resolves.toStrictEqual([
+          { outcome: "recorded" },
+          { outcome: "recorded" },
+        ]);
+      });
+
+      await withMockNowForTest(startedAt + 350_000, async () => {
+        await expect(
+          resolveVm0ManagedModelRouteFixture(
+            context,
+            claimed.selectedModel,
+            true,
+          ),
+        ).resolves.not.toMatchObject({
+          provider_type: primary.provider_type,
+          upstream_model: primary.upstream_model,
+        });
+      });
+      await withMockNowForTest(startedAt + 401_000, async () => {
+        await expect(
+          resolveVm0ManagedModelRouteFixture(
+            context,
+            claimed.selectedModel,
+            true,
+          ),
+        ).resolves.toMatchObject({
+          provider_type: primary.provider_type,
+          upstream_model: primary.upstream_model,
+        });
+      });
+    });
+  });
+
+  it("rejects untrusted evidence and ignores ineligible runs", async () => {
+    const startedAt = Date.UTC(2026, 7, 21, 2, 0, 0);
+    await withMockNowForTest(startedAt, async () => {
+      const claimed = await createClaimedVm0Run();
+      const primary = await resolveVm0ManagedModelRouteFixture(
+        context,
+        claimed.selectedModel,
+        true,
+      );
+      if (!primary) {
+        throw new Error("Expected a managed model primary route");
+      }
+      registerVm0ManagedCandidateCooldownCleanup(
+        context,
+        claimed.selectedModel,
+        primary,
+      );
+
+      const missingAuth = await runs.requestRunnerModelProviderFailureAs(
+        undefined,
+        claimed.runId,
+        [401],
+        {
+          runnerIdentity: claimed.runnerIdentity,
+          failureKind: "connection",
+        },
+      );
+      expectApiError(missingAuth.body);
+
+      const sandboxAuth = await runs.requestRunnerModelProviderFailureAs(
+        `Bearer ${runs.sandboxTokenForRun(claimed.actor, claimed.runId)}`,
+        claimed.runId,
+        [401],
+        {
+          runnerIdentity: claimed.runnerIdentity,
+          failureKind: "connection",
+        },
+      );
+      expectApiError(sandboxAuth.body);
+
+      const pat = await runs.createCliToken(claimed.actor);
+      const patAuth = await runs.requestRunnerModelProviderFailureAs(
+        `Bearer ${pat.token}`,
+        claimed.runId,
+        [403],
+        {
+          runnerIdentity: claimed.runnerIdentity,
+          failureKind: "connection",
+        },
+      );
+      expectApiError(patAuth.body);
+
+      await expect(
+        runs.reportRunnerModelProviderFailure(claimed.runId, {
+          runnerIdentity: {
+            ...claimed.runnerIdentity,
+            runnerId: randomUUID(),
+          },
+          failureKind: "connection",
+        }),
+      ).resolves.toStrictEqual({ outcome: "ignored" });
+      await expect(
+        runs.reportRunnerModelProviderFailure(claimed.runId, {
+          runnerIdentity: {
+            ...claimed.runnerIdentity,
+            heartbeatGeneration: claimed.runnerIdentity.heartbeatGeneration + 1,
+          },
+          failureKind: "connection",
+        }),
+      ).resolves.toStrictEqual({ outcome: "ignored" });
+
+      for (const body of [
+        {
+          runnerIdentity: claimed.runnerIdentity,
+          failureKind: "connection",
+          selectedModel: claimed.selectedModel,
+        },
+        {
+          runnerIdentity: claimed.runnerIdentity,
+          failureKind: "success",
+        },
+        {
+          runnerIdentity: claimed.runnerIdentity,
+          failureKind: "connection",
+          retryAfterSeconds: 301,
+        },
+      ]) {
+        const invalid = await runs.requestRawRunnerModelProviderFailure(
+          true,
+          claimed.runId,
+          [400],
+          body,
+        );
+        expectApiError(invalid.body);
+      }
+
+      for (const failureKind of [
+        "unclassified",
+        "semantic",
+        "request",
+        "schema",
+        "tool_capability",
+        "user_code",
+        "cancellation",
+      ]) {
+        const invalid = await runs.requestRawRunnerModelProviderFailure(
+          true,
+          claimed.runId,
+          [400],
+          {
+            runnerIdentity: claimed.runnerIdentity,
+            failureKind,
+          },
+        );
+        expectApiError(invalid.body);
+      }
+
+      const byokRun = await runs.createRun(claimed.actor, {
+        agentId: claimed.agentId,
+        prompt: "ignore a BYOK model provider failure",
+        modelProvider: "anthropic-api-key",
+      });
+      const byokRunnerIdentity = {
+        runnerId: randomUUID(),
+        heartbeatGeneration: 8,
+      };
+      await runs.claimRunnerJob(byokRun.runId, {
+        runnerIdentity: byokRunnerIdentity,
+      });
+      onTestFinished(async () => {
+        await runs.requestCancelRun(claimed.actor, byokRun.runId, [200, 400]);
+      });
+      await expect(
+        runs.reportRunnerModelProviderFailure(byokRun.runId, {
+          runnerIdentity: byokRunnerIdentity,
+          failureKind: "billing",
+        }),
+      ).resolves.toStrictEqual({ outcome: "ignored" });
+
+      await expect(
+        resolveVm0ManagedModelRouteFixture(
+          context,
+          claimed.selectedModel,
+          true,
+        ),
+      ).resolves.toMatchObject({
+        provider_type: primary.provider_type,
+        upstream_model: primary.upstream_model,
+      });
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -2593,8 +2593,6 @@ const modelProviderFailureInner$ = command(
         modelRuntimeProvider: agentRuns.modelRuntimeProvider,
         modelRuntimeModel: agentRuns.modelRuntimeModel,
         vm0ModelKeyId: agentRuns.vm0ModelKeyId,
-        runnerId: agentRuns.runnerId,
-        runnerHeartbeatGeneration: agentRuns.runnerHeartbeatGeneration,
       })
       .from(agentRuns)
       .where(eq(agentRuns.id, runId))
@@ -2607,11 +2605,7 @@ const modelProviderFailureInner$ = command(
       !run.selectedModel ||
       !run.modelRuntimeProvider ||
       !run.modelRuntimeModel ||
-      !run.vm0ModelKeyId ||
-      run.runnerId?.toLowerCase() !==
-        body.data.runnerIdentity.runnerId.toLowerCase() ||
-      run.runnerHeartbeatGeneration !==
-        body.data.runnerIdentity.heartbeatGeneration
+      !run.vm0ModelKeyId
     ) {
       L.debug("Managed model provider failure report ignored", { runId });
       return { status: 200 as const, body: { outcome: "ignored" as const } };

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -9,6 +9,7 @@ import {
   runnersBuiltinFirewallsResolveContract,
   runnersHeartbeatContract,
   runnersJobClaimContract,
+  runnersModelProviderFailuresContract,
   runnersPollContract,
   storedConnectorPermissionBaselineSchema,
   type CompatibleStoredExecutionContext,
@@ -82,6 +83,7 @@ import { generateSandboxToken } from "../auth/tokens";
 import { decryptPersistentSecretsMap } from "../services/crypto.utils";
 import { dispatchCompleteSideEffects$ } from "../services/agent-webhook-complete.service";
 import { historyGenerationRunIdForStoredExecutionContext } from "../services/agent-run-queue-payload.service";
+import { extendManagedModelCandidateCooldown } from "../services/built-in-model-runtime-route.service";
 import {
   recordActiveInputDeliveryReceipt,
   reserveActiveInputDelivery,
@@ -130,6 +132,7 @@ const INVALID_EXECUTION_CONTEXT_ERROR =
   "Runner job missing valid execution context";
 const MAX_VALIDATION_ISSUES_TO_LOG = 10;
 const RESUME_SESSION_HISTORY_URL_TTL_SECONDS = 60 * 60;
+const DEFAULT_MANAGED_MODEL_PROVIDER_COOLDOWN_SECONDS = 60;
 const RESUME_SESSION_HISTORY_LOAD_ERROR =
   "Runner job missing resume session history";
 const RESUME_SESSION_HISTORY_INVALID_ERROR =
@@ -768,6 +771,9 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const claimBody$ = bodyResultOf(runnersJobClaimContract.claim);
+const modelProviderFailureBody$ = bodyResultOf(
+  runnersModelProviderFailuresContract.report,
+);
 const connectorRuntimeSyncBody$ = bodyResultOf(
   runnersConnectorRuntimeSyncContract.sync,
 );
@@ -2557,6 +2563,83 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   );
 });
 
+const modelProviderFailureInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = await set(runnerAuth$, get(authorization$), signal);
+    signal.throwIfAborted();
+    if (!auth) {
+      return unauthorizedAuthenticationRequired;
+    }
+    if (auth.type !== "official-runner") {
+      return forbidden(
+        "Only official runners can report model provider failures",
+      );
+    }
+
+    const body = await get(modelProviderFailureBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const runId = get(
+      pathParamsOf(runnersModelProviderFailuresContract.report),
+    ).runId;
+    const db = set(writeDb$);
+    const [run] = await db
+      .select({
+        modelProvider: agentRuns.modelProvider,
+        selectedModel: agentRuns.selectedModel,
+        modelRuntimeProvider: agentRuns.modelRuntimeProvider,
+        modelRuntimeModel: agentRuns.modelRuntimeModel,
+        vm0ModelKeyId: agentRuns.vm0ModelKeyId,
+        runnerId: agentRuns.runnerId,
+        runnerHeartbeatGeneration: agentRuns.runnerHeartbeatGeneration,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, runId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (
+      !run ||
+      run.modelProvider !== "vm0" ||
+      !run.selectedModel ||
+      !run.modelRuntimeProvider ||
+      !run.modelRuntimeModel ||
+      !run.vm0ModelKeyId ||
+      run.runnerId?.toLowerCase() !==
+        body.data.runnerIdentity.runnerId.toLowerCase() ||
+      run.runnerHeartbeatGeneration !==
+        body.data.runnerIdentity.heartbeatGeneration
+    ) {
+      L.debug("Managed model provider failure report ignored", { runId });
+      return { status: 200 as const, body: { outcome: "ignored" as const } };
+    }
+
+    const retryAfterSeconds =
+      body.data.retryAfterSeconds ??
+      DEFAULT_MANAGED_MODEL_PROVIDER_COOLDOWN_SECONDS;
+    const unavailableUntil = await extendManagedModelCandidateCooldown(db, {
+      selectedModel: run.selectedModel,
+      providerType: run.modelRuntimeProvider,
+      upstreamModel: run.modelRuntimeModel,
+      retryAfterSeconds,
+    });
+    signal.throwIfAborted();
+    L.debug("Managed model provider failure report recorded", {
+      runId,
+      selectedModel: run.selectedModel,
+      providerType: run.modelRuntimeProvider,
+      upstreamModel: run.modelRuntimeModel,
+      failureKind: body.data.failureKind,
+      retryAfterSeconds,
+      unavailableUntil: unavailableUntil.toISOString(),
+    });
+    return { status: 200 as const, body: { outcome: "recorded" as const } };
+  },
+);
+
 const runnerRealtimeTokenBody$ = bodyResultOf(
   runnerRealtimeTokenContract.create,
 );
@@ -2803,6 +2886,10 @@ export const runnersRoutes: readonly RouteEntry[] = [
   {
     route: runnersJobClaimContract.claim,
     handler: claimInner$,
+  },
+  {
+    route: runnersModelProviderFailuresContract.report,
+    handler: modelProviderFailureInner$,
   },
   {
     route: runnersActiveInputsContract.reserve,

--- a/turbo/apps/api/src/signals/services/built-in-model-runtime-route.service.ts
+++ b/turbo/apps/api/src/signals/services/built-in-model-runtime-route.service.ts
@@ -5,7 +5,7 @@ import {
 } from "@okouai/api-contracts/contracts/model-providers";
 import { builtInModelKeys } from "@okouai/db/schema/built-in-model-key";
 import { managedModelCandidateCooldown } from "@okouai/db/schema/managed-model-cooldown";
-import { and, eq, gt } from "drizzle-orm";
+import { and, eq, gt, sql } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
@@ -21,6 +21,12 @@ export interface ModelRuntimeSessionRoute {
   readonly modelProvider: string | null;
   readonly modelRuntimeProvider: string | null;
   readonly modelRuntimeModel: string | null;
+}
+
+interface ManagedModelCandidateIdentity {
+  readonly selectedModel: string;
+  readonly providerType: string;
+  readonly upstreamModel: string;
 }
 
 function routeFromTarget(
@@ -99,6 +105,42 @@ export async function resolveBuiltInModelRuntimeRoute(
     return routeFromTarget(target, key);
   }
   return null;
+}
+
+export async function extendManagedModelCandidateCooldown(
+  db: Db,
+  args: ManagedModelCandidateIdentity & {
+    readonly retryAfterSeconds: number;
+  },
+): Promise<Date> {
+  const unavailableUntil = new Date(
+    nowDate().getTime() + args.retryAfterSeconds * 1000,
+  );
+  const [cooldown] = await db
+    .insert(managedModelCandidateCooldown)
+    .values({
+      selectedModel: args.selectedModel,
+      providerType: args.providerType,
+      upstreamModel: args.upstreamModel,
+      unavailableUntil,
+    })
+    .onConflictDoUpdate({
+      target: [
+        managedModelCandidateCooldown.selectedModel,
+        managedModelCandidateCooldown.providerType,
+        managedModelCandidateCooldown.upstreamModel,
+      ],
+      set: {
+        unavailableUntil: sql`GREATEST(${managedModelCandidateCooldown.unavailableUntil}, EXCLUDED.unavailable_until)`,
+      },
+    })
+    .returning({
+      unavailableUntil: managedModelCandidateCooldown.unavailableUntil,
+    });
+  if (!cooldown) {
+    throw new Error("Expected managed model candidate cooldown to be written");
+  }
+  return cooldown.unavailableUntil;
 }
 
 export function hasIncompatibleBuiltInModelRuntimeRoute(args: {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -116,7 +116,7 @@ export const managedModelProviderFailureKindSchema = z.enum([
   "connection",
 ]);
 
-export const MANAGED_MODEL_PROVIDER_RETRY_AFTER_MAX_SECONDS = 300;
+const MANAGED_MODEL_PROVIDER_RETRY_AFTER_MAX_SECONDS = 300;
 
 /**
  * Atomic advisory decision for cross-runner reuse coordination. A preferred

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -107,7 +107,7 @@ const runnerProcessIdentitySchema = z
   })
   .strict();
 
-export const managedModelProviderFailureKindSchema = z.enum([
+const managedModelProviderFailureKindSchema = z.enum([
   "authentication",
   "billing",
   "rate_limit",

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -1049,7 +1049,6 @@ export const runnersModelProviderFailuresContract = c.router({
     }),
     body: z
       .object({
-        runnerIdentity: runnerProcessIdentitySchema,
         failureKind: managedModelProviderFailureKindSchema,
         retryAfterSeconds: z
           .number()

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -107,6 +107,17 @@ const runnerProcessIdentitySchema = z
   })
   .strict();
 
+export const managedModelProviderFailureKindSchema = z.enum([
+  "authentication",
+  "billing",
+  "rate_limit",
+  "provider_unavailable",
+  "timeout",
+  "connection",
+]);
+
+export const MANAGED_MODEL_PROVIDER_RETRY_AFTER_MAX_SECONDS = 300;
+
 /**
  * Atomic advisory decision for cross-runner reuse coordination. A preferred
  * runner is not an exclusive assignee; another runner with a better compatible
@@ -1028,6 +1039,41 @@ export const runnersJobClaimContract = c.router({
   },
 });
 
+export const runnersModelProviderFailuresContract = c.router({
+  report: {
+    method: "POST",
+    path: "/api/runners/runs/:runId/model-provider-failures",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      runId: z.uuid(),
+    }),
+    body: z
+      .object({
+        runnerIdentity: runnerProcessIdentitySchema,
+        failureKind: managedModelProviderFailureKindSchema,
+        retryAfterSeconds: z
+          .number()
+          .int()
+          .positive()
+          .max(MANAGED_MODEL_PROVIDER_RETRY_AFTER_MAX_SECONDS)
+          .optional(),
+      })
+      .strict(),
+    responses: {
+      200: z
+        .object({
+          outcome: z.enum(["recorded", "ignored"]),
+        })
+        .strict(),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Report a managed model provider failure for a run",
+  },
+});
+
 const activeInputDeliveryReferenceSchema = z.object({
   deliveryId: z.uuid(),
   eventIds: z.array(z.uuid()).length(1),
@@ -1205,6 +1251,8 @@ export const runnersHeartbeatContract = c.router({
 
 export type RunnersPollContract = typeof runnersPollContract;
 export type RunnersJobClaimContract = typeof runnersJobClaimContract;
+export type RunnersModelProviderFailuresContract =
+  typeof runnersModelProviderFailuresContract;
 export type RunnersActiveInputsContract = typeof runnersActiveInputsContract;
 export type RunnersConnectorRuntimeSyncContract =
   typeof runnersConnectorRuntimeSyncContract;

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/routes.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/routes.test.ts
@@ -42,6 +42,12 @@ const expectedBindings = [
   },
   {
     method: "POST",
+    path: "/api/runners/runs/:runId/model-provider-failures",
+    rustModulePath: ["runners", "runs", "by_run_id", "model_provider_failures"],
+    rustConstName: "REPORT",
+  },
+  {
+    method: "POST",
     path: "/api/runners/runs/:runId/connector-runtime/sync",
     rustModulePath: [
       "runners",

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -36,6 +36,11 @@ const expectedBindings = [
     direction: "response",
   },
   {
+    rustModulePath: ["runners", "runs", "model_provider_failures"],
+    rustTypeName: "Request",
+    direction: "request",
+  },
+  {
     rustModulePath: ["runners", "storage"],
     rustTypeName: "ArtifactEntryMissingRootPolicy",
     direction: "response",

--- a/turbo/packages/api-contracts/src/rust-bindings/routes.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/routes.ts
@@ -5,6 +5,7 @@ import {
   runnersBuiltinFirewallsResolveContract,
   runnersHeartbeatContract,
   runnersJobClaimContract,
+  runnersModelProviderFailuresContract,
   runnersPollContract,
 } from "../contracts/runners";
 import {
@@ -64,6 +65,11 @@ export const rustRouteBindings = [
       "receipt",
     ],
     rustConstName: "RECEIPT",
+  },
+  {
+    route: runnersModelProviderFailuresContract.report,
+    rustModulePath: ["runners", "runs", "by_run_id", "model_provider_failures"],
+    rustConstName: "REPORT",
   },
   {
     route: runnersConnectorRuntimeSyncContract.sync,

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -4,6 +4,7 @@ import {
   activeInputDeliveryReserveResponseSchema,
   activeInputDeliveryReceiptResponseSchema,
   artifactMissingRootPolicySchema,
+  runnersModelProviderFailuresContract,
   storageMountEntrySchema,
 } from "../contracts/runners";
 import { fileEntryWithHashSchema } from "../contracts/storages";
@@ -68,6 +69,10 @@ export const rustTypeModuleDocs = [
   {
     rustModulePath: ["runners", "runs", "active_inputs", "receipt"],
     rustDoc: ["DTOs for recording active-input acceptance receipts."],
+  },
+  {
+    rustModulePath: ["runners", "runs", "model_provider_failures"],
+    rustDoc: ["DTOs for reporting bounded managed model provider failures."],
   },
   {
     rustModulePath: ["webhooks"],
@@ -181,6 +186,53 @@ export const rustTypeBindings = [
         variants: {
           delivered: ["The delivery receipt was accepted idempotently."],
           rejected: ["The delivery can no longer be accepted."],
+        },
+      },
+    ],
+  },
+  {
+    schema: runnersModelProviderFailuresContract.report.body,
+    rustModulePath: ["runners", "runs", "model_provider_failures"],
+    rustTypeName: "Request",
+    direction: "request",
+    declarations: [
+      {
+        rustTypeName: "RequestRunnerIdentity",
+        rustDoc: ["Official runner process identity that won the run claim."],
+        fields: {
+          runnerId: ["Stable runner process identifier."],
+          heartbeatGeneration: [
+            "Runner heartbeat generation active when the run was claimed.",
+          ],
+        },
+      },
+      {
+        rustTypeName: "RequestFailureKind",
+        rustDoc: [
+          "Bounded provider-independent failure eligible for route cooldown.",
+        ],
+        variants: {
+          authentication: ["Provider authentication failed."],
+          billing: ["Provider billing rejected the request."],
+          rate_limit: ["Provider rate limiting rejected the request."],
+          provider_unavailable: [
+            "The provider route was unavailable or overloaded.",
+          ],
+          timeout: ["The provider inference request timed out."],
+          connection: ["The provider connection failed."],
+        },
+      },
+      {
+        rustTypeName: "Request",
+        rustDoc: [
+          "Request body for reporting a managed model provider failure.",
+        ],
+        fields: {
+          runnerIdentity: ["Winning runner identity for the reported run."],
+          failureKind: ["Normalized eligible provider failure kind."],
+          retryAfterSeconds: [
+            "Optional bounded provider retry delay in seconds.",
+          ],
         },
       },
     ],

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -197,16 +197,6 @@ export const rustTypeBindings = [
     direction: "request",
     declarations: [
       {
-        rustTypeName: "RequestRunnerIdentity",
-        rustDoc: ["Official runner process identity that won the run claim."],
-        fields: {
-          runnerId: ["Stable runner process identifier."],
-          heartbeatGeneration: [
-            "Runner heartbeat generation active when the run was claimed.",
-          ],
-        },
-      },
-      {
         rustTypeName: "RequestFailureKind",
         rustDoc: [
           "Bounded provider-independent failure eligible for route cooldown.",
@@ -228,7 +218,6 @@ export const rustTypeBindings = [
           "Request body for reporting a managed model provider failure.",
         ],
         fields: {
-          runnerIdentity: ["Winning runner identity for the reported run."],
           failureKind: ["Normalized eligible provider failure kind."],
           retryAfterSeconds: [
             "Optional bounded provider retry delay in seconds.",


### PR DESCRIPTION
## Summary

- add a strict official-runner endpoint for bounded managed-model provider failure reports
- trust the shared official-runner credential and derive the exact model/provider/upstream route exclusively from run metadata
- atomically extend only that route's cooldown with monotonic deadlines and add real-database integration coverage
- generate the minimal Rust request DTO and route binding for the future runner producer

## Explicit exclusions

- no per-run runner ID or heartbeat-generation attestation; all VM0-operated official runners share one trust domain
- no runner-side failure classification or report delivery; that remains in #28194
- no credential-wide health, key revision, probes, success transition, or early cooldown clearing
- no route qualification or fallback enablement; that remains in #28195

## Validation

- `cd turbo && pnpm exec prettier --write packages/api-contracts/src/contracts/runners.ts packages/api-contracts/src/rust-bindings/types.ts apps/api/src/signals/routes/runners.ts apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts`
- `cd turbo && pnpm -F @okouai/api-contracts lint`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F @okouai/api-contracts check-types`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm knip`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/test-runtime-state.test.ts`
- `cd turbo && pnpm -F @okouai/api-contracts test`
- `cd turbo && pnpm -F @okouai/api-contracts generate:rust` (verified deterministic)
- `cd crates && cargo fmt --check`
- `cd crates && cargo check -p api-contracts`
- `cd crates && cargo clippy -p api-contracts --all-targets --all-features -- -D warnings`
- `cd crates && cargo doc -p api-contracts --no-deps`
- `cd crates && cargo test -p api-contracts`

Closes #28193

Parent context: #28148
