### PR TITLE
refactor(api): move computer-use off the brand namespace

### DIFF
--- a/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
+++ b/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
@@ -472,6 +472,71 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/shared-threads/:id/meta",
     "/api/zero/shared-threads/:id/meta",
   ],
+  // #28466
+  "/api/computer-use/audit-events": [
+    "/api/okou/computer-use/audit-events",
+    "/api/zero/computer-use/audit-events",
+  ],
+  "/api/computer-use/authorization-requests": [
+    "/api/okou/computer-use/authorization-requests",
+    "/api/zero/computer-use/authorization-requests",
+  ],
+  "/api/computer-use/authorization-requests/:requestToken": [
+    "/api/okou/computer-use/authorization-requests/:requestToken",
+    "/api/zero/computer-use/authorization-requests/:requestToken",
+  ],
+  "/api/computer-use/authorization-requests/:requestToken/apply": [
+    "/api/okou/computer-use/authorization-requests/:requestToken/apply",
+    "/api/zero/computer-use/authorization-requests/:requestToken/apply",
+  ],
+  "/api/computer-use/commands": [
+    "/api/okou/computer-use/commands",
+    "/api/zero/computer-use/commands",
+  ],
+  "/api/computer-use/commands/:commandId": [
+    "/api/okou/computer-use/commands/:commandId",
+    "/api/zero/computer-use/commands/:commandId",
+  ],
+  "/api/computer-use/commands/:commandId/plugin-content": [
+    "/api/okou/computer-use/commands/:commandId/plugin-content",
+    "/api/zero/computer-use/commands/:commandId/plugin-content",
+  ],
+  "/api/computer-use/commands/:commandId/screenshot": [
+    "/api/okou/computer-use/commands/:commandId/screenshot",
+    "/api/zero/computer-use/commands/:commandId/screenshot",
+  ],
+  "/api/computer-use/heartbeat": [
+    "/api/okou/computer-use/heartbeat",
+    "/api/zero/computer-use/heartbeat",
+  ],
+  "/api/computer-use/host/commands/:commandId/complete": [
+    "/api/okou/computer-use/host/commands/:commandId/complete",
+    "/api/zero/computer-use/host/commands/:commandId/complete",
+  ],
+  "/api/computer-use/host/commands/next": [
+    "/api/okou/computer-use/host/commands/next",
+    "/api/zero/computer-use/host/commands/next",
+  ],
+  "/api/computer-use/host/stop": [
+    "/api/okou/computer-use/host/stop",
+    "/api/zero/computer-use/host/stop",
+  ],
+  "/api/computer-use/hosts": [
+    "/api/okou/computer-use/hosts",
+    "/api/zero/computer-use/hosts",
+  ],
+  "/api/computer-use/hosts/start": [
+    "/api/okou/computer-use/hosts/start",
+    "/api/zero/computer-use/hosts/start",
+  ],
+  "/api/computer-use/plugin-commands": [
+    "/api/okou/computer-use/plugin-commands",
+    "/api/zero/computer-use/plugin-commands",
+  ],
+  "/api/computer-use/write-commands": [
+    "/api/okou/computer-use/write-commands",
+    "/api/zero/computer-use/write-commands",
+  ],
 };
 
 function missingBrandedPaths(

--- a/turbo/apps/api/src/signals/route-entry.ts
+++ b/turbo/apps/api/src/signals/route-entry.ts
@@ -693,6 +693,88 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/shared-threads/:id/meta",
     "/api/zero/shared-threads/:id/meta",
   ],
