### PR TITLE
refactor(api): move chat threads, chat events, and shared threads off the brand namespace

### DIFF
--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -277,8 +277,8 @@ canonical resource key: each thread owns at most one logical browser, and every
 provider instance for that browser carries the same thread attribution. The card
 never accepts a Browser Use `liveUrl` or CDP URL from message content. Instead,
 its thread-scoped computed reads the browser through
-`/api/okou/chat-threads/:threadId/browser`. A copied card therefore cannot
-resolve a browser owned by a different thread.
+`/api/chat-threads/:threadId/browser`. A copied card therefore cannot resolve a
+browser owned by a different thread.
 
 The message card follows the presentation and website preview treatment. It
 shows a `Cloud browser` header with a simplified `Live` or `Stopped` status,

--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -122,7 +122,7 @@ function isChatThreadEventRowsResponse(
   return (
     response.ok() &&
     request.method() === "GET" &&
-    url.pathname === `/api/okou/chat-threads/${threadId}/event-rows` &&
+    url.pathname === `/api/chat-threads/${threadId}/event-rows` &&
     rawSinceSeqId !== null &&
     Number.isSafeInteger(sinceSeqId) &&
     ((sinceSeqId === 0 && sinceEventId === null) ||
@@ -450,7 +450,7 @@ async function mockChatThread(
   const createdEventId = `d${options.threadId.slice(1)}`;
   let createdEventSeqId: number | null = null;
 
-  await page.route("**/api/okou/chat-threads/snapshot", async (route) => {
+  await page.route("**/api/chat-threads/snapshot", async (route) => {
     await route.fulfill({
       json: {
         chatThreads: [],
@@ -460,7 +460,7 @@ async function mockChatThread(
     });
   });
   await page.route(
-    (url) => url.pathname === "/api/okou/chat-threads/events",
+    (url) => url.pathname === "/api/chat-threads/events",
     async (route) => {
       const requestUrl = new URL(route.request().url());
       const rawSinceSeqId = requestUrl.searchParams.get("sinceSeqId");
@@ -497,7 +497,7 @@ async function mockChatThread(
   );
   await page.route(
     (url) =>
-      url.pathname === `/api/okou/chat-threads/${options.threadId}/event-rows`,
+      url.pathname === `/api/chat-threads/${options.threadId}/event-rows`,
     async (route) => {
       const requestUrl = new URL(route.request().url());
       const sinceSeqId = Number(
@@ -527,8 +527,7 @@ async function mockChatThread(
     },
   );
   await page.route(
-    (url) =>
-      url.pathname === `/api/okou/chat-threads/${options.threadId}/draft`,
+    (url) => url.pathname === `/api/chat-threads/${options.threadId}/draft`,
     async (route) => {
       await route.fulfill({
         json: { draftUserMessage: null, draftAttachments: null },
@@ -536,8 +535,7 @@ async function mockChatThread(
     },
   );
   await page.route(
-    (url) =>
-      url.pathname === `/api/okou/chat-threads/${options.threadId}/mark-read`,
+    (url) => url.pathname === `/api/chat-threads/${options.threadId}/mark-read`,
     async (route) => {
       await route.fulfill({
         json: { lastReadAt: options.createdAt, unreads: [] },
@@ -546,8 +544,7 @@ async function mockChatThread(
   );
   await page.route(
     (url) =>
-      url.pathname ===
-      `/api/okou/chat-threads/${options.threadId}/event-snapshot`,
+      url.pathname === `/api/chat-threads/${options.threadId}/event-snapshot`,
     async (route) => {
       await route.fulfill({
         headers: await negotiatedChatEventHeaders(route.request()),
@@ -557,7 +554,7 @@ async function mockChatThread(
     },
   );
   await page.route(
-    (url) => url.pathname === `/api/okou/chat-threads/${options.threadId}`,
+    (url) => url.pathname === `/api/chat-threads/${options.threadId}`,
     async (route) => {
       await route.fulfill({
         json: {
@@ -874,8 +871,7 @@ async function mockDelayedImageLayoutThread(
 ): Promise<void> {
   await page.route(
     (url) =>
-      url.pathname ===
-      `/api/okou/chat-threads/${imageLayoutThreadId}/artifacts`,
+      url.pathname === `/api/chat-threads/${imageLayoutThreadId}/artifacts`,
     async (route) => {
       await route.fulfill({ json: { runs: [] } });
     },

--- a/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
+++ b/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
@@ -5,6 +5,8 @@ import { z } from "zod";
 import { createAppWithRoutes } from "../app-factory-core";
 import { ROUTES } from "../signals/route";
 import { imageRecognitionRoutes } from "../signals/routes/image-recognition";
+import { imageShareXRoutes } from "../signals/routes/image-share-x";
+import { queuePositionRoutes } from "../signals/routes/queue-position";
 import { scrapeRoutes } from "../signals/routes/scrape";
 import { translationRoutes } from "../signals/routes/translation";
 import { weatherRoutes } from "../signals/routes/weather";
@@ -343,6 +345,133 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/zero/runs/:id/telemetry/agent",
   ],
   "/api/runs/queue": ["/api/okou/runs/queue", "/api/zero/runs/queue"],
+  // #28459: chat threads, chat events and search, shared threads,
+  // per-thread browser sessions and goals, thread workflow automations,
+  // queue position, and the X image share.
+  "/api/chat-threads": ["/api/okou/chat-threads", "/api/zero/chat-threads"],
+  "/api/chat-threads/:id": [
+    "/api/okou/chat-threads/:id",
+    "/api/zero/chat-threads/:id",
+  ],
+  "/api/chat-threads/:id/computer-use-host": [
+    "/api/okou/chat-threads/:id/computer-use-host",
+    "/api/zero/chat-threads/:id/computer-use-host",
+  ],
+  "/api/chat-threads/:id/connector-selections": [
+    "/api/okou/chat-threads/:id/connector-selections",
+    "/api/zero/chat-threads/:id/connector-selections",
+  ],
+  "/api/chat-threads/:id/draft": [
+    "/api/okou/chat-threads/:id/draft",
+    "/api/zero/chat-threads/:id/draft",
+  ],
+  "/api/chat-threads/:id/image-model": [
+    "/api/okou/chat-threads/:id/image-model",
+    "/api/zero/chat-threads/:id/image-model",
+  ],
+  "/api/chat-threads/:id/mark-read": [
+    "/api/okou/chat-threads/:id/mark-read",
+    "/api/zero/chat-threads/:id/mark-read",
+  ],
+  "/api/chat-threads/:id/mark-unread": [
+    "/api/okou/chat-threads/:id/mark-unread",
+    "/api/zero/chat-threads/:id/mark-unread",
+  ],
+  "/api/chat-threads/:id/metadata": [
+    "/api/okou/chat-threads/:id/metadata",
+    "/api/zero/chat-threads/:id/metadata",
+  ],
+  "/api/chat-threads/:id/model-selection": [
+    "/api/okou/chat-threads/:id/model-selection",
+    "/api/zero/chat-threads/:id/model-selection",
+  ],
+  "/api/chat-threads/:id/pin": [
+    "/api/okou/chat-threads/:id/pin",
+    "/api/zero/chat-threads/:id/pin",
+  ],
+  "/api/chat-threads/:id/rename": [
+    "/api/okou/chat-threads/:id/rename",
+    "/api/zero/chat-threads/:id/rename",
+  ],
+  "/api/chat-threads/:id/unpin": [
+    "/api/okou/chat-threads/:id/unpin",
+    "/api/zero/chat-threads/:id/unpin",
+  ],
+  "/api/chat-threads/:id/video-model": [
+    "/api/okou/chat-threads/:id/video-model",
+    "/api/zero/chat-threads/:id/video-model",
+  ],
+  "/api/chat-threads/:threadId/artifacts": [
+    "/api/okou/chat-threads/:threadId/artifacts",
+    "/api/zero/chat-threads/:threadId/artifacts",
+  ],
+  "/api/chat-threads/:threadId/browser": [
+    "/api/okou/chat-threads/:threadId/browser",
+    "/api/zero/chat-threads/:threadId/browser",
+  ],
+  "/api/chat-threads/:threadId/browser/close": [
+    "/api/okou/chat-threads/:threadId/browser/close",
+    "/api/zero/chat-threads/:threadId/browser/close",
+  ],
+  "/api/chat-threads/:threadId/browser/lease": [
+    "/api/okou/chat-threads/:threadId/browser/lease",
+    "/api/zero/chat-threads/:threadId/browser/lease",
+  ],
+  "/api/chat-threads/:threadId/browser/open": [
+    "/api/okou/chat-threads/:threadId/browser/open",
+    "/api/zero/chat-threads/:threadId/browser/open",
+  ],
+  "/api/chat-threads/:threadId/browser/resize": [
+    "/api/okou/chat-threads/:threadId/browser/resize",
+    "/api/zero/chat-threads/:threadId/browser/resize",
+  ],
+  "/api/chat-threads/:threadId/event-rows": [
+    "/api/okou/chat-threads/:threadId/event-rows",
+    "/api/zero/chat-threads/:threadId/event-rows",
+  ],
+  "/api/chat-threads/:threadId/event-snapshot": [
+    "/api/okou/chat-threads/:threadId/event-snapshot",
+    "/api/zero/chat-threads/:threadId/event-snapshot",
+  ],
+  "/api/chat-threads/:threadId/goal": [
+    "/api/okou/chat-threads/:threadId/goal",
+    "/api/zero/chat-threads/:threadId/goal",
+  ],
+  "/api/chat-threads/:threadId/goal/pause": [
+    "/api/okou/chat-threads/:threadId/goal/pause",
+    "/api/zero/chat-threads/:threadId/goal/pause",
+  ],
+  "/api/chat-threads/:threadId/shared-threads": [
+    "/api/okou/chat-threads/:threadId/shared-threads",
+    "/api/zero/chat-threads/:threadId/shared-threads",
+  ],
+  "/api/chat-threads/:threadId/workflow-automations": [
+    "/api/okou/chat-threads/:threadId/workflow-automations",
+    "/api/zero/chat-threads/:threadId/workflow-automations",
+  ],
+  "/api/chat-threads/events": [
+    "/api/okou/chat-threads/events",
+    "/api/zero/chat-threads/events",
+  ],
+  "/api/chat-threads/snapshot": [
+    "/api/okou/chat-threads/snapshot",
+    "/api/zero/chat-threads/snapshot",
+  ],
+  "/api/chat/events": ["/api/okou/chat/events", "/api/zero/chat/events"],
+  "/api/chat/search": ["/api/okou/chat/search", "/api/zero/chat/search"],
+  "/api/image-share/x": ["/api/okou/image-share/x", "/api/zero/image-share/x"],
+  "/api/queue-position": [
+    "/api/okou/queue-position",
+    "/api/zero/queue-position",
+  ],
+  "/api/shared-threads/:id": [
+    "/api/okou/shared-threads/:id",
+    "/api/zero/shared-threads/:id",
+  ],
+  "/api/shared-threads/:id/meta": [
+    "/api/okou/shared-threads/:id/meta",
+    "/api/zero/shared-threads/:id/meta",
+  ],
 };
 
 function missingBrandedPaths(
@@ -689,6 +818,48 @@ describe("branded paths for migrated neutral routes", () => {
 
       expect({ operation, neutral, okou, zero }).toStrictEqual({
         operation,
+        neutral,
+        okou: neutral,
+        zero: neutral,
+      });
+      expect(neutral).not.toBe(404);
+    }
+  });
+
+  // The #28459 twin of the two assertions above, for the chat slice. Every
+  // caller of these routes in this repository derives its URL from the
+  // contract, so a request-level case is the only place a dropped row shows
+  // up as the 404 a released client would get. Requests are unauthenticated,
+  // so the status is whatever the auth layer returns — the point is that all
+  // three forms reach the same handler instead of falling through to 404.
+  it("serves the migrated chat-slice paths through the production app factory", async () => {
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+
+    const families = [
+      { routes: queuePositionRoutes, method: "GET", suffix: "queue-position" },
+      { routes: imageShareXRoutes, method: "POST", suffix: "image-share/x" },
+    ] as const;
+
+    for (const { routes, method, suffix } of families) {
+      const app = createAppWithRoutes({ signal: context.signal, routes });
+
+      async function statusFor(path: string): Promise<number> {
+        const response = await app.request(`${REQUEST_ORIGIN}${path}`, {
+          method,
+          headers: { "content-type": "application/json" },
+          ...(method === "POST" ? { body: "{}" } : {}),
+        });
+        return response.status;
+      }
+
+      const neutral = await statusFor(`/api/${suffix}`);
+      const okou = await statusFor(`/api/okou/${suffix}`);
+      const zero = await statusFor(`/api/zero/${suffix}`);
+
+      expect({ suffix, neutral, okou, zero }).toStrictEqual({
+        suffix,
         neutral,
         okou: neutral,
         zero: neutral,

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -612,7 +612,7 @@ export function createAppWithRoutes({
   });
 
   // OpenTelemetry: each request gets a SERVER span named after its matched
-  // route template (e.g. `GET /api/okou/chat-threads/:threadId`). Child spans
+  // route template (e.g. `GET /api/chat-threads/:threadId`). Child spans
   // (db queries, outbound fetches) parent to it via standard context
   // propagation; correlate them to a route by their `trace_id`, not by
   // copying `http.route` onto each child span.

--- a/turbo/apps/api/src/signals/route-entry.ts
+++ b/turbo/apps/api/src/signals/route-entry.ts
@@ -552,6 +552,147 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/zero/runs/:id/telemetry/agent",
   ],
   "/api/runs/queue": ["/api/okou/runs/queue", "/api/zero/runs/queue"],
+  // #28459: the chat threads themselves, the chat event and search readers,
+  // shared threads, per-thread browser sessions, per-thread goals, workflow
+  // automations, queue position, and the X image share. Every caller in this
+  // repository derives its URL from the contract, so nothing here still asks
+  // for a branded form. Released builds do: a browser tab holding
+  // already-loaded platform code keeps calling the `okou` path it was built
+  // against until it navigates or reloads, the ~2 day old-web-client window in
+  // `docs/fallback.md` section 7; a commit-addressed CLI package pinned by an
+  // execution context's `CLI_PKG_URL` holds it for that context's queue and
+  // claimed-run lifetime; and the `okou-app` share worker deployed to
+  // Cloudflare Pages reads `shared-threads/:id/meta` from a build that ships
+  // separately from this one. The `zero` form was reachable through the
+  // blanket expansion until the contract moved. All of it is owed, and a row
+  // retires under #26701's evidence rules rather than on any of those clocks.
+  //
+  // A key holds its path parameter verbatim, because the lookup below matches
+  // `entry.route.path` exactly rather than an expanded request path.
+  "/api/chat-threads": ["/api/okou/chat-threads", "/api/zero/chat-threads"],
+  "/api/chat-threads/:id": [
+    "/api/okou/chat-threads/:id",
+    "/api/zero/chat-threads/:id",
+  ],
+  "/api/chat-threads/:id/computer-use-host": [
+    "/api/okou/chat-threads/:id/computer-use-host",
+    "/api/zero/chat-threads/:id/computer-use-host",
+  ],
+  "/api/chat-threads/:id/connector-selections": [
+    "/api/okou/chat-threads/:id/connector-selections",
+    "/api/zero/chat-threads/:id/connector-selections",
+  ],
+  "/api/chat-threads/:id/draft": [
+    "/api/okou/chat-threads/:id/draft",
+    "/api/zero/chat-threads/:id/draft",
+  ],
+  "/api/chat-threads/:id/image-model": [
+    "/api/okou/chat-threads/:id/image-model",
+    "/api/zero/chat-threads/:id/image-model",
+  ],
+  "/api/chat-threads/:id/mark-read": [
+    "/api/okou/chat-threads/:id/mark-read",
+    "/api/zero/chat-threads/:id/mark-read",
+  ],
+  "/api/chat-threads/:id/mark-unread": [
+    "/api/okou/chat-threads/:id/mark-unread",
+    "/api/zero/chat-threads/:id/mark-unread",
+  ],
+  "/api/chat-threads/:id/metadata": [
+    "/api/okou/chat-threads/:id/metadata",
+    "/api/zero/chat-threads/:id/metadata",
+  ],
+  "/api/chat-threads/:id/model-selection": [
+    "/api/okou/chat-threads/:id/model-selection",
+    "/api/zero/chat-threads/:id/model-selection",
+  ],
+  "/api/chat-threads/:id/pin": [
+    "/api/okou/chat-threads/:id/pin",
+    "/api/zero/chat-threads/:id/pin",
+  ],
+  "/api/chat-threads/:id/rename": [
+    "/api/okou/chat-threads/:id/rename",
+    "/api/zero/chat-threads/:id/rename",
+  ],
+  "/api/chat-threads/:id/unpin": [
+    "/api/okou/chat-threads/:id/unpin",
+    "/api/zero/chat-threads/:id/unpin",
+  ],
+  "/api/chat-threads/:id/video-model": [
+    "/api/okou/chat-threads/:id/video-model",
+    "/api/zero/chat-threads/:id/video-model",
+  ],
+  "/api/chat-threads/:threadId/artifacts": [
+    "/api/okou/chat-threads/:threadId/artifacts",
+    "/api/zero/chat-threads/:threadId/artifacts",
+  ],
+  "/api/chat-threads/:threadId/browser": [
+    "/api/okou/chat-threads/:threadId/browser",
+    "/api/zero/chat-threads/:threadId/browser",
+  ],
+  "/api/chat-threads/:threadId/browser/close": [
+    "/api/okou/chat-threads/:threadId/browser/close",
+    "/api/zero/chat-threads/:threadId/browser/close",
+  ],
+  "/api/chat-threads/:threadId/browser/lease": [
+    "/api/okou/chat-threads/:threadId/browser/lease",
+    "/api/zero/chat-threads/:threadId/browser/lease",
+  ],
+  "/api/chat-threads/:threadId/browser/open": [
+    "/api/okou/chat-threads/:threadId/browser/open",
+    "/api/zero/chat-threads/:threadId/browser/open",
+  ],
+  "/api/chat-threads/:threadId/browser/resize": [
+    "/api/okou/chat-threads/:threadId/browser/resize",
+    "/api/zero/chat-threads/:threadId/browser/resize",
+  ],
+  "/api/chat-threads/:threadId/event-rows": [
+    "/api/okou/chat-threads/:threadId/event-rows",
+    "/api/zero/chat-threads/:threadId/event-rows",
+  ],
+  "/api/chat-threads/:threadId/event-snapshot": [
+    "/api/okou/chat-threads/:threadId/event-snapshot",
+    "/api/zero/chat-threads/:threadId/event-snapshot",
+  ],
+  "/api/chat-threads/:threadId/goal": [
+    "/api/okou/chat-threads/:threadId/goal",
+    "/api/zero/chat-threads/:threadId/goal",
+  ],
+  "/api/chat-threads/:threadId/goal/pause": [
+    "/api/okou/chat-threads/:threadId/goal/pause",
+    "/api/zero/chat-threads/:threadId/goal/pause",
+  ],
+  "/api/chat-threads/:threadId/shared-threads": [
+    "/api/okou/chat-threads/:threadId/shared-threads",
+    "/api/zero/chat-threads/:threadId/shared-threads",
+  ],
+  "/api/chat-threads/:threadId/workflow-automations": [
+    "/api/okou/chat-threads/:threadId/workflow-automations",
+    "/api/zero/chat-threads/:threadId/workflow-automations",
+  ],
+  "/api/chat-threads/events": [
+    "/api/okou/chat-threads/events",
+    "/api/zero/chat-threads/events",
+  ],
+  "/api/chat-threads/snapshot": [
+    "/api/okou/chat-threads/snapshot",
+    "/api/zero/chat-threads/snapshot",
+  ],
+  "/api/chat/events": ["/api/okou/chat/events", "/api/zero/chat/events"],
+  "/api/chat/search": ["/api/okou/chat/search", "/api/zero/chat/search"],
+  "/api/image-share/x": ["/api/okou/image-share/x", "/api/zero/image-share/x"],
+  "/api/queue-position": [
+    "/api/okou/queue-position",
+    "/api/zero/queue-position",
+  ],
+  "/api/shared-threads/:id": [
+    "/api/okou/shared-threads/:id",
+    "/api/zero/shared-threads/:id",
+  ],
+  "/api/shared-threads/:id/meta": [
+    "/api/okou/shared-threads/:id/meta",
+    "/api/zero/shared-threads/:id/meta",
+  ],
 };
 
 /**

--- a/turbo/apps/api/src/signals/routes/__benches__/chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/chat-threads.bench.ts
@@ -843,7 +843,7 @@ const authHeaders = { authorization: "Bearer clerk-session" } as const;
 
 describe("bench side-effect-free GET API routes", () => {
   bench(
-    "GET /api/okou/chat-threads/:id",
+    "GET /api/chat-threads/:id",
     async () => {
       const fixture = await ensureSeeded();
       const response = await chatThreadClient.get({

--- a/turbo/apps/cli/src/commands/chat/__tests__/cancel.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/cancel.test.ts
@@ -9,8 +9,8 @@ const THREAD_ID = "00000000-0000-4000-8000-000000000001";
 const AGENT_ID = "00000000-0000-4000-8000-000000000010";
 const RUN_ID = "00000000-0000-4000-8000-000000000020";
 const EVENT_ID = "00000000-0000-4000-8000-000000000030";
-const METADATA_URL = `http://localhost:3000/api/okou/chat-threads/${THREAD_ID}/metadata`;
-const SEND_URL = "http://localhost:3000/api/okou/chat/events";
+const METADATA_URL = `http://localhost:3000/api/chat-threads/${THREAD_ID}/metadata`;
+const SEND_URL = "http://localhost:3000/api/chat/events";
 
 describe("okou chat cancel command", () => {
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});

--- a/turbo/apps/cli/src/commands/chat/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/create.test.ts
@@ -9,10 +9,10 @@ const CURRENT_THREAD_ID = "00000000-0000-4000-8000-000000000001";
 const NEW_THREAD_ID = "00000000-0000-4000-8000-000000000002";
 const AGENT_ID = "00000000-0000-4000-8000-000000000010";
 const OTHER_AGENT_ID = "00000000-0000-4000-8000-000000000011";
-const CREATE_URL = "http://localhost:3000/api/okou/chat-threads";
+const CREATE_URL = "http://localhost:3000/api/chat-threads";
 
 function metadataUrl(threadId: string): string {
-  return `http://localhost:3000/api/okou/chat-threads/${threadId}/metadata`;
+  return `http://localhost:3000/api/chat-threads/${threadId}/metadata`;
 }
 
 describe("okou chat create command", () => {

--- a/turbo/apps/cli/src/commands/chat/__tests__/get.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/get.test.ts
@@ -17,8 +17,8 @@ import { chatCommand } from "../index";
 const THREAD_ID = "00000000-0000-4000-8000-000000000001";
 const AGENT_ID = "00000000-0000-4000-8000-000000000010";
 const OTHER_THREAD_ID = "00000000-0000-4000-8000-000000000002";
-const GET_URL = `http://localhost:3000/api/okou/chat-threads/${THREAD_ID}/metadata`;
-const OTHER_GET_URL = `http://localhost:3000/api/okou/chat-threads/${OTHER_THREAD_ID}/metadata`;
+const GET_URL = `http://localhost:3000/api/chat-threads/${THREAD_ID}/metadata`;
+const OTHER_GET_URL = `http://localhost:3000/api/chat-threads/${OTHER_THREAD_ID}/metadata`;
 
 describe("okou chat get command", () => {
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});

--- a/turbo/apps/cli/src/commands/chat/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/list.test.ts
@@ -22,8 +22,8 @@ const INITIAL_SEQ_ID = 1;
 const RENAME_SEQ_ID = 2;
 const SORT_SEQ_ID = 3;
 const REFRESH_SEQ_ID = 4;
-const SNAPSHOT_URL = "http://localhost:3000/api/okou/chat-threads/snapshot";
-const EVENTS_URL = "http://localhost:3000/api/okou/chat-threads/events";
+const SNAPSHOT_URL = "http://localhost:3000/api/chat-threads/snapshot";
+const EVENTS_URL = "http://localhost:3000/api/chat-threads/events";
 
 function zeroToken(): string {
   const payload = Buffer.from(

--- a/turbo/apps/cli/src/commands/chat/__tests__/messages.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/messages.test.ts
@@ -27,8 +27,8 @@ import { server } from "../../../mocks/server";
 import { chatCommand } from "../index";
 
 const THREAD_ID = "00000000-0000-4000-8000-000000000001";
-const SNAPSHOT_URL = `http://localhost:3000/api/okou/chat-threads/${THREAD_ID}/event-snapshot`;
-const ROWS_URL = `http://localhost:3000/api/okou/chat-threads/${THREAD_ID}/event-rows`;
+const SNAPSHOT_URL = `http://localhost:3000/api/chat-threads/${THREAD_ID}/event-snapshot`;
+const ROWS_URL = `http://localhost:3000/api/chat-threads/${THREAD_ID}/event-rows`;
 const SNAPSHOT_DOWNLOAD_URL =
   "https://r2.example.test/chat-events/snapshot.ndjson.gz";
 const CHAT_EVENT_SCHEMA_HEADERS = {

--- a/turbo/apps/cli/src/commands/chat/__tests__/model.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/model.test.ts
@@ -16,9 +16,9 @@ import { chatCommand } from "../index";
 
 const THREAD_ID = "00000000-0000-4000-8000-000000000001";
 const OTHER_THREAD_ID = "00000000-0000-4000-8000-000000000002";
-const GET_URL = `http://localhost:3000/api/okou/chat-threads/${THREAD_ID}/metadata`;
-const OTHER_GET_URL = `http://localhost:3000/api/okou/chat-threads/${OTHER_THREAD_ID}/metadata`;
-const OTHER_MODEL_SELECTION_URL = `http://localhost:3000/api/okou/chat-threads/${OTHER_THREAD_ID}/model-selection`;
+const GET_URL = `http://localhost:3000/api/chat-threads/${THREAD_ID}/metadata`;
+const OTHER_GET_URL = `http://localhost:3000/api/chat-threads/${OTHER_THREAD_ID}/metadata`;
+const OTHER_MODEL_SELECTION_URL = `http://localhost:3000/api/chat-threads/${OTHER_THREAD_ID}/model-selection`;
 const MODEL_POLICIES_URL = "http://localhost:3000/api/okou/model-policies";
 
 const MODEL_POLICIES_RESPONSE = {

--- a/turbo/apps/cli/src/commands/chat/__tests__/rename.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/rename.test.ts
@@ -16,8 +16,8 @@ import { chatCommand } from "../index";
 
 const THREAD_ID = "00000000-0000-4000-8000-000000000001";
 const OTHER_THREAD_ID = "00000000-0000-4000-8000-000000000002";
-const RENAME_URL = `http://localhost:3000/api/okou/chat-threads/${THREAD_ID}/rename`;
-const OTHER_RENAME_URL = `http://localhost:3000/api/okou/chat-threads/${OTHER_THREAD_ID}/rename`;
+const RENAME_URL = `http://localhost:3000/api/chat-threads/${THREAD_ID}/rename`;
+const OTHER_RENAME_URL = `http://localhost:3000/api/chat-threads/${OTHER_THREAD_ID}/rename`;
 
 describe("okou chat rename command", () => {
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});

--- a/turbo/apps/cli/src/commands/chat/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/send.test.ts
@@ -13,10 +13,10 @@ const THREAD_ID = "00000000-0000-4000-8000-000000000001";
 const OTHER_THREAD_ID = "00000000-0000-4000-8000-000000000002";
 const AGENT_ID = "00000000-0000-4000-8000-000000000010";
 const RUN_ID = "00000000-0000-4000-8000-000000000020";
-const SEND_URL = "http://localhost:3000/api/okou/chat/events";
+const SEND_URL = "http://localhost:3000/api/chat/events";
 
 function metadataUrl(threadId: string): string {
-  return `http://localhost:3000/api/okou/chat-threads/${threadId}/metadata`;
+  return `http://localhost:3000/api/chat-threads/${threadId}/metadata`;
 }
 
 describe("okou chat send command", () => {

--- a/turbo/apps/cli/src/commands/search/__tests__/chat-source.test.ts
+++ b/turbo/apps/cli/src/commands/search/__tests__/chat-source.test.ts
@@ -63,7 +63,7 @@ describe("okou search --source chat", () => {
 
   it("renders chat search results grouped by thread", async () => {
     server.use(
-      http.get("http://localhost:3000/api/okou/chat/search", () => {
+      http.get("http://localhost:3000/api/chat/search", () => {
         return HttpResponse.json({
           results: [
             {
@@ -91,7 +91,7 @@ describe("okou search --source chat", () => {
 
   it("tolerates invalid chat message timestamps", async () => {
     server.use(
-      http.get("http://localhost:3000/api/okou/chat/search", () => {
+      http.get("http://localhost:3000/api/chat/search", () => {
         return HttpResponse.json({
           results: [
             {
@@ -119,7 +119,7 @@ describe("okou search --source chat", () => {
 
   it("handles no matches", async () => {
     server.use(
-      http.get("http://localhost:3000/api/okou/chat/search", () => {
+      http.get("http://localhost:3000/api/chat/search", () => {
         return HttpResponse.json({ results: [], hasMore: false });
       }),
     );
@@ -140,7 +140,7 @@ describe("okou search --source chat", () => {
   it("passes keyword and -C context to API", async () => {
     let capturedUrl: URL | undefined;
     server.use(
-      http.get("http://localhost:3000/api/okou/chat/search", ({ request }) => {
+      http.get("http://localhost:3000/api/chat/search", ({ request }) => {
         capturedUrl = new URL(request.url);
         return HttpResponse.json({ results: [], hasMore: false });
       }),
@@ -164,7 +164,7 @@ describe("okou search --source chat", () => {
   it("passes epoch --since to API instead of the default search window", async () => {
     let capturedUrl: URL | undefined;
     server.use(
-      http.get("http://localhost:3000/api/okou/chat/search", ({ request }) => {
+      http.get("http://localhost:3000/api/chat/search", ({ request }) => {
         capturedUrl = new URL(request.url);
         return HttpResponse.json({ results: [], hasMore: false });
       }),
@@ -186,7 +186,7 @@ describe("okou search --source chat", () => {
   it("passes -A and -B independently", async () => {
     let capturedUrl: URL | undefined;
     server.use(
-      http.get("http://localhost:3000/api/okou/chat/search", ({ request }) => {
+      http.get("http://localhost:3000/api/chat/search", ({ request }) => {
         capturedUrl = new URL(request.url);
         return HttpResponse.json({ results: [], hasMore: false });
       }),
@@ -212,7 +212,7 @@ describe("okou search --source chat", () => {
     let capturedUrl: URL | undefined;
     const agentId = "550e8400-e29b-41d4-a716-446655440001";
     server.use(
-      http.get("http://localhost:3000/api/okou/chat/search", ({ request }) => {
+      http.get("http://localhost:3000/api/chat/search", ({ request }) => {
         capturedUrl = new URL(request.url);
         return HttpResponse.json({ results: [], hasMore: false });
       }),
@@ -373,7 +373,7 @@ describe("okou search --source chat", () => {
 
   it("shows the hasMore hint when the API reports more results", async () => {
     server.use(
-      http.get("http://localhost:3000/api/okou/chat/search", () => {
+      http.get("http://localhost:3000/api/chat/search", () => {
         return HttpResponse.json({
           results: [
             {
@@ -403,7 +403,7 @@ describe("okou search --source chat", () => {
 
   it("surfaces API authentication errors", async () => {
     server.use(
-      http.get("http://localhost:3000/api/okou/chat/search", () => {
+      http.get("http://localhost:3000/api/chat/search", () => {
         return HttpResponse.json(
           { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
           { status: 401 },

--- a/turbo/apps/cli/src/commands/workflow/automation/__tests__/automation.test.ts
+++ b/turbo/apps/cli/src/commands/workflow/automation/__tests__/automation.test.ts
@@ -27,7 +27,7 @@ const THREAD_ID = "44444444-4444-4444-8444-444444444444";
 const MODEL_ID = "gpt-5.6-sol";
 const STRAPI_INTEGRATION_ID = "55555555-5555-4555-8555-555555555556";
 const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
-const THREAD_METADATA_URL = `http://localhost:3000/api/okou/chat-threads/${THREAD_ID}/metadata`;
+const THREAD_METADATA_URL = `http://localhost:3000/api/chat-threads/${THREAD_ID}/metadata`;
 const MODEL_POLICIES_URL = "http://localhost:3000/api/okou/model-policies";
 
 function zeroToken(orgId: string): string {

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -190,7 +190,7 @@ export const apiAgentsHandlers = [
     return respond(204);
   }),
 
-  // GET /api/okou/chat-threads/snapshot
+  // GET /api/chat-threads/snapshot
   mockApi(chatThreadsContract.snapshot, ({ respond }) => {
     return respond(200, {
       chatThreads: [],
@@ -199,7 +199,7 @@ export const apiAgentsHandlers = [
     });
   }),
 
-  // GET /api/okou/chat-threads/events
+  // GET /api/chat-threads/events
   mockApi(chatThreadsContract.events, ({ respond }) => {
     return respond(200, {
       events: [],
@@ -207,7 +207,7 @@ export const apiAgentsHandlers = [
     });
   }),
 
-  // GET /api/okou/chat/search
+  // GET /api/chat/search
   mockApi(chatSearchContract.search, ({ respond }) => {
     return respond(200, { results: [], hasMore: false });
   }),
@@ -222,7 +222,7 @@ export const apiAgentsHandlers = [
     return respond(200, { draftThreadIds: [] });
   }),
 
-  // POST /api/okou/chat-threads (create new thread)
+  // POST /api/chat-threads (create new thread)
   mockApi(chatThreadsContract.create, ({ body, respond }) => {
     return respond(201, {
       id: body.clientThreadId ?? "b0000000-0000-4000-a000-000000000001",
@@ -233,7 +233,7 @@ export const apiAgentsHandlers = [
     });
   }),
 
-  // GET /api/okou/chat-threads/:threadId/event-snapshot
+  // GET /api/chat-threads/:threadId/event-snapshot
   mockApi(chatThreadEventsContract.snapshot, ({ respond }) => {
     return respond(404, {
       error: {
@@ -243,17 +243,17 @@ export const apiAgentsHandlers = [
     });
   }),
 
-  // GET /api/okou/chat-threads/:threadId/event-rows
+  // GET /api/chat-threads/:threadId/event-rows
   mockApi(chatThreadEventsContract.rows, ({ respond }) => {
     return respond(200, { rows: [] });
   }),
 
-  // GET /api/okou/chat-threads/:threadId/artifacts
+  // GET /api/chat-threads/:threadId/artifacts
   mockApi(chatThreadArtifactsContract.list, ({ respond }) => {
     return respond(200, { runs: [] });
   }),
 
-  // GET /api/okou/chat-threads/:id (thread detail)
+  // GET /api/chat-threads/:id (thread detail)
   mockApi(chatThreadByIdContract.get, ({ respond }) => {
     return respond(200, {
       lastReadAt: "2026-03-10T00:00:00Z",
@@ -261,7 +261,7 @@ export const apiAgentsHandlers = [
     });
   }),
 
-  // GET /api/okou/chat-threads/:id/draft
+  // GET /api/chat-threads/:id/draft
   mockApi(chatThreadDraftContract.get, ({ respond }) => {
     return respond(200, {
       draftUserMessage: null,
@@ -269,17 +269,17 @@ export const apiAgentsHandlers = [
     });
   }),
 
-  // PATCH /api/okou/chat-threads/:id (update draft)
+  // PATCH /api/chat-threads/:id (update draft)
   mockApi(chatThreadByIdContract.patch, ({ respond }) => {
     return respond(204);
   }),
 
-  // POST /api/okou/chat-threads/:id/model-selection
+  // POST /api/chat-threads/:id/model-selection
   mockApi(chatThreadModelSelectionContract.update, ({ respond }) => {
     return respond(204);
   }),
 
-  // POST /api/okou/chat-threads/:id/computer-use-host
+  // POST /api/chat-threads/:id/computer-use-host
   mockApi(chatThreadComputerUseHostContract.update, ({ respond }) => {
     return respond(204);
   }),
@@ -294,7 +294,7 @@ export const apiAgentsHandlers = [
     return respond(204);
   }),
 
-  // POST /api/okou/chat-threads/:id/mark-read
+  // POST /api/chat-threads/:id/mark-read
   mockApi(chatThreadMarkReadContract.markRead, ({ respond }) => {
     return respond(200, { lastReadAt: null, unreads: [] });
   }),

--- a/turbo/apps/platform/src/mocks/handlers/api-queue-position.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-queue-position.ts
@@ -1,7 +1,7 @@
 /**
  * Queue Position API Handlers
  *
- * Mock handlers for /api/okou/queue-position endpoint.
+ * Mock handlers for /api/queue-position endpoint.
  * Default behavior: position 0, total 0.
  */
 
@@ -9,7 +9,7 @@ import { queuePositionContract } from "@okouai/api-contracts/contracts/queue-pos
 import { mockApi } from "../msw-contract.ts";
 
 export const apiQueuePositionHandlers = [
-  // GET /api/okou/queue-position
+  // GET /api/queue-position
   mockApi(queuePositionContract.getPosition, ({ respond }) =>
     respond(200, { position: 0, total: 0 }),
   ),

--- a/turbo/apps/platform/src/mocks/handlers/api-runs.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-runs.ts
@@ -82,7 +82,7 @@ export const apiRunsHandlers = [
     respond(200, { networkLogs: [], hasMore: false }),
   ),
 
-  // POST /api/okou/chat/events
+  // POST /api/chat/events
   mockApi(chatEventsContract.send, ({ respond }) =>
     respond(201, {
       runId: "a0000000-0000-4000-a000-000000000001",
@@ -92,7 +92,7 @@ export const apiRunsHandlers = [
     }),
   ),
 
-  // GET /api/okou/queue-position
+  // GET /api/queue-position
   mockApi(queuePositionContract.getPosition, ({ respond }) =>
     respond(200, { position: 0, total: 0 }),
   ),

--- a/turbo/apps/platform/src/mocks/msw-contract.ts
+++ b/turbo/apps/platform/src/mocks/msw-contract.ts
@@ -119,10 +119,10 @@ const methodMap = {
 } as const;
 
 function routePattern(route: AppRoute): string | RegExp {
-  if (route.path === "/api/okou/chat-threads/:id") {
+  if (route.path === "/api/chat-threads/:id") {
     // Keep thread detail mocks from swallowing static sibling routes while
     // still accepting the descriptive non-UUID thread ids used by UI tests.
-    return /\/api\/okou\/chat-threads\/(?!snapshot$|events$)([^/]+)$/;
+    return /\/api\/chat-threads\/(?!snapshot$|events$)([^/]+)$/;
   }
   return `*${route.path}`;
 }
@@ -132,7 +132,7 @@ function routeParamsForRequest<R extends AppRoute>(
   params: PathParams,
   url: URL,
 ): InferParams<R> {
-  if (route.path === "/api/okou/chat-threads/:id") {
+  if (route.path === "/api/chat-threads/:id") {
     return {
       ...params,
       id: url.pathname.split("/").pop() ?? "",

--- a/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
@@ -514,7 +514,7 @@ describe("shared database worker runtime", () => {
     const clientId = await connectRuntime();
     const dataKey = chatEventKey(crypto.randomUUID());
     context.mocks.http.get(
-      `*/api/okou/chat-threads/${dataKey.threadId}/event-snapshot`,
+      `*/api/chat-threads/${dataKey.threadId}/event-snapshot`,
       () => {
         return HttpResponse.json(
           {
@@ -549,7 +549,7 @@ describe("shared database worker runtime", () => {
       });
     });
     context.mocks.http.get(
-      `*/api/okou/chat-threads/${dataKey.threadId}/event-rows`,
+      `*/api/chat-threads/${dataKey.threadId}/event-rows`,
       () => {
         return HttpResponse.json(
           { rows: [] },
@@ -771,7 +771,7 @@ describe("shared database worker runtime", () => {
       });
     });
     context.mocks.http.get(
-      `*/api/okou/chat-threads/${dataKey.threadId}/event-rows`,
+      `*/api/chat-threads/${dataKey.threadId}/event-rows`,
       ({ request }) => {
         if (failNextPage) {
           failNextPage = false;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -927,13 +927,10 @@ describe("chat lifecycle", () => {
     const toastError = vi.spyOn(toast, "error");
     context.mocks.browser.voiceInput({ rms: 0.1 });
     mockChatLifecycle(context, { threadId });
-    context.mocks.http.patch(
-      "*/api/okou/chat-threads/:id",
-      async ({ request }) => {
-        draftPatches.push(await request.json());
-        return new Response(null, { status: 200 });
-      },
-    );
+    context.mocks.http.patch("*/api/chat-threads/:id", async ({ request }) => {
+      draftPatches.push(await request.json());
+      return new Response(null, { status: 200 });
+    });
     context.mocks.http.post("*/api/okou/voice-io/stt", () => {
       return new Response(JSON.stringify({ text: "Summarize the standup" }), {
         headers: { "Content-Type": "application/json" },
@@ -1111,13 +1108,10 @@ describe("chat lifecycle", () => {
       rms: [0.1, 0.1, 0, 0, 0],
     });
     mockChatLifecycle(context, { threadId });
-    context.mocks.http.patch(
-      "*/api/okou/chat-threads/:id",
-      async ({ request }) => {
-        draftPatches.push(await request.json());
-        return new Response(null, { status: 200 });
-      },
-    );
+    context.mocks.http.patch("*/api/chat-threads/:id", async ({ request }) => {
+      draftPatches.push(await request.json());
+      return new Response(null, { status: 200 });
+    });
     context.mocks.http.post("*/api/okou/voice-io/stt", async ({ request }) => {
       transcriptionRequested.resolve(undefined);
       const form = await request.formData();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -653,7 +653,7 @@ describe("chat drafts", () => {
       threadId,
       selectedModel: "claude-sonnet-4-6",
     });
-    context.mocks.http.get("*/api/okou/chat-threads/:id/draft", () => {
+    context.mocks.http.get("*/api/chat-threads/:id/draft", () => {
       return HttpResponse.json({
         draftUserMessage: {
           version: 1,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-events.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-events.test.ts
@@ -620,7 +620,7 @@ describe("ChatEvent folds", () => {
 
 describe("ChatEvent HTTP contracts", () => {
   it("uses event naming for the canonical send route", () => {
-    expect(chatEventsContract.send.path).toBe("/api/okou/chat/events");
+    expect(chatEventsContract.send.path).toBe("/api/chat/events");
   });
 
   it("uses event ids in canonical write bodies", () => {

--- a/turbo/packages/api-contracts/src/contracts/browser.ts
+++ b/turbo/packages/api-contracts/src/contracts/browser.ts
@@ -186,7 +186,7 @@ export const browserContract = c.router({
   },
   leaseByThread: {
     method: "POST",
-    path: "/api/okou/chat-threads/:threadId/browser/lease",
+    path: "/api/chat-threads/:threadId/browser/lease",
     headers: authHeadersSchema,
     pathParams: browserThreadParamsSchema,
     body: z.object({}),
@@ -198,7 +198,7 @@ export const browserContract = c.router({
   },
   open: {
     method: "POST",
-    path: "/api/okou/chat-threads/:threadId/browser/open",
+    path: "/api/chat-threads/:threadId/browser/open",
     headers: authHeadersSchema,
     pathParams: browserThreadParamsSchema,
     body: browserLifecycleRequestSchema,
@@ -210,7 +210,7 @@ export const browserContract = c.router({
   },
   close: {
     method: "POST",
-    path: "/api/okou/chat-threads/:threadId/browser/close",
+    path: "/api/chat-threads/:threadId/browser/close",
     headers: authHeadersSchema,
     pathParams: browserThreadParamsSchema,
     body: browserLifecycleRequestSchema,
@@ -222,7 +222,7 @@ export const browserContract = c.router({
   },
   resizeByThread: {
     method: "POST",
-    path: "/api/okou/chat-threads/:threadId/browser/resize",
+    path: "/api/chat-threads/:threadId/browser/resize",
     headers: authHeadersSchema,
     pathParams: browserThreadParamsSchema,
     body: browserResizeRequestSchema,
@@ -244,7 +244,7 @@ export const browserContract = c.router({
   },
   get: {
     method: "GET",
-    path: "/api/okou/chat-threads/:threadId/browser",
+    path: "/api/chat-threads/:threadId/browser",
     headers: authHeadersSchema,
     pathParams: browserThreadParamsSchema,
     responses: {

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -998,7 +998,7 @@ export const chatThreadsContract = c.router({
   },
   snapshot: {
     method: "GET",
-    path: "/api/okou/chat-threads/snapshot",
+    path: "/api/chat-threads/snapshot",
     headers: authHeadersSchema,
     responses: {
       200: z.object({
@@ -1014,7 +1014,7 @@ export const chatThreadsContract = c.router({
   },
   events: {
     method: "GET",
-    path: "/api/okou/chat-threads/events",
+    path: "/api/chat-threads/events",
     headers: authHeadersSchema,
     query: z.object({
       sinceSeqId: z.coerce.number().int().positive().optional(),
@@ -1032,7 +1032,7 @@ export const chatThreadsContract = c.router({
   },
   create: {
     method: "POST",
-    path: "/api/okou/chat-threads",
+    path: "/api/chat-threads",
     headers: authHeadersSchema,
     body: chatThreadCreateBodySchema,
     responses: {
@@ -1099,7 +1099,7 @@ const chatThreadThreadIdPathParamsSchema = z.object({
 export const chatThreadByIdContract = c.router({
   get: {
     method: "GET",
-    path: "/api/okou/chat-threads/:id",
+    path: "/api/chat-threads/:id",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     responses: {
@@ -1112,7 +1112,7 @@ export const chatThreadByIdContract = c.router({
   },
   patch: {
     method: "PATCH",
-    path: "/api/okou/chat-threads/:id",
+    path: "/api/chat-threads/:id",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     body: z
@@ -1134,7 +1134,7 @@ export const chatThreadByIdContract = c.router({
   },
   delete: {
     method: "DELETE",
-    path: "/api/okou/chat-threads/:id",
+    path: "/api/chat-threads/:id",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     query: z.object({ eventId: chatThreadEventIdSchema.optional() }).optional(),
@@ -1157,7 +1157,7 @@ export const chatThreadByIdContract = c.router({
 export const chatThreadDraftContract = c.router({
   get: {
     method: "GET",
-    path: "/api/okou/chat-threads/:id/draft",
+    path: "/api/chat-threads/:id/draft",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     responses: {
@@ -1187,7 +1187,7 @@ const chatThreadReadStateResponseSchema = z.object({
 export const chatThreadMarkReadContract = c.router({
   markRead: {
     method: "POST",
-    path: "/api/okou/chat-threads/:id/mark-read",
+    path: "/api/chat-threads/:id/mark-read",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     body: c.noBody(),
@@ -1205,7 +1205,7 @@ export const chatThreadMarkReadContract = c.router({
 export const chatThreadMarkUnreadContract = c.router({
   markUnread: {
     method: "POST",
-    path: "/api/okou/chat-threads/:id/mark-unread",
+    path: "/api/chat-threads/:id/mark-unread",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     body: c.noBody(),
@@ -1253,7 +1253,7 @@ export const chatThreadMarkAgentReadContract = c.router({
 export const chatThreadPinContract = c.router({
   pin: {
     method: "POST",
-    path: "/api/okou/chat-threads/:id/pin",
+    path: "/api/chat-threads/:id/pin",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     query: z.object({ eventId: chatThreadEventIdSchema.optional() }).optional(),
@@ -1271,7 +1271,7 @@ export const chatThreadPinContract = c.router({
 export const chatThreadUnpinContract = c.router({
   unpin: {
     method: "POST",
-    path: "/api/okou/chat-threads/:id/unpin",
+    path: "/api/chat-threads/:id/unpin",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     query: z.object({ eventId: chatThreadEventIdSchema.optional() }).optional(),
@@ -1298,7 +1298,7 @@ export const chatThreadUnpinContract = c.router({
 export const chatThreadRenameContract = c.router({
   rename: {
     method: "POST",
-    path: "/api/okou/chat-threads/:id/rename",
+    path: "/api/chat-threads/:id/rename",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     body: z.object({
@@ -1323,7 +1323,7 @@ export const chatThreadRenameContract = c.router({
 export const chatThreadMetadataContract = c.router({
   get: {
     method: "GET",
-    path: "/api/okou/chat-threads/:id/metadata",
+    path: "/api/chat-threads/:id/metadata",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     responses: {
@@ -1344,7 +1344,7 @@ export const chatThreadMetadataContract = c.router({
 export const chatThreadModelSelectionContract = c.router({
   update: {
     method: "POST",
-    path: "/api/okou/chat-threads/:id/model-selection",
+    path: "/api/chat-threads/:id/model-selection",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     body: chatThreadModelSelectionUpdateBodySchema,
@@ -1364,7 +1364,7 @@ export const chatThreadModelSelectionContract = c.router({
 export const chatThreadConnectorSelectionContract = c.router({
   get: {
     method: "GET",
-    path: "/api/okou/chat-threads/:id/connector-selections",
+    path: "/api/chat-threads/:id/connector-selections",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     responses: {
@@ -1380,7 +1380,7 @@ export const chatThreadConnectorSelectionContract = c.router({
   },
   update: {
     method: "PUT",
-    path: "/api/okou/chat-threads/:id/connector-selections",
+    path: "/api/chat-threads/:id/connector-selections",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     body: connectorAccountSelectionSchema,
@@ -1395,7 +1395,7 @@ export const chatThreadConnectorSelectionContract = c.router({
   },
   clear: {
     method: "DELETE",
-    path: "/api/okou/chat-threads/:id/connector-selections",
+    path: "/api/chat-threads/:id/connector-selections",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     body: connectorAccountTargetSchema,
@@ -1417,7 +1417,7 @@ export const chatThreadConnectorSelectionContract = c.router({
 export const chatThreadVideoModelContract = c.router({
   update: {
     method: "POST",
-    path: "/api/okou/chat-threads/:id/video-model",
+    path: "/api/chat-threads/:id/video-model",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     body: chatThreadVideoModelUpdateBodySchema,
@@ -1439,7 +1439,7 @@ export const chatThreadVideoModelContract = c.router({
 export const chatThreadImageModelContract = c.router({
   update: {
     method: "POST",
-    path: "/api/okou/chat-threads/:id/image-model",
+    path: "/api/chat-threads/:id/image-model",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     body: chatThreadImageModelUpdateBodySchema,
@@ -1461,7 +1461,7 @@ export const chatThreadImageModelContract = c.router({
 export const chatThreadComputerUseHostContract = c.router({
   update: {
     method: "POST",
-    path: "/api/okou/chat-threads/:id/computer-use-host",
+    path: "/api/chat-threads/:id/computer-use-host",
     headers: authHeadersSchema,
     pathParams: chatThreadIdPathParamsSchema,
     body: z
@@ -1494,7 +1494,7 @@ export const chatThreadComputerUseHostContract = c.router({
 export const chatEventsContract = c.router({
   send: {
     method: "POST",
-    path: "/api/okou/chat/events",
+    path: "/api/chat/events",
     headers: authHeadersSchema,
     body: z.union([
       chatEventNormalSendBodySchema,
@@ -1607,14 +1607,14 @@ const chatSearchResponseSchema = z.object({
 });
 
 /**
- * Chat search contract (GET /api/okou/chat/search)
+ * Chat search contract (GET /api/chat/search)
  * Searches chat messages within the caller's own threads in the caller's org.
  * Authorization is enforced at the DB query level via userId + orgId filters.
  */
 export const chatSearchContract = c.router({
   search: {
     method: "GET",
-    path: "/api/okou/chat/search",
+    path: "/api/chat/search",
     headers: authHeadersSchema,
     query: z.object({
       keyword: z.string().trim().min(1),
@@ -1644,7 +1644,7 @@ export const chatThreadEventsContract = c.router({
    */
   snapshot: {
     method: "GET",
-    path: "/api/okou/chat-threads/:threadId/event-snapshot",
+    path: "/api/chat-threads/:threadId/event-snapshot",
     headers: chatEventReadHeadersSchema,
     pathParams: chatThreadThreadIdPathParamsSchema,
     responses: {
@@ -1671,7 +1671,7 @@ export const chatThreadEventsContract = c.router({
    */
   rows: {
     method: "GET",
-    path: "/api/okou/chat-threads/:threadId/event-rows",
+    path: "/api/chat-threads/:threadId/event-rows",
     headers: chatEventReadHeadersSchema,
     pathParams: chatThreadThreadIdPathParamsSchema,
     query: z.union([
@@ -1705,7 +1705,7 @@ export const chatThreadEventsContract = c.router({
 export const chatThreadArtifactsContract = c.router({
   list: {
     method: "GET",
-    path: "/api/okou/chat-threads/:threadId/artifacts",
+    path: "/api/chat-threads/:threadId/artifacts",
     headers: authHeadersSchema,
     pathParams: chatThreadThreadIdPathParamsSchema,
     responses: {
@@ -1721,7 +1721,7 @@ export const chatThreadArtifactsContract = c.router({
   },
   syncGoogleDrive: {
     method: "POST",
-    path: "/api/okou/chat-threads/:threadId/artifacts",
+    path: "/api/chat-threads/:threadId/artifacts",
     headers: authHeadersSchema,
     pathParams: chatThreadThreadIdPathParamsSchema,
     body: z.object({

--- a/turbo/packages/api-contracts/src/contracts/goals.ts
+++ b/turbo/packages/api-contracts/src/contracts/goals.ts
@@ -92,7 +92,7 @@ export const goalsContract = c.router({
   },
   getForChatThread: {
     method: "GET",
-    path: "/api/okou/chat-threads/:threadId/goal",
+    path: "/api/chat-threads/:threadId/goal",
     headers: authHeadersSchema,
     pathParams: chatThreadGoalParamsSchema,
     responses: {
@@ -148,7 +148,7 @@ export const goalsContract = c.router({
   },
   pauseForChatThread: {
     method: "POST",
-    path: "/api/okou/chat-threads/:threadId/goal/pause",
+    path: "/api/chat-threads/:threadId/goal/pause",
     headers: authHeadersSchema,
     pathParams: chatThreadGoalParamsSchema,
     body: c.noBody(),

--- a/turbo/packages/api-contracts/src/contracts/image-share-x.ts
+++ b/turbo/packages/api-contracts/src/contracts/image-share-x.ts
@@ -21,7 +21,7 @@ export type ImageShareXResponse = z.infer<typeof imageShareXResponseSchema>;
 export const imageShareXContract = c.router({
   post: {
     method: "POST",
-    path: "/api/okou/image-share/x",
+    path: "/api/image-share/x",
     headers: authHeadersSchema,
     body: imageShareXRequestSchema,
     responses: {

--- a/turbo/packages/api-contracts/src/contracts/queue-position.ts
+++ b/turbo/packages/api-contracts/src/contracts/queue-position.ts
@@ -10,13 +10,13 @@ const queuePositionResponseSchema = z.object({
 });
 
 /**
- * Queue position contract (GET /api/okou/queue-position)
+ * Queue position contract (GET /api/queue-position)
  * Returns the position of a queued run within its org queue.
  */
 export const queuePositionContract = c.router({
   getPosition: {
     method: "GET",
-    path: "/api/okou/queue-position",
+    path: "/api/queue-position",
     headers: authHeadersSchema,
     query: z.object({
       runId: z.string().min(1, "runId is required"),

--- a/turbo/packages/api-contracts/src/contracts/shared-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/shared-threads.ts
@@ -175,7 +175,7 @@ const sharedThreadAuthHeadersSchema: ZodSchema<
 const sharedThreadsRuntimeSpec = {
   create: {
     method: "POST",
-    path: "/api/okou/chat-threads/:threadId/shared-threads",
+    path: "/api/chat-threads/:threadId/shared-threads",
     headers: sharedThreadAuthHeadersSchema,
     pathParams: createSharedThreadPathParamsSchema,
     body: createSharedThreadBodySchema,
@@ -191,7 +191,7 @@ const sharedThreadsRuntimeSpec = {
   },
   get: {
     method: "GET",
-    path: "/api/okou/shared-threads/:id",
+    path: "/api/shared-threads/:id",
     pathParams: sharedThreadIdPathParamsSchema,
     responses: {
       200: sharedThreadResponseSchema,
@@ -201,7 +201,7 @@ const sharedThreadsRuntimeSpec = {
   },
   meta: {
     method: "GET",
-    path: "/api/okou/shared-threads/:id/meta",
+    path: "/api/shared-threads/:id/meta",
     pathParams: sharedThreadIdPathParamsSchema,
     responses: {
       200: sharedThreadMetaResponseSchema,
@@ -215,7 +215,7 @@ const sharedThreadsRuntimeContract = c.router(sharedThreadsRuntimeSpec);
 
 type CreateSharedThreadRoute = AppRoute<CreateSharedThreadRouteTypes> & {
   readonly method: "POST";
-  readonly path: "/api/okou/chat-threads/:threadId/shared-threads";
+  readonly path: "/api/chat-threads/:threadId/shared-threads";
   readonly headers: ZodSchema<SharedThreadAuthHeaders, SharedThreadAuthHeaders>;
   readonly pathParams: ZodSchema<
     CreateSharedThreadPathParams,
@@ -226,7 +226,7 @@ type CreateSharedThreadRoute = AppRoute<CreateSharedThreadRouteTypes> & {
 
 type ReadSharedThreadRoute = AppRoute<ReadSharedThreadRouteTypes> & {
   readonly method: "GET";
-  readonly path: "/api/okou/shared-threads/:id";
+  readonly path: "/api/shared-threads/:id";
   readonly pathParams: ZodSchema<
     SharedThreadIdPathParams,
     SharedThreadIdPathParams
@@ -235,7 +235,7 @@ type ReadSharedThreadRoute = AppRoute<ReadSharedThreadRouteTypes> & {
 
 type ReadSharedThreadMetaRoute = AppRoute<ReadSharedThreadMetaRouteTypes> & {
   readonly method: "GET";
-  readonly path: "/api/okou/shared-threads/:id/meta";
+  readonly path: "/api/shared-threads/:id/meta";
   readonly pathParams: ZodSchema<
     SharedThreadIdPathParams,
     SharedThreadIdPathParams

--- a/turbo/packages/api-contracts/src/contracts/workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/workflows.ts
@@ -1810,7 +1810,7 @@ export const workflowAutomationsContract = c.router({
   },
   listForChatThread: {
     method: "GET",
-    path: "/api/okou/chat-threads/:threadId/workflow-automations",
+    path: "/api/chat-threads/:threadId/workflow-automations",
     headers: authHeadersSchema,
     pathParams: chatThreadIdParams,
     responses: {

--- a/turbo/packages/eslint-rules/src/ccstate/rules/no-non-zero-api.ts
+++ b/turbo/packages/eslint-rules/src/ccstate/rules/no-non-zero-api.ts
@@ -41,6 +41,13 @@ const MIGRATED_NEUTRAL_API_PATHS: readonly string[] = [
   "/api/push-subscriptions",
   "/api/realtime/token",
   "/api/runs",
+  // #28459
+  "/api/chat-threads",
+  "/api/chat/events",
+  "/api/chat/search",
+  "/api/image-share/x",
+  "/api/queue-position",
+  "/api/shared-threads",
 ];
 
 /**


### PR DESCRIPTION
Part of #28278. Closes #28459.

Second wave. Moves 34 product routes off the brand namespace: chat threads and their per-thread reads and writes, the chat event and search readers, shared threads, per-thread browser sessions and goals, thread workflow automations, queue position, and the X image share. Method, schemas, and handlers are unchanged — this is a path move.

## Contract paths

`packages/api-contracts/src/contracts/{chat-threads,shared-threads,browser,goals,workflows,queue-position,image-share-x}.ts` declare the neutral form. Only the 34 routes this slice owns moved; `/api/okou/browser/authorization-requests/**` and the `/api/okou/workflows/**` family are untouched.

## Compatibility

`apiNamespaceAliasPaths()` returns a neutral path unchanged, so the moment a contract declares one, both of its branded registrations disappear and a released caller 404s. Every moved route therefore gains a row in `MIGRATED_BRANDED_PATHS` naming its `/api/okou/**` and `/api/zero/**` form, each key reproducing its path parameter verbatim because the lookup matches `entry.route.path` exactly.

`apiNamespaceAliasPaths()`, `LEGACY_ZERO_PATHS`, `FINAL_PROVIDER_CONSOLE_PATHS`, and #28356's blanket expansion and fallback report are unchanged.

## Fallbacks

- `turbo/apps/api/src/signals/route-entry.ts:MIGRATED_BRANDED_PATHS` — 34 new rows, one per moved route, each naming that route's `/api/okou/**` and `/api/zero/**` form. Each row keeps the route answering on both branded paths after the contract declares the neutral one. Without them the compatibility disappears silently rather than loudly: `apiNamespaceAliasPaths()` returns a neutral path unchanged, so the blanket expansion derives no branded path for a migrated contract, and every released caller gets a 404.
  - **Surfaces and windows:** three, and the longest governs.
    - Old web or app clients — a tab holding already-loaded platform code keeps calling the branded path until it navigates or reloads: **~2 days** (`docs/fallback.md` §7).
    - Commit-addressed CLI packages pinned by an execution context's `CLI_PKG_URL` — the context keeps its artifact after a later API deploy, so exposure is the queue lifetime plus claimed execution, bounded by the runner's 2h `JOB_TIMEOUT`: **up to ~2 hours** past the drain.
    - The `okou-app` share worker on Cloudflare Pages, which reads `shared-threads/:id/meta` — it deploys on its own path and is deliberately left on the branded form by this PR, so this surface has **no window at all** until that worker moves.
  - **Removal condition:** #26701's evidence rules, not any of those clocks. The request log retains about three days, which cannot distinguish a drained caller from a weekly one, so a row is not retired on log silence alone. The `shared-threads/:id/meta` rows additionally wait until `.github/pages/okou-app/_worker.js` calls the neutral path. Follow-up: #26701.
  - **Justification:** `docs/fallback.md` §6.1, time-boxed cross-version rollout compatibility. This is the mechanism #28400/#28404 added for exactly this migration.

## Hardcoded callers

Everything in `apps/platform`, `apps/cli`, and `apps/desktop` that talks to these routes derives its URL from the contract, so the change surface is the test doubles and the mock router that match on a path:

- `apps/platform/src/mocks/msw-contract.ts` — the thread-detail special case matches `route.path`, so it had to move with the contract or the `*`-prefixed pattern would start swallowing `/chat-threads/snapshot` and `/chat-threads/events`;
- `apps/platform/src/mocks/handlers/**` comments, and the platform, CLI, and `shared-database` test doubles that pin absolute or wildcard URLs;
- `e2e/playwright/tests/chat.spec.ts` — `page.route` intercepts the platform's own requests, which are now neutral;
- `packages/eslint-rules` `no-non-zero-api` gains this slice's neutral prefixes, since `apps/platform` still rejects a non-branded `/api/` literal otherwise.

`apps/api` tests that request a branded form are left alone on purpose: they exercise the compatibility the table now provides, and `createAppWithRoutes` still serves them. The e2e bash helpers stay branded for the same reason.

## Tests

`migrated-branded-paths.test.ts` restates all 34 neutral paths and both branded forms literally in `MIGRATED_ROUTE_PATHS` — never derived from `apiNamespaceAliasPaths()` or read back from the table under test — which drives the existing whole-route-table assertion, and adds a request-level case through the production app factory so a reordering of `withMigratedBrandedPaths` fails here rather than in production. `assertUniqueRouteRegistrations` still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

