### PR TITLE
docs(vsock-proto): document decoder protocol-error recovery

### DIFF
--- a/crates/vsock-proto/src/frame.rs
+++ b/crates/vsock-proto/src/frame.rs
@@ -130,6 +130,10 @@ impl Decoder {
     ///
     /// Protocol errors are detected before any complete frame in the current
     /// buffered data is visited, preserving the all-or-error behavior of [`Self::decode`].
+    /// When a protocol error is returned, all currently buffered data is
+    /// discarded, including complete frames that were preflighted before the
+    /// invalid frame. The decoder is left empty and can be reused with
+    /// subsequent input.
     /// If the visitor returns an error, frames through the rejected frame are
     /// consumed and later complete frames remain buffered.
     pub fn decode_with<E>(


### PR DESCRIPTION
## Summary

- Document that `Decoder::decode_with` discards all buffered data when preflight reports a protocol error, visits no frame from that batch, and remains reusable for subsequent input.
- Preserve the documented distinction from visitor errors, which consume through the rejected frame while retaining later complete frames.

## Scope and exclusions

- Documentation-only change in `crates/vsock-proto/src/frame.rs`.
- No runtime, test, public signature, protocol, dependency, generated-file, database, or deployment changes.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-proto --all-features --no-deps`

Closes #28468