+  // #28466: the desktop Computer Use family. The highest-traffic branded family
+  // in the repository — about 716,000 requests over the retained request-log
+  // window — and the one with the longest-lived callers: `computer-use-host.ts`
+  // in an installed Desktop build hardcodes the `okou` form of the host
+  // endpoints, and an installed build updates on its owner's schedule rather
+  // than on a deploy, so it has no window at all. The `zero` form carried
+  // measured traffic of its own and was reachable through the blanket expansion
+  // until the contract moved. Both are owed on all sixteen paths.
+  //
+  // The four rows `LEGACY_ZERO_PATHS` lists — `host/commands/next`,
+  // `audit-events`, `heartbeat`, and `hosts/start` — were served by that table
+  // before this move and are served by these rows after it: the contract no
+  // longer declares a branded path for the expansion to classify. The rows
+  // there stay untouched, and removal of either set follows #26701's evidence
+  // rules.
+  //
+  // A key holds its path parameter verbatim, because the lookup below matches
+  // `entry.route.path` exactly rather than an expanded request path.
+  "/api/computer-use/audit-events": [
+    "/api/okou/computer-use/audit-events",
+    "/api/zero/computer-use/audit-events",
+  ],
+  "/api/computer-use/authorization-requests": [
+    "/api/okou/computer-use/authorization-requests",
+    "/api/zero/computer-use/authorization-requests",
+  ],
+  "/api/computer-use/authorization-requests/:requestToken": [
+    "/api/okou/computer-use/authorization-requests/:requestToken",
+    "/api/zero/computer-use/authorization-requests/:requestToken",
+  ],
+  "/api/computer-use/authorization-requests/:requestToken/apply": [
+    "/api/okou/computer-use/authorization-requests/:requestToken/apply",
+    "/api/zero/computer-use/authorization-requests/:requestToken/apply",
+  ],
+  "/api/computer-use/commands": [
+    "/api/okou/computer-use/commands",
+    "/api/zero/computer-use/commands",
+  ],
+  "/api/computer-use/commands/:commandId": [
+    "/api/okou/computer-use/commands/:commandId",
+    "/api/zero/computer-use/commands/:commandId",
+  ],
+  "/api/computer-use/commands/:commandId/plugin-content": [
+    "/api/okou/computer-use/commands/:commandId/plugin-content",
+    "/api/zero/computer-use/commands/:commandId/plugin-content",
+  ],
+  "/api/computer-use/commands/:commandId/screenshot": [
+    "/api/okou/computer-use/commands/:commandId/screenshot",
+    "/api/zero/computer-use/commands/:commandId/screenshot",
+  ],
+  "/api/computer-use/heartbeat": [
+    "/api/okou/computer-use/heartbeat",
+    "/api/zero/computer-use/heartbeat",
+  ],
+  "/api/computer-use/host/commands/:commandId/complete": [
+    "/api/okou/computer-use/host/commands/:commandId/complete",
+    "/api/zero/computer-use/host/commands/:commandId/complete",
+  ],
+  "/api/computer-use/host/commands/next": [
+    "/api/okou/computer-use/host/commands/next",
+    "/api/zero/computer-use/host/commands/next",
+  ],
+  "/api/computer-use/host/stop": [
+    "/api/okou/computer-use/host/stop",
+    "/api/zero/computer-use/host/stop",
+  ],
+  "/api/computer-use/hosts": [
+    "/api/okou/computer-use/hosts",
+    "/api/zero/computer-use/hosts",
+  ],
+  "/api/computer-use/hosts/start": [
+    "/api/okou/computer-use/hosts/start",
+    "/api/zero/computer-use/hosts/start",
+  ],
+  "/api/computer-use/plugin-commands": [
+    "/api/okou/computer-use/plugin-commands",
+    "/api/zero/computer-use/plugin-commands",
+  ],
+  "/api/computer-use/write-commands": [
+    "/api/okou/computer-use/write-commands",
+    "/api/zero/computer-use/write-commands",
+  ],
 };
 
 /**

--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -1582,4 +1582,32 @@ describe("FILE-03 desktop computer-use runtime", () => {
     }
     expect(resweep.body.cleaned).toBe(0);
   });
+
+  // #28466 moved this contract to `/api/computer-use/**`. The heartbeat is the
+  // busiest path in the family and its caller is an installed Desktop build
+  // that hardcodes the branded form and updates on its owner's schedule, so
+  // the `MIGRATED_BRANDED_PATHS` rows have to keep both branded paths
+  // registered. The registration-level assertions live in
+  // `migrated-branded-paths.test.ts`; this is the executed request that proves
+  // an old build still reaches the handler and gets its host back.
+  it("serves the migrated heartbeat on the neutral path and both branded paths", async () => {
+    const actor = bdd.user({ orgId: `org_${randomUUID()}` });
+    const host = await api.startComputerUseHost(actor, {
+      hostName: "Studio Mac",
+    });
+
+    const responses = [];
+    for (const path of [
+      "/api/computer-use/heartbeat",
+      "/api/okou/computer-use/heartbeat",
+      "/api/zero/computer-use/heartbeat",
+    ]) {
+      responses.push(
+        await api.requestComputerUseHeartbeatAtPath(host.hostToken, path),
+      );
+    }
+
+    const served = { status: 200, body: { ok: true, hostId: host.hostId } };
+    expect(responses).toStrictEqual([served, served, served]);
+  });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
@@ -32,7 +32,10 @@ import type { ComputerUseAnyPluginCallBody } from "@okouai/api-contracts/contrac
 
 import { now } from "../../../../lib/time";
 import { accept, type TestContext } from "../../../../__tests__/test-context";
-import { setupApp } from "../../../../__tests__/test-helpers";
+import {
+  setupApp,
+  setupRawAppRequest,
+} from "../../../../__tests__/test-helpers";
 import { signSandboxJwtForTests } from "../../../auth/tokens";
 import type { ApiTestUser } from "./api-bdd";
 import { createRouteMocks } from "./route-test";
@@ -546,6 +549,28 @@ export function createComputerUseBddApi(context: TestContext) {
           body: hostRuntimeBody(),
         }),
         statuses,
+      );
+    },
+
+    /**
+     * Heartbeats at an explicit path instead of through the contract client.
+     * The clients above build their URL from the path the contract declares,
+     * so after #28466 moved this contract to `/api/computer-use/heartbeat`
+     * they can no longer reach the branded paths an installed Desktop build
+     * still hardcodes — which is exactly what the `MIGRATED_BRANDED_PATHS`
+     * rows keep registered.
+     */
+    async requestComputerUseHeartbeatAtPath(hostToken: string, path: string) {
+      return await setupRawAppRequest({ context, routes: computerUseRoutes })(
+        path,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            ...hostHeaders(hostToken),
+          },
+          body: JSON.stringify(hostRuntimeBody()),
+        },
       );
     },
 

--- a/turbo/apps/cli/src/commands/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/computer-use/__tests__/computer-use.test.ts
@@ -292,7 +292,7 @@ describe("computer-use command visibility", () => {
     vi.stubEnv("OKOU_TOKEN", "run-token-without-computer-use");
 
     server.use(
-      http.post("http://localhost:3000/api/okou/computer-use/commands", () => {
+      http.post("http://localhost:3000/api/computer-use/commands", () => {
         return HttpResponse.json(
           {
             error: {
@@ -333,14 +333,14 @@ describe("computer-use command visibility", () => {
 
     let pollCount = 0;
     server.use(
-      http.post("http://localhost:3000/api/okou/computer-use/commands", () => {
+      http.post("http://localhost:3000/api/computer-use/commands", () => {
         return HttpResponse.json({
           commandId: "cmd_poll",
           status: "queued",
         });
       }),
       http.get(
-        "http://localhost:3000/api/okou/computer-use/commands/cmd_poll",
+        "http://localhost:3000/api/computer-use/commands/cmd_poll",
         () => {
           pollCount += 1;
 
@@ -396,14 +396,14 @@ describe("computer-use command visibility", () => {
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     server.use(
-      http.post("https://api.okou.ai/api/okou/computer-use/commands", () => {
+      http.post("https://api.okou.ai/api/computer-use/commands", () => {
         return HttpResponse.json({
           commandId: "cmd_okou_origin",
           status: "queued",
         });
       }),
       http.get(
-        "https://api.okou.ai/api/okou/computer-use/commands/cmd_okou_origin",
+        "https://api.okou.ai/api/computer-use/commands/cmd_okou_origin",
         () => {
           return HttpResponse.json({
             id: "cmd_okou_origin",
@@ -432,7 +432,7 @@ describe("computer-use command visibility", () => {
 
     server.use(
       http.post(
-        "https://canonical.example.test/api/okou/computer-use/commands",
+        "https://canonical.example.test/api/computer-use/commands",
         () => {
           return HttpResponse.json({
             commandId: "cmd_canonical_origin",
@@ -441,7 +441,7 @@ describe("computer-use command visibility", () => {
         },
       ),
       http.get(
-        "https://canonical.example.test/api/okou/computer-use/commands/cmd_canonical_origin",
+        "https://canonical.example.test/api/computer-use/commands/cmd_canonical_origin",
         () => {
           return HttpResponse.json({
             id: "cmd_canonical_origin",
@@ -540,7 +540,7 @@ describe("computer-use command visibility", () => {
     const appState = "snapshot_id=desktop_test_snapshot\nw0 AXWindow";
     server.use(
       http.post(
-        "http://localhost:3000/api/okou/computer-use/commands",
+        "http://localhost:3000/api/computer-use/commands",
         async ({ request }) => {
           const body = (await request.json()) as Record<string, unknown>;
           expect(body.kind).toBe("app.state");
@@ -551,32 +551,29 @@ describe("computer-use command visibility", () => {
           });
         },
       ),
-      http.get(
-        "http://localhost:3000/api/okou/computer-use/commands/cmd_1",
-        () => {
-          return HttpResponse.json({
-            id: "cmd_1",
-            kind: "app.state",
-            status: "succeeded",
-            hostId: "host_1",
-            hostName: "Desktop",
-            payload: { app: "Slack/Test App" },
-            result: {
-              app: "Slack/Test App",
-              snapshotId: "desktop_test_snapshot",
-              appState,
-              screenshot: `data:image/png;base64,${screenshotBase64}`,
-              screenshotMimeType: "image/png",
-              screenshotWidth: 1363,
-              screenshotHeight: 1200,
-            },
-            timeoutMs: 10_000,
-            createdAt: "2026-05-21T10:00:00.000Z",
-            claimedAt: "2026-05-21T10:00:01.000Z",
-            completedAt: "2026-05-21T10:00:02.000Z",
-          });
-        },
-      ),
+      http.get("http://localhost:3000/api/computer-use/commands/cmd_1", () => {
+        return HttpResponse.json({
+          id: "cmd_1",
+          kind: "app.state",
+          status: "succeeded",
+          hostId: "host_1",
+          hostName: "Desktop",
+          payload: { app: "Slack/Test App" },
+          result: {
+            app: "Slack/Test App",
+            snapshotId: "desktop_test_snapshot",
+            appState,
+            screenshot: `data:image/png;base64,${screenshotBase64}`,
+            screenshotMimeType: "image/png",
+            screenshotWidth: 1363,
+            screenshotHeight: 1200,
+          },
+          timeoutMs: 10_000,
+          createdAt: "2026-05-21T10:00:00.000Z",
+          claimedAt: "2026-05-21T10:00:01.000Z",
+          completedAt: "2026-05-21T10:00:02.000Z",
+        });
+      }),
     );
 
     await computerUseCommand.parseAsync([
@@ -611,7 +608,7 @@ describe("computer-use command visibility", () => {
 
     server.use(
       http.post(
-        "http://localhost:3000/api/okou/computer-use/write-commands",
+        "http://localhost:3000/api/computer-use/write-commands",
         async ({ request }) => {
           const body = (await request.json()) as Record<string, unknown>;
           expect(body).toMatchObject({
@@ -631,7 +628,7 @@ describe("computer-use command visibility", () => {
         },
       ),
       http.get(
-        "http://localhost:3000/api/okou/computer-use/commands/cmd_click",
+        "http://localhost:3000/api/computer-use/commands/cmd_click",
         () => {
           return HttpResponse.json({
             id: "cmd_click",
@@ -691,7 +688,7 @@ describe("computer-use command visibility", () => {
     const appState = "snapshot_id=desktop_test_snapshot\n7 button Send";
     server.use(
       http.post(
-        "http://localhost:3000/api/okou/computer-use/write-commands",
+        "http://localhost:3000/api/computer-use/write-commands",
         async ({ request }) => {
           const body = (await request.json()) as Record<string, unknown>;
           expect(body).toMatchObject({
@@ -710,7 +707,7 @@ describe("computer-use command visibility", () => {
         },
       ),
       http.get(
-        "http://localhost:3000/api/okou/computer-use/commands/cmd_click_index",
+        "http://localhost:3000/api/computer-use/commands/cmd_click_index",
         () => {
           return HttpResponse.json({
             id: "cmd_click_index",
@@ -772,7 +769,7 @@ describe("computer-use command visibility", () => {
 
     server.use(
       http.post(
-        "http://localhost:3000/api/okou/computer-use/write-commands",
+        "http://localhost:3000/api/computer-use/write-commands",
         async ({ request }) => {
           const body = (await request.json()) as Record<string, unknown>;
           expect(body).toMatchObject({
@@ -789,7 +786,7 @@ describe("computer-use command visibility", () => {
         },
       ),
       http.get(
-        "http://localhost:3000/api/okou/computer-use/commands/cmd_press",
+        "http://localhost:3000/api/computer-use/commands/cmd_press",
         () => {
           return HttpResponse.json({
             id: "cmd_press",
@@ -834,7 +831,7 @@ describe("computer-use command visibility", () => {
 
     server.use(
       http.post(
-        "http://localhost:3000/api/okou/computer-use/write-commands",
+        "http://localhost:3000/api/computer-use/write-commands",
         async ({ request }) => {
           const body = (await request.json()) as Record<string, unknown>;
           expect(body).toMatchObject({
@@ -851,7 +848,7 @@ describe("computer-use command visibility", () => {
         },
       ),
       http.get(
-        "http://localhost:3000/api/okou/computer-use/commands/cmd_type",
+        "http://localhost:3000/api/computer-use/commands/cmd_type",
         () => {
           return HttpResponse.json({
             id: "cmd_type",
@@ -894,14 +891,14 @@ describe("computer-use command visibility", () => {
     let createBody: unknown;
     server.use(
       http.post(
-        "http://localhost:3000/api/okou/computer-use/plugin-commands",
+        "http://localhost:3000/api/computer-use/plugin-commands",
         async ({ request }) => {
           createBody = await request.json();
           return HttpResponse.json({ commandId: "cmd_mcp", status: "queued" });
         },
       ),
       http.get(
-        "http://localhost:3000/api/okou/computer-use/commands/cmd_mcp",
+        "http://localhost:3000/api/computer-use/commands/cmd_mcp",
         () => {
           return HttpResponse.json({
             id: "cmd_mcp",
@@ -959,14 +956,14 @@ describe("computer-use command visibility", () => {
     let createBody: unknown;
     server.use(
       http.post(
-        "http://localhost:3000/api/okou/computer-use/plugin-commands",
+        "http://localhost:3000/api/computer-use/plugin-commands",
         async ({ request }) => {
           createBody = await request.json();
           return HttpResponse.json({ commandId: "cmd_list", status: "queued" });
         },
       ),
       http.get(
-        "http://localhost:3000/api/okou/computer-use/commands/cmd_list",
+        "http://localhost:3000/api/computer-use/commands/cmd_list",
         () => {
           return HttpResponse.json({
             id: "cmd_list",
@@ -1018,7 +1015,7 @@ describe("computer-use command visibility", () => {
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     server.use(
-      http.get("http://localhost:3000/api/okou/computer-use/hosts", () => {
+      http.get("http://localhost:3000/api/computer-use/hosts", () => {
         return HttpResponse.json({
           hosts: [
             {
@@ -1059,7 +1056,7 @@ describe("computer-use command visibility", () => {
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     server.use(
-      http.get("http://localhost:3000/api/okou/computer-use/hosts", () => {
+      http.get("http://localhost:3000/api/computer-use/hosts", () => {
         return HttpResponse.json({ hosts: [] });
       }),
     );
@@ -1085,11 +1082,11 @@ describe("computer-use command visibility", () => {
 
     const screenshotBytes = Buffer.from("proxy-png-bytes");
     server.use(
-      http.post("http://localhost:3000/api/okou/computer-use/commands", () => {
+      http.post("http://localhost:3000/api/computer-use/commands", () => {
         return HttpResponse.json({ commandId: "cmd_ptr", status: "queued" });
       }),
       http.get(
-        "http://localhost:3000/api/okou/computer-use/commands/cmd_ptr",
+        "http://localhost:3000/api/computer-use/commands/cmd_ptr",
         () => {
           return HttpResponse.json({
             id: "cmd_ptr",
@@ -1117,7 +1114,7 @@ describe("computer-use command visibility", () => {
         },
       ),
       http.get(
-        "http://localhost:3000/api/okou/computer-use/commands/cmd_ptr/screenshot",
+        "http://localhost:3000/api/computer-use/commands/cmd_ptr/screenshot",
         () => {
           return new HttpResponse(screenshotBytes, {
             status: 200,
@@ -1150,11 +1147,11 @@ describe("computer-use command visibility", () => {
     vi.stubEnv("OKOU_TOKEN", "test-token");
 
     server.use(
-      http.post("http://localhost:3000/api/okou/computer-use/commands", () => {
+      http.post("http://localhost:3000/api/computer-use/commands", () => {
         return HttpResponse.json({ commandId: "cmd_exp", status: "queued" });
       }),
       http.get(
-        "http://localhost:3000/api/okou/computer-use/commands/cmd_exp",
+        "http://localhost:3000/api/computer-use/commands/cmd_exp",
         () => {
           return HttpResponse.json({
             id: "cmd_exp",

--- a/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
@@ -684,7 +684,7 @@ describe("okou connector permission-request command", () => {
 
     server.use(
       http.post(
-        "http://localhost:3000/api/okou/computer-use/authorization-requests",
+        "http://localhost:3000/api/computer-use/authorization-requests",
         ({ request }) => {
           expect(request.headers.get("authorization")).toBe("Bearer run-token");
           return HttpResponse.json({

--- a/turbo/apps/cli/src/lib/api/domains/computer-use.ts
+++ b/turbo/apps/cli/src/lib/api/domains/computer-use.ts
@@ -189,7 +189,7 @@ export async function fetchComputerUseScreenshot(
 ): Promise<{ readonly buffer: Buffer; readonly mimeType: string }> {
   const config = await getComputerUseClientConfig();
   const response = await fetch(
-    `${config.baseUrl}/api/okou/computer-use/commands/${encodeURIComponent(
+    `${config.baseUrl}/api/computer-use/commands/${encodeURIComponent(
       commandId,
     )}/screenshot`,
     { headers: headersWithCliClientHeaders(config.baseHeaders) },
@@ -218,7 +218,7 @@ export async function fetchComputerUsePluginContent(
 }> {
   const config = await getComputerUseClientConfig();
   const response = await fetch(
-    `${config.baseUrl}/api/okou/computer-use/commands/${encodeURIComponent(
+    `${config.baseUrl}/api/computer-use/commands/${encodeURIComponent(
       commandId,
     )}/plugin-content`,
     { headers: headersWithCliClientHeaders(config.baseHeaders) },

--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -97,7 +97,7 @@ function createRuntime(
   const hostFetch =
     options.hostFetch ??
     vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
       return jsonResponse({ status: "idle" });
@@ -170,7 +170,7 @@ describe("ComputerUseHostRuntime", () => {
       throw new Error("Expected Computer Use host registration request");
     }
     const [url, init] = call;
-    expect(url).toBe("https://api.vm0.ai/api/okou/computer-use/hosts/start");
+    expect(url).toBe("https://api.vm0.ai/api/computer-use/hosts/start");
     expect(init?.method).toBe("POST");
     expect(JSON.parse(String(init?.body))).toMatchObject({
       installationId: INSTALLATION_ID,
@@ -197,7 +197,7 @@ describe("ComputerUseHostRuntime", () => {
       return jsonResponse({ hostId: "host-1", hostToken: "token-1" });
     });
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
       return jsonResponse({ status: "idle" });
@@ -220,7 +220,7 @@ describe("ComputerUseHostRuntime", () => {
     await vi.advanceTimersByTimeAsync(2_000);
 
     const heartbeatCall = hostFetch.mock.calls.find(([url]) => {
-      return url.endsWith("/api/okou/computer-use/heartbeat");
+      return url.endsWith("/api/computer-use/heartbeat");
     });
     if (!heartbeatCall) {
       throw new Error("Expected Computer Use heartbeat request");
@@ -236,7 +236,7 @@ describe("ComputerUseHostRuntime", () => {
       installationId: INSTALLATION_ID,
     });
     expect(sessionFetch.mock.calls[0]?.[0]).toBe(
-      "https://api.vm0.ai/api/okou/computer-use/hosts/start",
+      "https://api.vm0.ai/api/computer-use/hosts/start",
     );
 
     await runtime.stop();
@@ -246,10 +246,10 @@ describe("ComputerUseHostRuntime", () => {
     vi.useFakeTimers();
     let nextCalls = 0;
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         nextCalls++;
         return jsonResponse({ status: "idle" });
       }
@@ -274,16 +274,16 @@ describe("ComputerUseHostRuntime", () => {
     const heartbeat = deferred<Response>();
     let nextCalls = 0;
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return heartbeat.promise;
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         nextCalls++;
         return nextCalls === 1
           ? new Response("{}", { status: 500 })
           : jsonResponse({ status: "idle" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/stop")) {
+      if (url.endsWith("/api/computer-use/host/stop")) {
         return jsonResponse({ ok: true });
       }
       throw new Error(`Unexpected host request: ${url}`);
@@ -319,10 +319,10 @@ describe("ComputerUseHostRuntime", () => {
     const heartbeat = deferred<Response>();
     const commandPoll = deferred<Response>();
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return heartbeat.promise;
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         return commandPoll.promise;
       }
       throw new Error(`Unexpected host request: ${url}`);
@@ -356,10 +356,10 @@ describe("ComputerUseHostRuntime", () => {
   it("deactivates for restart when command polling rejects the host token", async () => {
     vi.useFakeTimers();
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         return new Response("{}", { status: 401 });
       }
       throw new Error(`Unexpected host request: ${url}`);
@@ -393,10 +393,10 @@ describe("ComputerUseHostRuntime", () => {
   it("deactivates for restart when command completion rejects the host token", async () => {
     vi.useFakeTimers();
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         return jsonResponse({
           status: "command",
           command: {
@@ -406,7 +406,7 @@ describe("ComputerUseHostRuntime", () => {
           },
         });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/cmd-1/complete")) {
+      if (url.endsWith("/api/computer-use/host/commands/cmd-1/complete")) {
         return new Response("{}", { status: 401 });
       }
       throw new Error(`Unexpected host request: ${url}`);
@@ -438,10 +438,10 @@ describe("ComputerUseHostRuntime", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-25T08:00:00.000Z"));
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         return jsonResponse({
           status: "claimed",
           command: {
@@ -451,7 +451,7 @@ describe("ComputerUseHostRuntime", () => {
           },
         });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/cmd-1/complete")) {
+      if (url.endsWith("/api/computer-use/host/commands/cmd-1/complete")) {
         return jsonResponse({ ok: true });
       }
       return jsonResponse({ status: "idle" });
@@ -517,9 +517,7 @@ describe("ComputerUseHostRuntime", () => {
       { accessibility: true, screenRecording: false },
     );
     const completionCall = hostFetch.mock.calls.find(([url]) => {
-      return url.endsWith(
-        "/api/okou/computer-use/host/commands/cmd-1/complete",
-      );
+      return url.endsWith("/api/computer-use/host/commands/cmd-1/complete");
     });
     if (!completionCall) {
       throw new Error("Expected Computer Use command completion request");
@@ -548,10 +546,10 @@ describe("ComputerUseHostRuntime", () => {
     vi.useFakeTimers();
     let nextCommandId = 0;
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         if (nextCommandId === 25) {
           return jsonResponse({ status: "idle" });
         }
@@ -565,7 +563,7 @@ describe("ComputerUseHostRuntime", () => {
           },
         });
       }
-      if (url.includes("/api/okou/computer-use/host/commands/cmd-")) {
+      if (url.includes("/api/computer-use/host/commands/cmd-")) {
         return jsonResponse({ ok: true });
       }
       throw new Error(`Unexpected host request: ${url}`);
@@ -603,16 +601,16 @@ describe("ComputerUseHostRuntime", () => {
     };
     let nextCalls = 0;
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         nextCalls++;
         return nextCalls === 1
           ? jsonResponse({ status: "command", command })
           : jsonResponse({ status: "idle" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/cmd-1/complete")) {
+      if (url.endsWith("/api/computer-use/host/commands/cmd-1/complete")) {
         return jsonResponse({ ok: true });
       }
       throw new Error(`Unexpected host request: ${url}`);
@@ -664,16 +662,16 @@ describe("ComputerUseHostRuntime", () => {
     let nextCalls = 0;
     let completeCalls = 0;
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         nextCalls++;
         return nextCalls === 1
           ? jsonResponse({ status: "command", command })
           : jsonResponse({ status: "idle" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/cmd-1/complete")) {
+      if (url.endsWith("/api/computer-use/host/commands/cmd-1/complete")) {
         completeCalls++;
         return jsonResponse({ ok: true });
       }
@@ -698,7 +696,7 @@ describe("ComputerUseHostRuntime", () => {
     await vi.advanceTimersByTimeAsync(90_000);
 
     const heartbeatCalls = hostFetch.mock.calls.filter(([url]) => {
-      return url.endsWith("/api/okou/computer-use/heartbeat");
+      return url.endsWith("/api/computer-use/heartbeat");
     });
     expect(heartbeatCalls.length).toBeGreaterThan(1);
     expect(completeCalls).toBe(0);
@@ -722,19 +720,19 @@ describe("ComputerUseHostRuntime", () => {
     const events: string[] = [];
     let nextCalls = 0;
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         nextCalls += 1;
         events.push("claim");
         return jsonResponse({ status: "command", command });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/cmd-1/complete")) {
+      if (url.endsWith("/api/computer-use/host/commands/cmd-1/complete")) {
         events.push("complete");
         return jsonResponse({ ok: true });
       }
-      if (url.endsWith("/api/okou/computer-use/host/stop")) {
+      if (url.endsWith("/api/computer-use/host/stop")) {
         events.push("stop");
         return jsonResponse({ ok: true });
       }
@@ -776,10 +774,10 @@ describe("ComputerUseHostRuntime", () => {
     let nextCalls = 0;
     let completeCalls = 0;
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         nextCalls++;
         return nextCalls === 1
           ? jsonResponse({
@@ -792,7 +790,7 @@ describe("ComputerUseHostRuntime", () => {
             })
           : jsonResponse({ status: "idle" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/cmd-1/complete")) {
+      if (url.endsWith("/api/computer-use/host/commands/cmd-1/complete")) {
         completeCalls++;
         return completeCalls === 1
           ? new Response("{}", { status: 503 })
@@ -823,10 +821,10 @@ describe("ComputerUseHostRuntime", () => {
     let nextCalls = 0;
     let completeCalls = 0;
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         nextCalls++;
         return nextCalls === 1
           ? jsonResponse({
@@ -839,7 +837,7 @@ describe("ComputerUseHostRuntime", () => {
             })
           : jsonResponse({ status: "idle" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/cmd-1/complete")) {
+      if (url.endsWith("/api/computer-use/host/commands/cmd-1/complete")) {
         completeCalls++;
         return new Response("{}", { status: 409 });
       }
@@ -876,10 +874,10 @@ describe("ComputerUseHostRuntime", () => {
     let firstCommandClaimed = false;
     let secondCommandClaimed = false;
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         const offset = Date.now() - startedAtMs;
         claimOffsets.push(offset);
         if (offset === 5_000 && !firstCommandClaimed) {
@@ -906,7 +904,7 @@ describe("ComputerUseHostRuntime", () => {
         }
         return jsonResponse({ status: "idle" });
       }
-      if (url.includes("/api/okou/computer-use/host/commands/cmd-")) {
+      if (url.includes("/api/computer-use/host/commands/cmd-")) {
         return jsonResponse({ ok: true });
       }
       throw new Error(`Unexpected host request: ${url}`);
@@ -969,10 +967,10 @@ describe("ComputerUseHostRuntime", () => {
     let nextCalls = 0;
     let completeCalls = 0;
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url, init) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         nextCalls++;
         return nextCalls === 1
           ? jsonResponse({
@@ -985,7 +983,7 @@ describe("ComputerUseHostRuntime", () => {
             })
           : jsonResponse({ status: "idle" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/cmd-1/complete")) {
+      if (url.endsWith("/api/computer-use/host/commands/cmd-1/complete")) {
         completeCalls++;
         return completeCalls === 1
           ? await hungResponseUntilAbort(init)
@@ -1065,13 +1063,13 @@ describe("ComputerUseHostRuntime", () => {
     let heartbeatCalls = 0;
     let nextCalls = 0;
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         heartbeatCalls++;
         return heartbeatCalls === 1
           ? new Response("{}", { status: 503 })
           : jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         nextCalls++;
         return jsonResponse({ status: "idle" });
       }
@@ -1113,14 +1111,14 @@ describe("ComputerUseHostRuntime", () => {
     let heartbeatCalls = 0;
     let nextCalls = 0;
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url, init) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         heartbeatCalls++;
         if (heartbeatCalls === 1) {
           return await hungResponseUntilAbort(init);
         }
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         nextCalls++;
         return jsonResponse({ status: "idle" });
       }
@@ -1164,10 +1162,10 @@ describe("ComputerUseHostRuntime", () => {
     vi.useFakeTimers();
     let nextCalls = 0;
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url, init) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         nextCalls++;
         return nextCalls === 1
           ? await hungResponseUntilAbort(init)
@@ -1211,10 +1209,10 @@ describe("ComputerUseHostRuntime", () => {
     vi.setSystemTime(new Date("2026-06-10T10:00:00.000Z"));
     let nextCalls = 0;
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         nextCalls++;
         if (nextCalls === 1) {
           return jsonResponse({
@@ -1230,7 +1228,7 @@ describe("ComputerUseHostRuntime", () => {
           ? new Response("{}", { status: 500 })
           : jsonResponse({ status: "idle" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/cmd-1/complete")) {
+      if (url.endsWith("/api/computer-use/host/commands/cmd-1/complete")) {
         return jsonResponse({ ok: true });
       }
       throw new Error(`Unexpected host request: ${url}`);
@@ -1272,10 +1270,10 @@ describe("ComputerUseHostRuntime", () => {
     vi.setSystemTime(new Date("2026-06-10T10:00:00.000Z"));
     let nextCalls = 0;
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         nextCalls++;
         return nextCalls === 1
           ? new Response("{}", {
@@ -1314,17 +1312,17 @@ describe("ComputerUseHostRuntime", () => {
     vi.useFakeTimers();
     let heartbeatCalls = 0;
     const sessionFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.includes("/api/okou/computer-use/audit-events")) {
+      if (url.includes("/api/computer-use/audit-events")) {
         throw new Error("Heartbeat must not depend on audit history refresh");
       }
       return jsonResponse({ hostId: "host-1", hostToken: "token-1" });
     });
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         heartbeatCalls++;
         return jsonResponse({ ok: true, hostId: "host-1" });
       }
-      if (url.endsWith("/api/okou/computer-use/host/commands/next")) {
+      if (url.endsWith("/api/computer-use/host/commands/next")) {
         return jsonResponse({ status: "idle" });
       }
       throw new Error(`Unexpected host request: ${url}`);
@@ -1345,7 +1343,7 @@ describe("ComputerUseHostRuntime", () => {
     expect(heartbeatCalls).toBe(2);
     expect(
       sessionFetch.mock.calls.some(([url]) => {
-        return url.includes("/api/okou/computer-use/audit-events");
+        return url.includes("/api/computer-use/audit-events");
       }),
     ).toBe(false);
 
@@ -1363,7 +1361,7 @@ describe("ComputerUseHostRuntime", () => {
     await runtime.stop();
 
     const stopCall = hostFetch.mock.calls.find(([url]) => {
-      return url.endsWith("/api/okou/computer-use/host/stop");
+      return url.endsWith("/api/computer-use/host/stop");
     });
     if (!stopCall) {
       throw new Error("Expected Computer Use host stop request");
@@ -1384,7 +1382,7 @@ describe("ComputerUseHostRuntime", () => {
   it("reports heartbeat active host conflicts without retrying", async () => {
     vi.useFakeTimers();
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.endsWith("/api/okou/computer-use/heartbeat")) {
+      if (url.endsWith("/api/computer-use/heartbeat")) {
         return jsonResponse(
           {
             error: { message: "A Desktop Computer Use host is already active" },
@@ -1401,7 +1399,7 @@ describe("ComputerUseHostRuntime", () => {
 
     expect(hostFetch).toHaveBeenCalledOnce();
     expect(hostFetch.mock.calls[0]?.[0]).toBe(
-      "https://api.vm0.ai/api/okou/computer-use/heartbeat",
+      "https://api.vm0.ai/api/computer-use/heartbeat",
     );
     expect(runtime.getState()).toMatchObject({
       status: "error",
@@ -1430,7 +1428,7 @@ describe("ComputerUseHostRuntime", () => {
 
     expect(sessionFetch).toHaveBeenCalledTimes(2);
     expect(sessionFetch.mock.calls[0]?.[0]).toBe(
-      "https://api.vm0.ai/api/okou/computer-use/hosts/start",
+      "https://api.vm0.ai/api/computer-use/hosts/start",
     );
     expect(sessionFetch.mock.calls[1]?.[0]).toBe(
       "https://api.vm0.ai/api/auth/me",

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -704,7 +704,7 @@ export class ComputerUseHostRuntime {
   private async startHost(): Promise<number | null> {
     this.setState({ status: "connecting", lastError: null });
     const response = await this.sessionFetch(
-      `${this.apiBaseUrl}/api/okou/computer-use/hosts/start`,
+      `${this.apiBaseUrl}/api/computer-use/hosts/start`,
       {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -814,7 +814,7 @@ export class ComputerUseHostRuntime {
       label: "heartbeat",
       timeoutMs: HEARTBEAT_REQUEST_TIMEOUT_MS,
       request: async (signal) => {
-        return await this.hostFetch("/api/okou/computer-use/heartbeat", {
+        return await this.hostFetch("/api/computer-use/heartbeat", {
           method: "POST",
           body: JSON.stringify(await this.runtimeBody()),
           signal,
@@ -858,16 +858,13 @@ export class ComputerUseHostRuntime {
       label: "command poll",
       timeoutMs: COMMAND_POLL_REQUEST_TIMEOUT_MS,
       request: async (signal) => {
-        return await this.hostFetch(
-          "/api/okou/computer-use/host/commands/next",
-          {
-            method: "POST",
-            body: JSON.stringify({
-              supportedCapabilities: [...this.getSupportedCapabilities()],
-            }),
-            signal,
-          },
-        );
+        return await this.hostFetch("/api/computer-use/host/commands/next", {
+          method: "POST",
+          body: JSON.stringify({
+            supportedCapabilities: [...this.getSupportedCapabilities()],
+          }),
+          signal,
+        });
       },
     });
     if (next.status === 401) {
@@ -950,7 +947,7 @@ export class ComputerUseHostRuntime {
           timeoutMs: COMMAND_COMPLETION_REQUEST_TIMEOUT_MS,
           request: async (signal) => {
             return await this.hostFetch(
-              `/api/okou/computer-use/host/commands/${commandId}/complete`,
+              `/api/computer-use/host/commands/${commandId}/complete`,
               {
                 method: "POST",
                 body: JSON.stringify(completed),
@@ -1008,7 +1005,7 @@ export class ComputerUseHostRuntime {
 
   private async stopHost(hostToken: string): Promise<void> {
     const response = await this.hostFetchRequest(
-      `${this.apiBaseUrl}/api/okou/computer-use/host/stop`,
+      `${this.apiBaseUrl}/api/computer-use/host/stop`,
       {
         method: "POST",
         body: JSON.stringify({}),

--- a/turbo/apps/desktop/src/desktop-computer-use-api.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-api.test.ts
@@ -39,8 +39,7 @@ describe("createDesktopComputerUseSessionFetch", () => {
             return [{ name: "app_session", value: "app-cookie" }];
           }
           if (
-            filter.url ===
-            "https://api.vm0.ai/api/okou/computer-use/hosts/start"
+            filter.url === "https://api.vm0.ai/api/computer-use/hosts/start"
           ) {
             return [{ name: "api_session", value: "api-cookie" }];
           }
@@ -69,7 +68,7 @@ describe("createDesktopComputerUseSessionFetch", () => {
         return "desktop-token";
       },
     });
-    await sessionFetch("https://api.vm0.ai/api/okou/computer-use/hosts/start", {
+    await sessionFetch("https://api.vm0.ai/api/computer-use/hosts/start", {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -82,7 +81,7 @@ describe("createDesktopComputerUseSessionFetch", () => {
 
     expect(cookieUrls).toStrictEqual([
       "https://app.vm0.ai/",
-      "https://api.vm0.ai/api/okou/computer-use/hosts/start",
+      "https://api.vm0.ai/api/computer-use/hosts/start",
     ]);
     const call = fetchMock.mock.calls[0];
     if (!call) {

--- a/turbo/packages/api-contracts/src/contracts/computer-use.ts
+++ b/turbo/packages/api-contracts/src/contracts/computer-use.ts
@@ -556,7 +556,7 @@ export const computerUseAuditEventListResponseSchema = z.object({
 export const computerUseHostsContract = c.router({
   start: {
     method: "POST",
-    path: "/api/okou/computer-use/hosts/start",
+    path: "/api/computer-use/hosts/start",
     headers: authHeadersSchema,
     body: computerUseRuntimeBodySchema,
     responses: {
@@ -569,7 +569,7 @@ export const computerUseHostsContract = c.router({
   },
   list: {
     method: "GET",
-    path: "/api/okou/computer-use/hosts",
+    path: "/api/computer-use/hosts",
     headers: authHeadersSchema,
     responses: {
       200: computerUseHostListResponseSchema,
@@ -583,7 +583,7 @@ export const computerUseHostsContract = c.router({
 export const computerUseHeartbeatContract = c.router({
   heartbeat: {
     method: "POST",
-    path: "/api/okou/computer-use/heartbeat",
+    path: "/api/computer-use/heartbeat",
     headers: authHeadersSchema,
     body: computerUseRuntimeBodySchema,
     responses: {
@@ -595,7 +595,7 @@ export const computerUseHeartbeatContract = c.router({
   },
   stop: {
     method: "POST",
-    path: "/api/okou/computer-use/host/stop",
+    path: "/api/computer-use/host/stop",
     headers: authHeadersSchema,
     body: computerUseHostStopBodySchema,
     responses: {
@@ -609,7 +609,7 @@ export const computerUseHeartbeatContract = c.router({
 export const computerUseAuthorizationRequestsContract = c.router({
   create: {
     method: "POST",
-    path: "/api/okou/computer-use/authorization-requests",
+    path: "/api/computer-use/authorization-requests",
     headers: authHeadersSchema,
     body: computerUseAuthorizationRequestCreateBodySchema,
     responses: {
@@ -625,7 +625,7 @@ export const computerUseAuthorizationRequestsContract = c.router({
   },
   get: {
     method: "GET",
-    path: "/api/okou/computer-use/authorization-requests/:requestToken",
+    path: "/api/computer-use/authorization-requests/:requestToken",
     headers: authHeadersSchema,
     pathParams: authorizationRequestTokenPathParamsSchema,
     responses: {
@@ -639,7 +639,7 @@ export const computerUseAuthorizationRequestsContract = c.router({
   },
   apply: {
     method: "POST",
-    path: "/api/okou/computer-use/authorization-requests/:requestToken/apply",
+    path: "/api/computer-use/authorization-requests/:requestToken/apply",
     headers: authHeadersSchema,
     pathParams: authorizationRequestTokenPathParamsSchema,
     body: computerUseAuthorizationRequestApplyBodySchema,
@@ -658,7 +658,7 @@ export const computerUseAuthorizationRequestsContract = c.router({
 export const computerUseCommandContract = c.router({
   create: {
     method: "POST",
-    path: "/api/okou/computer-use/commands",
+    path: "/api/computer-use/commands",
     headers: authHeadersSchema,
     body: computerUseCommandCreateBodySchema,
     responses: {
@@ -673,7 +673,7 @@ export const computerUseCommandContract = c.router({
   },
   get: {
     method: "GET",
-    path: "/api/okou/computer-use/commands/:commandId",
+    path: "/api/computer-use/commands/:commandId",
     headers: authHeadersSchema,
     pathParams: commandIdPathParamsSchema,
     responses: {
@@ -686,7 +686,7 @@ export const computerUseCommandContract = c.router({
   },
   getScreenshot: {
     method: "GET",
-    path: "/api/okou/computer-use/commands/:commandId/screenshot",
+    path: "/api/computer-use/commands/:commandId/screenshot",
     headers: authHeadersSchema,
     pathParams: commandIdPathParamsSchema,
     responses: {
@@ -699,7 +699,7 @@ export const computerUseCommandContract = c.router({
   },
   getPluginContent: {
     method: "GET",
-    path: "/api/okou/computer-use/commands/:commandId/plugin-content",
+    path: "/api/computer-use/commands/:commandId/plugin-content",
     headers: authHeadersSchema,
     pathParams: commandIdPathParamsSchema,
     responses: {
@@ -715,7 +715,7 @@ export const computerUseCommandContract = c.router({
 export const computerUseWriteCommandContract = c.router({
   create: {
     method: "POST",
-    path: "/api/okou/computer-use/write-commands",
+    path: "/api/computer-use/write-commands",
     headers: authHeadersSchema,
     body: computerUseWriteCommandCreateBodySchema,
     responses: {
@@ -733,7 +733,7 @@ export const computerUseWriteCommandContract = c.router({
 export const computerUsePluginCommandContract = c.router({
   create: {
     method: "POST",
-    path: "/api/okou/computer-use/plugin-commands",
+    path: "/api/computer-use/plugin-commands",
     headers: authHeadersSchema,
     body: computerUseAnyPluginCallBodySchema,
     responses: {
@@ -751,7 +751,7 @@ export const computerUsePluginCommandContract = c.router({
 export const computerUseHostCommandsContract = c.router({
   next: {
     method: "POST",
-    path: "/api/okou/computer-use/host/commands/next",
+    path: "/api/computer-use/host/commands/next",
     headers: authHeadersSchema,
     body: computerUseHostCommandNextBodySchema,
     responses: {
@@ -762,7 +762,7 @@ export const computerUseHostCommandsContract = c.router({
   },
   complete: {
     method: "POST",
-    path: "/api/okou/computer-use/host/commands/:commandId/complete",
+    path: "/api/computer-use/host/commands/:commandId/complete",
     headers: authHeadersSchema,
     pathParams: commandIdPathParamsSchema,
     body: computerUseHostCommandCompleteBodySchema,
@@ -780,7 +780,7 @@ export const computerUseHostCommandsContract = c.router({
 export const computerUseAuditEventsContract = c.router({
   list: {
     method: "GET",
-    path: "/api/okou/computer-use/audit-events",
+    path: "/api/computer-use/audit-events",
     headers: authHeadersSchema,
     query: z.object({
       limit: z.coerce.number().int().positive().max(200).default(50),


### PR DESCRIPTION
Part of #28278, closes #28466.

Sixteen desktop Computer Use routes drop the `/api/okou` segment: host start and list, heartbeat and stop, the delegated authorization requests, the read/write/plugin command routes, the host command claim and completion, and the audit events. Method, schemas, and handlers are unchanged.

## Compatibility

`apiNamespaceAliasPaths()` returns a neutral path unchanged, so declaring the neutral form removes both branded registrations. Every moved route therefore gains a `MIGRATED_BRANDED_PATHS` row naming its `/api/okou/**` and `/api/zero/**` forms, each key reproducing its path parameter verbatim because the lookup matches `entry.route.path` exactly.

These rows are load-bearing rather than precautionary. This is the highest-traffic branded family in the repository — roughly 716,000 requests over the retained request-log window — and its busiest caller is an installed Desktop build that hardcodes the branded host endpoints in `computer-use-host.ts` and updates on its owner's schedule.

The four rows `LEGACY_ZERO_PATHS` already held for this family (`host/commands/next`, `audit-events`, `heartbeat`, `hosts/start`) stay untouched. The migrated table now serves them, because the contract no longer declares a branded path for the blanket expansion to classify. `apiNamespaceAliasPaths()`, `LEGACY_ZERO_PATHS`, `FINAL_PROVIDER_CONSOLE_PATHS`, and the #28356 blanket expansion and fallback report are all unchanged.

## Fallbacks

- `turbo/apps/api/src/signals/route-entry.ts:MIGRATED_BRANDED_PATHS` — 16 new rows, one per moved route, each naming that route's `/api/okou/**` and `/api/zero/**` form. Each row keeps the route answering on both branded paths after the contract declares the neutral one. Without them the compatibility disappears silently rather than loudly: `apiNamespaceAliasPaths()` returns a neutral path unchanged, so the blanket expansion derives no branded path for a migrated contract, and every released caller gets a 404.
  - **Surfaces and windows:** three apply, and the longest governs.
    - Installed Desktop builds — `apps/desktop/src/computer-use-host.ts` hardcodes the branded host-loop paths, and an installed build updates on its owner's schedule rather than on a deploy: **no window at all**. This is the dominant surface here and the reason these rows are not optional.
    - Old web or app clients — the platform Computer Use views derive their URL from the contract, so a tab holding already-loaded platform code keeps calling the branded path until it navigates or reloads: **~2 days** (`docs/fallback.md` §7).
    - Commit-addressed CLI packages pinned by an execution context's `CLI_PKG_URL` — the context keeps its artifact after a later API deploy, so exposure is the queue lifetime plus claimed execution, bounded by the runner's 2h `JOB_TIMEOUT`: **up to ~2 hours** past the drain. Such a package both embeds the branded contract path and hand-builds the branded screenshot and plugin-content URLs.
  - **Removal condition:** #26701's evidence rules, not any of those clocks. The request log retains about three days, which cannot distinguish a drained caller from a weekly one, and the Desktop surface has no clock to wait out at all. Follow-up: #26701.
  - **Justification:** `docs/fallback.md` §6.1, time-boxed cross-version rollout compatibility. This is the mechanism #28400 added for exactly this migration.

## Callers

Callers we control move with the contracts:

- `apps/desktop/src/computer-use-host.ts` — the five hardcoded host-loop URLs
- `apps/cli/src/lib/api/domains/computer-use.ts` — the screenshot and plugin-content downloads, which build their URL by hand
- The CLI, Desktop, and connector tests that hardcode either form, in both quoting styles

The platform app derives every Computer Use URL from the contract, so it needed no edit and the `no-non-zero-api` allow list is untouched. The `apps/api` tests that request a branded form are left alone on purpose: they exercise the compatibility the table now provides.

## Tests

- Sixteen rows added to `MIGRATED_ROUTE_PATHS` in `migrated-branded-paths.test.ts`, restated literally rather than derived from `apiNamespaceAliasPaths()` or read back from the production table, so a dropped row fails the test instead of changing what it asserts.
- A new executed-request test in the computer-use BDD suite issues a real heartbeat at `/api/computer-use/heartbeat`, `/api/okou/computer-use/heartbeat`, and `/api/zero/computer-use/heartbeat` and asserts all three return the same host — the registration assertions could only imply that.
- Verified the rows are load-bearing: removing the sixteen rows locally fails six tests across `api-namespace-compatibility.test.ts`, `migrated-branded-paths.test.ts`, and the BDD suite.
- `assertUniqueRouteRegistrations` still holds; `pnpm format`, `turbo run lint`, `check-types`, and `knip` pass. Desktop (339), CLI, api-contracts (593), eslint-rules (768), platform computer-use views, and the API namespace/computer-use suites all pass. Two pre-existing local failures (`cli generate image`, `api chat-threads.bdd`) reproduce on a clean checkout of `main` and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
