### PR TITLE
refactor(api): move integrations off the brand namespace

### DIFF
--- a/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
+++ b/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
@@ -4,8 +4,12 @@ import { z } from "zod";
 
 import { createAppWithRoutes } from "../app-factory-core";
 import { ROUTES } from "../signals/route";
+import { feishuConnectRoutes } from "../signals/routes/feishu-connect";
 import { imageRecognitionRoutes } from "../signals/routes/image-recognition";
 import { scrapeRoutes } from "../signals/routes/scrape";
+import { slackConnectRoutes } from "../signals/routes/slack-connect";
+import { strapiIntegrationsRoutes } from "../signals/routes/strapi-integrations";
+import { teamsConnectRoutes } from "../signals/routes/teams-connect";
 import { translationRoutes } from "../signals/routes/translation";
 import { weatherRoutes } from "../signals/routes/weather";
 import { webSearchRoutes } from "../signals/routes/web-search";
@@ -343,6 +347,139 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/zero/runs/:id/telemetry/agent",
   ],
   "/api/runs/queue": ["/api/okou/runs/queue", "/api/zero/runs/queue"],
+  // #28423
+  "/api/integrations/feishu": [
+    "/api/okou/integrations/feishu",
+    "/api/zero/integrations/feishu",
+  ],
+  "/api/integrations/feishu/app-id": [
+    "/api/okou/integrations/feishu/app-id",
+    "/api/zero/integrations/feishu/app-id",
+  ],
+  "/api/integrations/feishu/connect": [
+    "/api/okou/integrations/feishu/connect",
+    "/api/zero/integrations/feishu/connect",
+  ],
+  "/api/integrations/feishu/download-file": [
+    "/api/okou/integrations/feishu/download-file",
+    "/api/zero/integrations/feishu/download-file",
+  ],
+  "/api/integrations/feishu/installations/:installationId": [
+    "/api/okou/integrations/feishu/installations/:installationId",
+    "/api/zero/integrations/feishu/installations/:installationId",
+  ],
+  "/api/integrations/feishu/installations/:installationId/connect": [
+    "/api/okou/integrations/feishu/installations/:installationId/connect",
+    "/api/zero/integrations/feishu/installations/:installationId/connect",
+  ],
+  "/api/integrations/feishu/message": [
+    "/api/okou/integrations/feishu/message",
+    "/api/zero/integrations/feishu/message",
+  ],
+  "/api/integrations/feishu/upload-file/complete": [
+    "/api/okou/integrations/feishu/upload-file/complete",
+    "/api/zero/integrations/feishu/upload-file/complete",
+  ],
+  "/api/integrations/feishu/upload-file/init": [
+    "/api/okou/integrations/feishu/upload-file/init",
+    "/api/zero/integrations/feishu/upload-file/init",
+  ],
+  "/api/integrations/github/upload-file/complete": [
+    "/api/okou/integrations/github/upload-file/complete",
+    "/api/zero/integrations/github/upload-file/complete",
+  ],
+  "/api/integrations/github/upload-file/init": [
+    "/api/okou/integrations/github/upload-file/init",
+    "/api/zero/integrations/github/upload-file/init",
+  ],
+  "/api/integrations/phone/download-file": [
+    "/api/okou/integrations/phone/download-file",
+    "/api/zero/integrations/phone/download-file",
+  ],
+  "/api/integrations/phone/message": [
+    "/api/okou/integrations/phone/message",
+    "/api/zero/integrations/phone/message",
+  ],
+  "/api/integrations/phone/upload-file/complete": [
+    "/api/okou/integrations/phone/upload-file/complete",
+    "/api/zero/integrations/phone/upload-file/complete",
+  ],
+  "/api/integrations/phone/upload-file/init": [
+    "/api/okou/integrations/phone/upload-file/init",
+    "/api/zero/integrations/phone/upload-file/init",
+  ],
+  "/api/integrations/slack": [
+    "/api/okou/integrations/slack",
+    "/api/zero/integrations/slack",
+  ],
+  "/api/integrations/slack/connect": [
+    "/api/okou/integrations/slack/connect",
+    "/api/zero/integrations/slack/connect",
+  ],
+  "/api/integrations/slack/message": [
+    "/api/okou/integrations/slack/message",
+    "/api/zero/integrations/slack/message",
+  ],
+  "/api/integrations/slack/upload-file/complete": [
+    "/api/okou/integrations/slack/upload-file/complete",
+    "/api/zero/integrations/slack/upload-file/complete",
+  ],
+  "/api/integrations/slack/upload-file/init": [
+    "/api/okou/integrations/slack/upload-file/init",
+    "/api/zero/integrations/slack/upload-file/init",
+  ],
+  "/api/integrations/slack/upload-file/materialize": [
+    "/api/okou/integrations/slack/upload-file/materialize",
+    "/api/zero/integrations/slack/upload-file/materialize",
+  ],
+  "/api/integrations/strapi": [
+    "/api/okou/integrations/strapi",
+    "/api/zero/integrations/strapi",
+  ],
+  "/api/integrations/strapi/:integrationId": [
+    "/api/okou/integrations/strapi/:integrationId",
+    "/api/zero/integrations/strapi/:integrationId",
+  ],
+  "/api/integrations/strapi/:integrationId/check-test": [
+    "/api/okou/integrations/strapi/:integrationId/check-test",
+    "/api/zero/integrations/strapi/:integrationId/check-test",
+  ],
+  "/api/integrations/strapi/:integrationId/secret": [
+    "/api/okou/integrations/strapi/:integrationId/secret",
+    "/api/zero/integrations/strapi/:integrationId/secret",
+  ],
+  "/api/integrations/teams/connect": [
+    "/api/okou/integrations/teams/connect",
+    "/api/zero/integrations/teams/connect",
+  ],
+  "/api/integrations/teams/message": [
+    "/api/okou/integrations/teams/message",
+    "/api/zero/integrations/teams/message",
+  ],
+  "/api/integrations/teams/upload-file/complete": [
+    "/api/okou/integrations/teams/upload-file/complete",
+    "/api/zero/integrations/teams/upload-file/complete",
+  ],
+  "/api/integrations/teams/upload-file/init": [
+    "/api/okou/integrations/teams/upload-file/init",
+    "/api/zero/integrations/teams/upload-file/init",
+  ],
+  "/api/integrations/telegram/bots": [
+    "/api/okou/integrations/telegram/bots",
+    "/api/zero/integrations/telegram/bots",
+  ],
+  "/api/integrations/telegram/message": [
+    "/api/okou/integrations/telegram/message",
+    "/api/zero/integrations/telegram/message",
+  ],
+  "/api/integrations/telegram/upload-file/complete": [
+    "/api/okou/integrations/telegram/upload-file/complete",
+    "/api/zero/integrations/telegram/upload-file/complete",
+  ],
+  "/api/integrations/telegram/upload-file/init": [
+    "/api/okou/integrations/telegram/upload-file/init",
+    "/api/zero/integrations/telegram/upload-file/init",
+  ],
 };
 
 function missingBrandedPaths(
@@ -625,6 +762,50 @@ describe("branded paths for migrated neutral routes", () => {
           headers: { "content-type": "application/json" },
           body: "{}",
         });
+        return response.status;
+      }
+
+      const neutral = await statusFor(`/api/${suffix}`);
+      const okou = await statusFor(`/api/okou/${suffix}`);
+      const zero = await statusFor(`/api/zero/${suffix}`);
+
+      expect({ suffix, neutral, okou, zero }).toStrictEqual({
+        suffix,
+        neutral,
+        okou: neutral,
+        zero: neutral,
+      });
+      expect(neutral).not.toBe(404);
+    }
+  });
+
+  // The #28423 twin: the integration control plane, driven through the same
+  // production app factory. The registration assertion above rebuilds the
+  // composition itself and so cannot see how `createAppWithRoutes` wires it —
+  // if `withMigratedBrandedPaths` were dropped from or reordered in that chain,
+  // every branded integration path would 404 here while that assertion still
+  // passed. Requests are unauthenticated, so the status is whatever the auth
+  // layer returns; the point is that all three forms reach the same handler.
+  it("serves the migrated integration paths through the production app factory", async () => {
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+
+    // One GET per contract file this slice moved, written out rather than read
+    // back from `MIGRATED_BRANDED_PATHS`.
+    const families = [
+      { routes: feishuConnectRoutes, suffix: "integrations/feishu" },
+      { routes: feishuConnectRoutes, suffix: "integrations/feishu/app-id" },
+      { routes: slackConnectRoutes, suffix: "integrations/slack/connect" },
+      { routes: teamsConnectRoutes, suffix: "integrations/teams/connect" },
+      { routes: strapiIntegrationsRoutes, suffix: "integrations/strapi" },
+    ];
+
+    for (const { routes, suffix } of families) {
+      const app = createAppWithRoutes({ signal: context.signal, routes });
+
+      async function statusFor(path: string): Promise<number> {
+        const response = await app.request(`${REQUEST_ORIGIN}${path}`);
         return response.status;
       }
 

--- a/turbo/apps/api/src/signals/route-entry.ts
+++ b/turbo/apps/api/src/signals/route-entry.ts
@@ -552,6 +552,157 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/zero/runs/:id/telemetry/agent",
   ],
   "/api/runs/queue": ["/api/okou/runs/queue", "/api/zero/runs/queue"],
+  // #28423: the integration control plane and the CLI messaging and file
+  // surfaces for Feishu, Slack, Microsoft Teams, Telegram, GitHub, AgentPhone,
+  // and Strapi. Two callers hold a branded form independently of the contract:
+  // `downloadFeishuFile` and `downloadPhoneFile` in the CLI build their URL by
+  // hand, so a published package keeps asking for the `okou` path it shipped
+  // with. Every other caller derives its URL from the contract, which a
+  // published CLI package still embeds at the version it was built from, and
+  // the `zero` form was reachable through the blanket expansion until the
+  // contract moved. Both are owed.
+  //
+  // Surfaces: commit-addressed CLI packages pinned by execution contexts
+  // created before this deploy, which drain over the queue lifetime plus
+  // claimed execution bounded by the runner's 2h `JOB_TIMEOUT`, and a released
+  // platform tab holding the branded connect and Strapi paths until it
+  // navigates or reloads (~2 days). Neither window is the removal condition:
+  // these rows retire under #26701's evidence rules like every other row here.
+  //
+  // A key holds its path parameter verbatim, because the lookup below matches
+  // `entry.route.path` exactly rather than an expanded request path.
+  "/api/integrations/feishu": [
+    "/api/okou/integrations/feishu",
+    "/api/zero/integrations/feishu",
+  ],
+  "/api/integrations/feishu/app-id": [
+    "/api/okou/integrations/feishu/app-id",
+    "/api/zero/integrations/feishu/app-id",
+  ],
+  "/api/integrations/feishu/connect": [
+    "/api/okou/integrations/feishu/connect",
+    "/api/zero/integrations/feishu/connect",
+  ],
+  "/api/integrations/feishu/download-file": [
+    "/api/okou/integrations/feishu/download-file",
+    "/api/zero/integrations/feishu/download-file",
+  ],
+  "/api/integrations/feishu/installations/:installationId": [
+    "/api/okou/integrations/feishu/installations/:installationId",
+    "/api/zero/integrations/feishu/installations/:installationId",
+  ],
+  "/api/integrations/feishu/installations/:installationId/connect": [
+    "/api/okou/integrations/feishu/installations/:installationId/connect",
+    "/api/zero/integrations/feishu/installations/:installationId/connect",
+  ],
+  "/api/integrations/feishu/message": [
+    "/api/okou/integrations/feishu/message",
+    "/api/zero/integrations/feishu/message",
+  ],
+  "/api/integrations/feishu/upload-file/complete": [
+    "/api/okou/integrations/feishu/upload-file/complete",
+    "/api/zero/integrations/feishu/upload-file/complete",
+  ],
+  "/api/integrations/feishu/upload-file/init": [
+    "/api/okou/integrations/feishu/upload-file/init",
+    "/api/zero/integrations/feishu/upload-file/init",
+  ],
+  "/api/integrations/github/upload-file/complete": [
+    "/api/okou/integrations/github/upload-file/complete",
+    "/api/zero/integrations/github/upload-file/complete",
+  ],
+  "/api/integrations/github/upload-file/init": [
+    "/api/okou/integrations/github/upload-file/init",
+    "/api/zero/integrations/github/upload-file/init",
+  ],
+  "/api/integrations/phone/download-file": [
+    "/api/okou/integrations/phone/download-file",
+    "/api/zero/integrations/phone/download-file",
+  ],
+  "/api/integrations/phone/message": [
+    "/api/okou/integrations/phone/message",
+    "/api/zero/integrations/phone/message",
+  ],
+  "/api/integrations/phone/upload-file/complete": [
+    "/api/okou/integrations/phone/upload-file/complete",
+    "/api/zero/integrations/phone/upload-file/complete",
+  ],
+  "/api/integrations/phone/upload-file/init": [
+    "/api/okou/integrations/phone/upload-file/init",
+    "/api/zero/integrations/phone/upload-file/init",
+  ],
+  "/api/integrations/slack": [
+    "/api/okou/integrations/slack",
+    "/api/zero/integrations/slack",
+  ],
+  "/api/integrations/slack/connect": [
+    "/api/okou/integrations/slack/connect",
+    "/api/zero/integrations/slack/connect",
+  ],
+  "/api/integrations/slack/message": [
+    "/api/okou/integrations/slack/message",
+    "/api/zero/integrations/slack/message",
+  ],
+  "/api/integrations/slack/upload-file/complete": [
+    "/api/okou/integrations/slack/upload-file/complete",
+    "/api/zero/integrations/slack/upload-file/complete",
+  ],
+  "/api/integrations/slack/upload-file/init": [
+    "/api/okou/integrations/slack/upload-file/init",
+    "/api/zero/integrations/slack/upload-file/init",
+  ],
+  "/api/integrations/slack/upload-file/materialize": [
+    "/api/okou/integrations/slack/upload-file/materialize",
+    "/api/zero/integrations/slack/upload-file/materialize",
+  ],
+  "/api/integrations/strapi": [
+    "/api/okou/integrations/strapi",
+    "/api/zero/integrations/strapi",
+  ],
+  "/api/integrations/strapi/:integrationId": [
+    "/api/okou/integrations/strapi/:integrationId",
+    "/api/zero/integrations/strapi/:integrationId",
+  ],
+  "/api/integrations/strapi/:integrationId/check-test": [
+    "/api/okou/integrations/strapi/:integrationId/check-test",
+    "/api/zero/integrations/strapi/:integrationId/check-test",
+  ],
+  "/api/integrations/strapi/:integrationId/secret": [
+    "/api/okou/integrations/strapi/:integrationId/secret",
+    "/api/zero/integrations/strapi/:integrationId/secret",
+  ],
+  "/api/integrations/teams/connect": [
+    "/api/okou/integrations/teams/connect",
+    "/api/zero/integrations/teams/connect",
+  ],
+  "/api/integrations/teams/message": [
+    "/api/okou/integrations/teams/message",
+    "/api/zero/integrations/teams/message",
+  ],
+  "/api/integrations/teams/upload-file/complete": [
+    "/api/okou/integrations/teams/upload-file/complete",
+    "/api/zero/integrations/teams/upload-file/complete",
+  ],
+  "/api/integrations/teams/upload-file/init": [
+    "/api/okou/integrations/teams/upload-file/init",
+    "/api/zero/integrations/teams/upload-file/init",
+  ],
+  "/api/integrations/telegram/bots": [
+    "/api/okou/integrations/telegram/bots",
+    "/api/zero/integrations/telegram/bots",
+  ],
+  "/api/integrations/telegram/message": [
+    "/api/okou/integrations/telegram/message",
+    "/api/zero/integrations/telegram/message",
+  ],
+  "/api/integrations/telegram/upload-file/complete": [
+    "/api/okou/integrations/telegram/upload-file/complete",
+    "/api/zero/integrations/telegram/upload-file/complete",
+  ],
+  "/api/integrations/telegram/upload-file/init": [
+    "/api/okou/integrations/telegram/upload-file/init",
+    "/api/zero/integrations/telegram/upload-file/init",
+  ],
 };
 
 /**

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-feishu-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-feishu-message.test.ts
@@ -195,7 +195,7 @@ async function connectCurrentFeishuUser(actor: FeishuTestActor): Promise<void> {
   await flushWaitUntilForTest();
 }
 
-describe("POST /api/okou/integrations/feishu/message", () => {
+describe("POST /api/integrations/feishu/message", () => {
   let captured: CapturedRequest[];
 
   beforeEach(() => {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-message.test.ts
@@ -60,7 +60,7 @@ function sandboxToken(args: {
   });
 }
 
-describe("POST /api/okou/integrations/slack/message", () => {
+describe("POST /api/integrations/slack/message", () => {
   beforeEach(() => {
     context.mocks.slack.chat.postMessage.mockResolvedValue({
       ok: true,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-upload-complete.test.ts
@@ -186,7 +186,7 @@ interface RunScopedContext {
   readonly agentId: string;
 }
 
-describe("POST /api/okou/integrations/slack/upload-file/complete", () => {
+describe("POST /api/integrations/slack/upload-file/complete", () => {
   const slackFixtures: SlackIntegrationFixture[] = [];
   const usageFixtures: UsageStateFixture[] = [];
 

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-upload-init.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-upload-init.test.ts
@@ -54,7 +54,7 @@ function sandboxToken(args: {
   });
 }
 
-describe("POST /api/okou/integrations/slack/upload-file/init", () => {
+describe("POST /api/integrations/slack/upload-file/init", () => {
   const slackFixtures: SlackIntegrationFixture[] = [];
 
   beforeEach(() => {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-upload-complete.test.ts
@@ -145,7 +145,7 @@ async function seedSendableContext(): Promise<UploadCompleteFixture> {
   };
 }
 
-describe("POST /api/okou/integrations/telegram/upload-file/complete", () => {
+describe("POST /api/integrations/telegram/upload-file/complete", () => {
   const fixtures: UploadCompleteFixture[] = [];
 
   afterEach(async () => {

--- a/turbo/apps/cli/src/commands/feishu/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/feishu/__tests__/download-file.test.ts
@@ -9,7 +9,7 @@ import { server } from "../../../mocks/server";
 import { downloadFileCommand } from "../download-file";
 
 const DOWNLOAD_URL =
-  "http://localhost:3000/api/okou/integrations/feishu/download-file";
+  "http://localhost:3000/api/integrations/feishu/download-file";
 
 describe("okou feishu download-file command", () => {
   vi.spyOn(process, "exit").mockImplementation((): never => {

--- a/turbo/apps/cli/src/commands/feishu/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/feishu/__tests__/send.test.ts
@@ -6,7 +6,7 @@ import { server } from "../../../mocks/server";
 import { sendCommand } from "../message/send";
 
 const FEISHU_MESSAGE_URL =
-  "http://localhost:3000/api/okou/integrations/feishu/message";
+  "http://localhost:3000/api/integrations/feishu/message";
 
 describe("okou feishu message send command", () => {
   vi.spyOn(process, "exit").mockImplementation((): never => {

--- a/turbo/apps/cli/src/commands/feishu/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/feishu/__tests__/upload-file.test.ts
@@ -10,9 +10,9 @@ import { server } from "../../../mocks/server";
 import { uploadFileCommand } from "../upload-file";
 
 const UPLOAD_INIT_URL =
-  "http://localhost:3000/api/okou/integrations/feishu/upload-file/init";
+  "http://localhost:3000/api/integrations/feishu/upload-file/init";
 const UPLOAD_COMPLETE_URL =
-  "http://localhost:3000/api/okou/integrations/feishu/upload-file/complete";
+  "http://localhost:3000/api/integrations/feishu/upload-file/complete";
 const STORAGE_UPLOAD_URL = "https://storage.test/feishu-upload";
 const FILE_CONTENT = "feishu pdf content";
 

--- a/turbo/apps/cli/src/commands/github/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/github/__tests__/upload-file.test.ts
@@ -8,9 +8,9 @@ import { uploadFileCommand } from "../upload-file";
 import chalk from "chalk";
 
 const UPLOAD_INIT_URL =
-  "http://localhost:3000/api/okou/integrations/github/upload-file/init";
+  "http://localhost:3000/api/integrations/github/upload-file/init";
 const UPLOAD_COMPLETE_URL =
-  "http://localhost:3000/api/okou/integrations/github/upload-file/complete";
+  "http://localhost:3000/api/integrations/github/upload-file/complete";
 const R2_UPLOAD_URL = "https://mock-r2.test/github-upload";
 
 describe("okou github upload-file command", () => {

--- a/turbo/apps/cli/src/commands/phone/__tests__/commands.test.ts
+++ b/turbo/apps/cli/src/commands/phone/__tests__/commands.test.ts
@@ -10,12 +10,12 @@ import { messageCommand } from "../message";
 import { uploadFileCommand } from "../upload-file";
 
 const DOWNLOAD_URL =
-  "http://localhost:3000/api/okou/integrations/phone/download-file";
-const MESSAGE_URL = "http://localhost:3000/api/okou/integrations/phone/message";
+  "http://localhost:3000/api/integrations/phone/download-file";
+const MESSAGE_URL = "http://localhost:3000/api/integrations/phone/message";
 const UPLOAD_INIT_URL =
-  "http://localhost:3000/api/okou/integrations/phone/upload-file/init";
+  "http://localhost:3000/api/integrations/phone/upload-file/init";
 const UPLOAD_COMPLETE_URL =
-  "http://localhost:3000/api/okou/integrations/phone/upload-file/complete";
+  "http://localhost:3000/api/integrations/phone/upload-file/complete";
 const R2_UPLOAD_URL = "https://mock-r2.test/phone-upload";
 
 describe("okou phone commands", () => {

--- a/turbo/apps/cli/src/commands/slack/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/slack/__tests__/send.test.ts
@@ -14,7 +14,7 @@ import { sendCommand } from "../message/send";
 import chalk from "chalk";
 
 const SLACK_MESSAGE_URL =
-  "http://localhost:3000/api/okou/integrations/slack/message";
+  "http://localhost:3000/api/integrations/slack/message";
 
 describe("okou slack message send command", () => {
   vi.spyOn(process, "exit").mockImplementation((() => {

--- a/turbo/apps/cli/src/commands/slack/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/slack/__tests__/upload-file.test.ts
@@ -17,11 +17,11 @@ import { uploadFileCommand } from "../upload-file";
 import chalk from "chalk";
 
 const UPLOAD_INIT_URL =
-  "http://localhost:3000/api/okou/integrations/slack/upload-file/init";
+  "http://localhost:3000/api/integrations/slack/upload-file/init";
 const UPLOAD_COMPLETE_URL =
-  "http://localhost:3000/api/okou/integrations/slack/upload-file/complete";
+  "http://localhost:3000/api/integrations/slack/upload-file/complete";
 const UPLOAD_MATERIALIZE_URL =
-  "http://localhost:3000/api/okou/integrations/slack/upload-file/materialize";
+  "http://localhost:3000/api/integrations/slack/upload-file/materialize";
 const SLACK_PRESIGNED_URL = "https://files.slack.com/upload/v1/test-presigned";
 const CANONICAL_PRESIGNED_URL = "https://r2.example.com/upload/canonical-asset";
 

--- a/turbo/apps/cli/src/commands/teams/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/teams/__tests__/send.test.ts
@@ -9,7 +9,7 @@ import { server } from "../../../mocks/server";
 import { sendCommand } from "../message/send";
 
 const TEAMS_MESSAGE_URL =
-  "http://localhost:3000/api/okou/integrations/teams/message";
+  "http://localhost:3000/api/integrations/teams/message";
 
 describe("okou teams message send command", () => {
   vi.spyOn(process, "exit").mockImplementation((() => {

--- a/turbo/apps/cli/src/commands/teams/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/teams/__tests__/upload-file.test.ts
@@ -11,9 +11,9 @@ import { server } from "../../../mocks/server";
 import { uploadFileCommand } from "../upload-file";
 
 const UPLOAD_INIT_URL =
-  "http://localhost:3000/api/okou/integrations/teams/upload-file/init";
+  "http://localhost:3000/api/integrations/teams/upload-file/init";
 const UPLOAD_COMPLETE_URL =
-  "http://localhost:3000/api/okou/integrations/teams/upload-file/complete";
+  "http://localhost:3000/api/integrations/teams/upload-file/complete";
 const R2_UPLOAD_URL = "https://mock-r2.test/teams-upload";
 
 describe("okou teams upload-file command", () => {

--- a/turbo/apps/cli/src/commands/telegram/__tests__/bot-list.test.ts
+++ b/turbo/apps/cli/src/commands/telegram/__tests__/bot-list.test.ts
@@ -9,7 +9,7 @@ import { listCommand } from "../bot/list";
 import chalk from "chalk";
 
 const TELEGRAM_BOTS_URL =
-  "http://localhost:3000/api/okou/integrations/telegram/bots";
+  "http://localhost:3000/api/integrations/telegram/bots";
 
 describe("okou telegram bot list command", () => {
   vi.spyOn(process, "exit").mockImplementation((() => {

--- a/turbo/apps/cli/src/commands/telegram/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/telegram/__tests__/send.test.ts
@@ -9,7 +9,7 @@ import { sendCommand } from "../message/send";
 import chalk from "chalk";
 
 const TELEGRAM_MESSAGE_URL =
-  "http://localhost:3000/api/okou/integrations/telegram/message";
+  "http://localhost:3000/api/integrations/telegram/message";
 
 describe("okou telegram message send command", () => {
   vi.spyOn(process, "exit").mockImplementation((() => {

--- a/turbo/apps/cli/src/commands/telegram/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/telegram/__tests__/upload-file.test.ts
@@ -12,9 +12,9 @@ import { uploadFileCommand } from "../upload-file";
 import chalk from "chalk";
 
 const UPLOAD_INIT_URL =
-  "http://localhost:3000/api/okou/integrations/telegram/upload-file/init";
+  "http://localhost:3000/api/integrations/telegram/upload-file/init";
 const UPLOAD_COMPLETE_URL =
-  "http://localhost:3000/api/okou/integrations/telegram/upload-file/complete";
+  "http://localhost:3000/api/integrations/telegram/upload-file/complete";
 const R2_UPLOAD_URL = "https://mock-r2.test/telegram-upload";
 
 describe("okou telegram upload-file command", () => {

--- a/turbo/apps/cli/src/lib/api/domains/integrations-feishu.ts
+++ b/turbo/apps/cli/src/lib/api/domains/integrations-feishu.ts
@@ -80,7 +80,7 @@ export async function downloadFeishuFile(
     throw new ApiRequestError("Not authenticated", "UNAUTHORIZED", 401);
   }
 
-  const url = new URL("/api/okou/integrations/feishu/download-file", baseUrl);
+  const url = new URL("/api/integrations/feishu/download-file", baseUrl);
   url.searchParams.set("message_id", messageId);
   url.searchParams.set("file_key", fileKey);
   url.searchParams.set("type", resourceType);

--- a/turbo/apps/cli/src/lib/api/domains/integrations-phone.ts
+++ b/turbo/apps/cli/src/lib/api/domains/integrations-phone.ts
@@ -86,7 +86,7 @@ export async function downloadPhoneFile(
     throw new ApiRequestError("Not authenticated", "UNAUTHORIZED", 401);
   }
 
-  const url = new URL("/api/okou/integrations/phone/download-file", baseUrl);
+  const url = new URL("/api/integrations/phone/download-file", baseUrl);
   url.searchParams.set("file_id", fileId);
 
   const headers: Record<string, string> = {

--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-slack-connect.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-slack-connect.ts
@@ -1,7 +1,7 @@
 /**
  * Slack Connect API Handlers
  *
- * Mock handlers for /api/okou/integrations/slack/connect endpoint.
+ * Mock handlers for /api/integrations/slack/connect endpoint.
  * Default behavior: user is not yet connected.
  */
 
@@ -26,7 +26,7 @@ export function resetMockSlackConnect(): void {
 }
 
 export const apiIntegrationsSlackConnectHandlers = [
-  // GET /api/okou/integrations/slack/connect — check connection status
+  // GET /api/integrations/slack/connect — check connection status
   mockApi(slackConnectContract.getStatus, ({ respond }) => {
     return respond(200, {
       isConnected: mockData.isConnected,
@@ -34,7 +34,7 @@ export const apiIntegrationsSlackConnectHandlers = [
     });
   }),
 
-  // POST /api/okou/integrations/slack/connect — connect account
+  // POST /api/integrations/slack/connect — connect account
   // body ({ workspaceId, slackUserId, channelId?, threadTs? }) is contract-typed
   // but not used for routing — the mock simulates errors via mockData.postError.
   mockApi(slackConnectContract.connect, ({ respond }) => {

--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-slack-org.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-slack-org.ts
@@ -34,12 +34,12 @@ export function resetMockSlackOrgIntegration(): void {
 }
 
 export const apiIntegrationsSlackOrgHandlers = [
-  // GET /api/okou/integrations/slack
+  // GET /api/integrations/slack
   mockApi(integrationsSlackContract.getStatus, ({ respond }) => {
     return respond(200, mockSlackOrgData);
   }),
 
-  // DELETE /api/okou/integrations/slack
+  // DELETE /api/integrations/slack
   mockApi(integrationsSlackContract.disconnect, ({ query, respond }) => {
     if (query.action === "uninstall") {
       mockSlackOrgData = {

--- a/turbo/packages/api-contracts/src/contracts/feishu-connect.ts
+++ b/turbo/packages/api-contracts/src/contracts/feishu-connect.ts
@@ -91,7 +91,7 @@ const feishuConnectStatusSchema = z.object({
 export const feishuConnectContract = c.router({
   getStatus: {
     method: "GET",
-    path: "/api/okou/integrations/feishu",
+    path: "/api/integrations/feishu",
     headers: authHeadersSchema,
     responses: {
       200: feishuConnectStatusSchema,
@@ -102,7 +102,7 @@ export const feishuConnectContract = c.router({
   },
   checkAppId: {
     method: "GET",
-    path: "/api/okou/integrations/feishu/app-id",
+    path: "/api/integrations/feishu/app-id",
     headers: authHeadersSchema,
     query: z.object({
       appId: z.string().trim().min(1),
@@ -117,7 +117,7 @@ export const feishuConnectContract = c.router({
   },
   setup: {
     method: "POST",
-    path: "/api/okou/integrations/feishu",
+    path: "/api/integrations/feishu",
     headers: authHeadersSchema,
     body: z.object({
       appId: z.string().trim().min(1),
@@ -139,7 +139,7 @@ export const feishuConnectContract = c.router({
   },
   updateInstallation: {
     method: "PATCH",
-    path: "/api/okou/integrations/feishu/installations/:installationId",
+    path: "/api/integrations/feishu/installations/:installationId",
     headers: authHeadersSchema,
     pathParams: z.object({ installationId: z.string().uuid() }),
     body: z.object({
@@ -157,7 +157,7 @@ export const feishuConnectContract = c.router({
   },
   removeInstallation: {
     method: "DELETE",
-    path: "/api/okou/integrations/feishu/installations/:installationId",
+    path: "/api/integrations/feishu/installations/:installationId",
     headers: authHeadersSchema,
     pathParams: z.object({ installationId: z.string().uuid() }),
     body: c.noBody(),
@@ -171,7 +171,7 @@ export const feishuConnectContract = c.router({
   },
   disconnectInstallation: {
     method: "DELETE",
-    path: "/api/okou/integrations/feishu/installations/:installationId/connect",
+    path: "/api/integrations/feishu/installations/:installationId/connect",
     headers: authHeadersSchema,
     pathParams: z.object({ installationId: z.string().uuid() }),
     body: c.noBody(),
@@ -185,7 +185,7 @@ export const feishuConnectContract = c.router({
   },
   remove: {
     method: "DELETE",
-    path: "/api/okou/integrations/feishu",
+    path: "/api/integrations/feishu",
     headers: authHeadersSchema,
     body: c.noBody(),
     responses: {
@@ -198,7 +198,7 @@ export const feishuConnectContract = c.router({
   },
   disconnect: {
     method: "DELETE",
-    path: "/api/okou/integrations/feishu/connect",
+    path: "/api/integrations/feishu/connect",
     headers: authHeadersSchema,
     body: c.noBody(),
     responses: {

--- a/turbo/packages/api-contracts/src/contracts/integrations-slack.ts
+++ b/turbo/packages/api-contracts/src/contracts/integrations-slack.ts
@@ -27,13 +27,13 @@ const slackOrgStatusSchema = z.object({
 });
 
 /**
- * Integrations Slack contract (GET/DELETE /api/okou/integrations/slack)
+ * Integrations Slack contract (GET/DELETE /api/integrations/slack)
  * Manages org-scoped Slack workspace info.
  */
 export const integrationsSlackContract = c.router({
   getStatus: {
     method: "GET",
-    path: "/api/okou/integrations/slack",
+    path: "/api/integrations/slack",
     headers: authHeadersSchema,
     responses: {
       200: slackOrgStatusSchema,
@@ -43,7 +43,7 @@ export const integrationsSlackContract = c.router({
   },
   disconnect: {
     method: "DELETE",
-    path: "/api/okou/integrations/slack",
+    path: "/api/integrations/slack",
     headers: authHeadersSchema,
     body: c.noBody(),
     query: z.object({

--- a/turbo/packages/api-contracts/src/contracts/integrations.ts
+++ b/turbo/packages/api-contracts/src/contracts/integrations.ts
@@ -10,7 +10,7 @@ const directUploadResponseShape = {
 
 /**
  * Integration Slack message contract
- * POST /api/okou/integrations/slack/message
+ * POST /api/integrations/slack/message
  *
  * Sends a Slack message via the org's installed bot token.
  * Requires `slack:write` capability (via OKOU_TOKEN).
@@ -45,7 +45,7 @@ export type SendSlackMessageResponse = z.infer<
 export const integrationsSlackMessageContract = c.router({
   sendMessage: {
     method: "POST",
-    path: "/api/okou/integrations/slack/message",
+    path: "/api/integrations/slack/message",
     headers: authHeadersSchema,
     body: sendSlackMessageBodySchema,
     responses: {
@@ -64,7 +64,7 @@ export type IntegrationsSlackMessageContract =
 
 /**
  * Integration Feishu message contract
- * POST /api/okou/integrations/feishu/message
+ * POST /api/integrations/feishu/message
  *
  * Sends a Feishu message via an org-owned custom app.
  * Requires `feishu:write` capability (via OKOU_TOKEN).
@@ -127,7 +127,7 @@ export type SendFeishuMessageResponse = z.infer<
 export const integrationsFeishuMessageContract = c.router({
   sendMessage: {
     method: "POST",
-    path: "/api/okou/integrations/feishu/message",
+    path: "/api/integrations/feishu/message",
     headers: authHeadersSchema,
     body: sendFeishuMessageBodySchema,
     responses: {
@@ -159,7 +159,7 @@ export type FeishuResourceType = z.infer<typeof feishuResourceTypeSchema>;
 export const integrationsFeishuDownloadFileContract = c.router({
   download: {
     method: "GET",
-    path: "/api/okou/integrations/feishu/download-file",
+    path: "/api/integrations/feishu/download-file",
     headers: authHeadersSchema,
     query: z.object({
       installation_id: z.string().uuid().optional(),
@@ -224,7 +224,7 @@ export type FeishuUploadInitResponse = z.infer<
 export const integrationsFeishuUploadInitContract = c.router({
   init: {
     method: "POST",
-    path: "/api/okou/integrations/feishu/upload-file/init",
+    path: "/api/integrations/feishu/upload-file/init",
     headers: authHeadersSchema,
     body: feishuUploadInitBodySchema,
     responses: {
@@ -296,7 +296,7 @@ export type FeishuUploadCompleteResponse = z.infer<
 export const integrationsFeishuUploadCompleteContract = c.router({
   complete: {
     method: "POST",
-    path: "/api/okou/integrations/feishu/upload-file/complete",
+    path: "/api/integrations/feishu/upload-file/complete",
     headers: authHeadersSchema,
     body: feishuUploadCompleteBodySchema,
     responses: {
@@ -314,7 +314,7 @@ export const integrationsFeishuUploadCompleteContract = c.router({
 
 /**
  * Integration Telegram message contract
- * POST /api/okou/integrations/telegram/message
+ * POST /api/integrations/telegram/message
  *
  * Sends a Telegram message via an org-owned bot token.
  * Requires `telegram:write` capability (via OKOU_TOKEN).
@@ -344,7 +344,7 @@ export type SendTelegramMessageResponse = z.infer<
 export const integrationsTelegramMessageContract = c.router({
   sendMessage: {
     method: "POST",
-    path: "/api/okou/integrations/telegram/message",
+    path: "/api/integrations/telegram/message",
     headers: authHeadersSchema,
     body: sendTelegramMessageBodySchema,
     responses: {
@@ -364,7 +364,7 @@ export type IntegrationsTelegramMessageContract =
 
 /**
  * Integration Microsoft Teams message contract
- * POST /api/okou/integrations/teams/message
+ * POST /api/integrations/teams/message
  *
  * Sends a Microsoft Teams message via the org's installed Teams bot.
  * Requires `teams:write` capability (via OKOU_TOKEN).
@@ -429,7 +429,7 @@ export type SendTeamsMessageResponse = z.infer<
 export const integrationsTeamsMessageContract = c.router({
   sendMessage: {
     method: "POST",
-    path: "/api/okou/integrations/teams/message",
+    path: "/api/integrations/teams/message",
     headers: authHeadersSchema,
     body: sendTeamsMessageBodySchema,
     responses: {
@@ -449,7 +449,7 @@ export type IntegrationsTeamsMessageContract =
 
 /**
  * Integration AgentPhone message contract
- * POST /api/okou/integrations/phone/message
+ * POST /api/integrations/phone/message
  *
  * Sends an AgentPhone text message to the connected phone handle.
  * Requires `phone:write` capability (via OKOU_TOKEN).
@@ -479,7 +479,7 @@ export type SendPhoneMessageResponse = z.infer<
 export const integrationsPhoneMessageContract = c.router({
   sendMessage: {
     method: "POST",
-    path: "/api/okou/integrations/phone/message",
+    path: "/api/integrations/phone/message",
     headers: authHeadersSchema,
     body: sendPhoneMessageBodySchema,
     responses: {
@@ -504,7 +504,7 @@ const phoneDownloadFileQuerySchema = z.object({
 export const integrationsPhoneDownloadFileContract = c.router({
   download: {
     method: "GET",
-    path: "/api/okou/integrations/phone/download-file",
+    path: "/api/integrations/phone/download-file",
     headers: authHeadersSchema,
     query: phoneDownloadFileQuerySchema,
     responses: {
@@ -525,7 +525,7 @@ export type IntegrationsPhoneDownloadFileContract =
 
 /**
  * Integration Telegram bot list contract
- * GET /api/okou/integrations/telegram/bots
+ * GET /api/integrations/telegram/bots
  *
  * Lists Telegram bots available in the authenticated user's org.
  * Requires `telegram:read` capability (via OKOU_TOKEN).
@@ -568,7 +568,7 @@ export type ListTelegramBotsResponse = z.infer<
 export const integrationsTelegramBotListContract = c.router({
   listBots: {
     method: "GET",
-    path: "/api/okou/integrations/telegram/bots",
+    path: "/api/integrations/telegram/bots",
     headers: authHeadersSchema,
     responses: {
       200: listTelegramBotsResponseSchema,
@@ -584,7 +584,7 @@ export type IntegrationsTelegramBotListContract =
 
 /**
  * Integration Slack file upload — init contract
- * POST /api/okou/integrations/slack/upload-file/init
+ * POST /api/integrations/slack/upload-file/init
  *
  * Requests a pre-signed upload URL from Slack via the org's bot token.
  * The CLI then uploads the file directly to that URL (no auth needed).
@@ -634,7 +634,7 @@ export type SlackUploadInitResponse = z.infer<
 export const integrationsSlackUploadInitContract = c.router({
   init: {
     method: "POST",
-    path: "/api/okou/integrations/slack/upload-file/init",
+    path: "/api/integrations/slack/upload-file/init",
     headers: authHeadersSchema,
     body: slackUploadInitBodySchema,
     responses: {
@@ -685,7 +685,7 @@ export type SlackUploadMaterializeResponse = z.infer<
 export const integrationsSlackUploadMaterializeContract = c.router({
   materialize: {
     method: "POST",
-    path: "/api/okou/integrations/slack/upload-file/materialize",
+    path: "/api/integrations/slack/upload-file/materialize",
     headers: authHeadersSchema,
     body: slackUploadMaterializeBodySchema,
     responses: {
@@ -701,7 +701,7 @@ export const integrationsSlackUploadMaterializeContract = c.router({
 
 /**
  * Integration Telegram file upload — init contract
- * POST /api/okou/integrations/telegram/upload-file/init
+ * POST /api/integrations/telegram/upload-file/init
  *
  * Requests a pre-signed upload URL for a temporary VM0-hosted file. The CLI
  * uploads the file body directly to R2, then the complete route asks Telegram
@@ -735,7 +735,7 @@ export type TelegramUploadInitResponse = z.infer<
 export const integrationsTelegramUploadInitContract = c.router({
   init: {
     method: "POST",
-    path: "/api/okou/integrations/telegram/upload-file/init",
+    path: "/api/integrations/telegram/upload-file/init",
     headers: authHeadersSchema,
     body: telegramUploadInitBodySchema,
     responses: {
@@ -750,7 +750,7 @@ export const integrationsTelegramUploadInitContract = c.router({
 
 /**
  * Integration Microsoft Teams file upload — init contract
- * POST /api/okou/integrations/teams/upload-file/init
+ * POST /api/integrations/teams/upload-file/init
  *
  * Requests a pre-signed upload URL for a temporary VM0-hosted file. The CLI
  * uploads the file body directly to R2, then the complete route sends a Teams
@@ -782,7 +782,7 @@ export type TeamsUploadInitResponse = z.infer<
 export const integrationsTeamsUploadInitContract = c.router({
   init: {
     method: "POST",
-    path: "/api/okou/integrations/teams/upload-file/init",
+    path: "/api/integrations/teams/upload-file/init",
     headers: authHeadersSchema,
     body: teamsUploadInitBodySchema,
     responses: {
@@ -797,7 +797,7 @@ export const integrationsTeamsUploadInitContract = c.router({
 
 /**
  * Integration Telegram file upload — complete contract
- * POST /api/okou/integrations/telegram/upload-file/complete
+ * POST /api/integrations/telegram/upload-file/complete
  *
  * Sends an uploaded file URL to a Telegram chat via sendDocument using the
  * requested org-owned bot token.
@@ -833,7 +833,7 @@ export type TelegramUploadCompleteResponse = z.infer<
 export const integrationsTelegramUploadCompleteContract = c.router({
   complete: {
     method: "POST",
-    path: "/api/okou/integrations/telegram/upload-file/complete",
+    path: "/api/integrations/telegram/upload-file/complete",
     headers: authHeadersSchema,
     body: telegramUploadCompleteBodySchema,
     responses: {
@@ -850,7 +850,7 @@ export const integrationsTelegramUploadCompleteContract = c.router({
 
 /**
  * Integration Microsoft Teams file upload — complete contract
- * POST /api/okou/integrations/teams/upload-file/complete
+ * POST /api/integrations/teams/upload-file/complete
  *
  * Sends an uploaded file URL to a Microsoft Teams conversation using the org's
  * installed Teams bot.
@@ -884,7 +884,7 @@ export type TeamsUploadCompleteResponse = z.infer<
 export const integrationsTeamsUploadCompleteContract = c.router({
   complete: {
     method: "POST",
-    path: "/api/okou/integrations/teams/upload-file/complete",
+    path: "/api/integrations/teams/upload-file/complete",
     headers: authHeadersSchema,
     body: teamsUploadCompleteBodySchema,
     responses: {
@@ -902,7 +902,7 @@ export const integrationsTeamsUploadCompleteContract = c.router({
 
 /**
  * Integration GitHub file upload — init contract
- * POST /api/okou/integrations/github/upload-file/init
+ * POST /api/integrations/github/upload-file/init
  *
  * Requests a pre-signed upload URL for a temporary VM0-hosted file. The CLI
  * uploads the file body directly to R2, then the complete route posts the file
@@ -934,7 +934,7 @@ export type GithubUploadInitResponse = z.infer<
 export const integrationsGithubUploadInitContract = c.router({
   init: {
     method: "POST",
-    path: "/api/okou/integrations/github/upload-file/init",
+    path: "/api/integrations/github/upload-file/init",
     headers: authHeadersSchema,
     body: githubUploadInitBodySchema,
     responses: {
@@ -952,7 +952,7 @@ export const integrationsGithubUploadInitContract = c.router({
 
 /**
  * Integration GitHub file upload — complete contract
- * POST /api/okou/integrations/github/upload-file/complete
+ * POST /api/integrations/github/upload-file/complete
  *
  * Posts an uploaded file URL to a GitHub issue or pull request comment using
  * the organization GitHub App installation token.
@@ -993,7 +993,7 @@ export type GithubUploadCompleteResponse = z.infer<
 export const integrationsGithubUploadCompleteContract = c.router({
   complete: {
     method: "POST",
-    path: "/api/okou/integrations/github/upload-file/complete",
+    path: "/api/integrations/github/upload-file/complete",
     headers: authHeadersSchema,
     body: githubUploadCompleteBodySchema,
     responses: {
@@ -1011,7 +1011,7 @@ export const integrationsGithubUploadCompleteContract = c.router({
 
 /**
  * Integration AgentPhone file upload — init contract
- * POST /api/okou/integrations/phone/upload-file/init
+ * POST /api/integrations/phone/upload-file/init
  *
  * Requests a pre-signed upload URL for a VM0-hosted file. The CLI uploads the
  * file body directly to R2, then complete sends the public file URL through
@@ -1043,7 +1043,7 @@ export type PhoneUploadInitResponse = z.infer<
 export const integrationsPhoneUploadInitContract = c.router({
   init: {
     method: "POST",
-    path: "/api/okou/integrations/phone/upload-file/init",
+    path: "/api/integrations/phone/upload-file/init",
     headers: authHeadersSchema,
     body: phoneUploadInitBodySchema,
     responses: {
@@ -1058,7 +1058,7 @@ export const integrationsPhoneUploadInitContract = c.router({
 
 /**
  * Integration AgentPhone file upload — complete contract
- * POST /api/okou/integrations/phone/upload-file/complete
+ * POST /api/integrations/phone/upload-file/complete
  *
  * Sends an uploaded file URL to a connected phone handle through AgentPhone.
  * Requires `phone:write` capability (via OKOU_TOKEN).
@@ -1095,7 +1095,7 @@ export type PhoneUploadCompleteResponse = z.infer<
 export const integrationsPhoneUploadCompleteContract = c.router({
   complete: {
     method: "POST",
-    path: "/api/okou/integrations/phone/upload-file/complete",
+    path: "/api/integrations/phone/upload-file/complete",
     headers: authHeadersSchema,
     body: phoneUploadCompleteBodySchema,
     responses: {
@@ -1112,7 +1112,7 @@ export const integrationsPhoneUploadCompleteContract = c.router({
 
 /**
  * Integration Slack file upload — complete contract
- * POST /api/okou/integrations/slack/upload-file/complete
+ * POST /api/integrations/slack/upload-file/complete
  *
  * Finalizes a Slack file upload and shares it to a channel/thread.
  * Requires `slack:write` capability (via OKOU_TOKEN).
@@ -1148,7 +1148,7 @@ export type SlackUploadCompleteResponse = z.infer<
 export const integrationsSlackUploadCompleteContract = c.router({
   complete: {
     method: "POST",
-    path: "/api/okou/integrations/slack/upload-file/complete",
+    path: "/api/integrations/slack/upload-file/complete",
     headers: authHeadersSchema,
     body: slackUploadCompleteBodySchema,
     responses: {

--- a/turbo/packages/api-contracts/src/contracts/slack-connect.ts
+++ b/turbo/packages/api-contracts/src/contracts/slack-connect.ts
@@ -18,13 +18,13 @@ const slackConnectResponseSchema = z.object({
 });
 
 /**
- * Slack connect contract (GET/POST /api/okou/integrations/slack/connect)
+ * Slack connect contract (GET/POST /api/integrations/slack/connect)
  * Manages per-user Slack connection.
  */
 export const slackConnectContract = c.router({
   getStatus: {
     method: "GET",
-    path: "/api/okou/integrations/slack/connect",
+    path: "/api/integrations/slack/connect",
     headers: authHeadersSchema,
     responses: {
       200: slackConnectStatusSchema,
@@ -34,7 +34,7 @@ export const slackConnectContract = c.router({
   },
   connect: {
     method: "POST",
-    path: "/api/okou/integrations/slack/connect",
+    path: "/api/integrations/slack/connect",
     headers: authHeadersSchema,
     body: z.object({
       workspaceId: z.string().min(1),

--- a/turbo/packages/api-contracts/src/contracts/strapi-integrations.ts
+++ b/turbo/packages/api-contracts/src/contracts/strapi-integrations.ts
@@ -30,7 +30,7 @@ const integrationIdParams = z.object({ integrationId: z.string().uuid() });
 export const strapiIntegrationsContract = c.router({
   list: {
     method: "GET",
-    path: "/api/okou/integrations/strapi",
+    path: "/api/integrations/strapi",
     headers: authHeadersSchema,
     responses: {
       200: z.array(strapiIntegrationSchema),
@@ -41,7 +41,7 @@ export const strapiIntegrationsContract = c.router({
   },
   create: {
     method: "POST",
-    path: "/api/okou/integrations/strapi",
+    path: "/api/integrations/strapi",
     headers: authHeadersSchema,
     body: z.object({
       name: z.string().trim().min(1).max(128),
@@ -60,7 +60,7 @@ export const strapiIntegrationsContract = c.router({
   },
   revealSecret: {
     method: "POST",
-    path: "/api/okou/integrations/strapi/:integrationId/secret",
+    path: "/api/integrations/strapi/:integrationId/secret",
     headers: authHeadersSchema,
     pathParams: integrationIdParams,
     body: c.noBody(),
@@ -74,7 +74,7 @@ export const strapiIntegrationsContract = c.router({
   },
   checkTest: {
     method: "POST",
-    path: "/api/okou/integrations/strapi/:integrationId/check-test",
+    path: "/api/integrations/strapi/:integrationId/check-test",
     headers: authHeadersSchema,
     pathParams: integrationIdParams,
     body: c.noBody(),
@@ -91,7 +91,7 @@ export const strapiIntegrationsContract = c.router({
   },
   remove: {
     method: "DELETE",
-    path: "/api/okou/integrations/strapi/:integrationId",
+    path: "/api/integrations/strapi/:integrationId",
     headers: authHeadersSchema,
     pathParams: integrationIdParams,
     body: c.noBody(),

--- a/turbo/packages/api-contracts/src/contracts/teams-connect.ts
+++ b/turbo/packages/api-contracts/src/contracts/teams-connect.ts
@@ -70,7 +70,7 @@ const teamsDisconnectResponseSchema = z.object({
 export const teamsConnectContract = c.router({
   getStatus: {
     method: "GET",
-    path: "/api/okou/integrations/teams/connect",
+    path: "/api/integrations/teams/connect",
     headers: authHeadersSchema,
     responses: {
       200: teamsConnectStatusSchema,
@@ -80,7 +80,7 @@ export const teamsConnectContract = c.router({
   },
   connect: {
     method: "POST",
-    path: "/api/okou/integrations/teams/connect",
+    path: "/api/integrations/teams/connect",
     headers: authHeadersSchema,
     body: teamsConnectBodySchema,
     responses: {
@@ -94,7 +94,7 @@ export const teamsConnectContract = c.router({
   },
   disconnect: {
     method: "DELETE",
-    path: "/api/okou/integrations/teams/connect",
+    path: "/api/integrations/teams/connect",
     headers: authHeadersSchema,
     query: z.object({
       action: z.string().optional(),


### PR DESCRIPTION
Part of #28278, closes #28458.

## What moves

Thirty-three product routes drop the `/api/okou` segment. Method, request/response schemas, and handlers are unchanged.

- **Feishu control plane** (`feishu-connect.ts`) — status, app-id check, setup, installation update/remove, installation disconnect, remove, disconnect
- **Slack control plane** (`integrations-slack.ts`, `slack-connect.ts`) — org status/disconnect, connect status/connect
- **Teams control plane** (`teams-connect.ts`) — connect status/connect/disconnect
- **Strapi integrations** (`strapi-integrations.ts`) — list, create, reveal secret, check-test, remove
- **CLI messaging and file surfaces** (`integrations.ts`) — Feishu/Slack/Teams/Telegram/AgentPhone message, Telegram bot list, Feishu/AgentPhone download-file, and the Feishu/Slack/Teams/Telegram/GitHub/AgentPhone upload-file init/complete (plus Slack materialize)

## Why the table rows are not optional

`apiNamespaceAliasPaths()` returns a neutral path unchanged, so the instant a contract declares the neutral form both `/api/okou/**` and `/api/zero/**` stop being registered and every already-released client 404s. Each moved route therefore gains a `MIGRATED_BRANDED_PATHS` row (`apps/api/src/signals/route-entry.ts`) naming both branded forms, in the same commit as the contract move. Keys keep their `:param` segments verbatim, because the lookup matches `entry.route.path` exactly rather than an expanded request path.

`apiNamespaceAliasPaths()`, `LEGACY_ZERO_PATHS`, `FINAL_PROVIDER_CONSOLE_PATHS`, and the #28356 blanket expansion and fallback report are untouched.

## Fallbacks

- `turbo/apps/api/src/signals/route-entry.ts:MIGRATED_BRANDED_PATHS` — 33 new rows keeping `/api/okou/integrations/**` and `/api/zero/integrations/**` resolving after the contracts declare the neutral path, so a caller built against the branded form does not 404. Surfaces and windows (`docs/fallback.md` §7): **existing runner or sandbox, up to 2h** — a commit-addressed CLI package pinned by an execution context's `CLI_PKG_URL`, draining over the queue lifetime plus claimed execution bounded by the runner's `JOB_TIMEOUT`; and **old web or app client, ~2 days** — a platform tab holding already-loaded code for the Slack, Teams, and Feishu connect paths and the Strapi console. Removal condition: #26701's request-log evidence rules, not either clock — the log retains about three days and cannot tell a drained caller from a weekly one; the longer ~2 day window is the floor, not the trigger. Follow-up: #26701.

## Hardcoded call sites

Only two callers build one of these URLs by hand: `downloadFeishuFile` and `downloadPhoneFile` in the CLI domain clients. They move with the contracts.

The other four `integrations-*` CLI domain clients (`slack`, `teams`, `telegram`, `github`) also hand-build a download-file URL, but those four download routes are **not in this slice** — they are declared inline in `apps/api/src/signals/routes/` rather than in `packages/api-contracts`, and they are not among the thirty-three paths #28458 lists. Their branded literals are deliberately left alone, along with their tests. This is the one place where the issue's "six CLI domain clients" framing over-counts: only two of the six change here.

Everything else (platform signals, CLI commands, MSW test doubles) derives its URL from the contract, so the MSW absolute-origin literals in the CLI command tests move with it. The platform mock-handler comments are updated to match; those files are outside `ccstate/no-non-zero-api`'s scope (global `src/mocks/**` ignore), and no platform source literal names a path in this slice, so the rule's allow list needs no new entries.

## Tests

- `migrated-branded-paths.test.ts` — the thirty-three neutral paths and their two branded forms are **restated literally**, never derived from `apiNamespaceAliasPaths()` or read back from the production table
- New: `serves the migrated integration paths through the production app factory` drives one GET per moved contract file through `createAppWithRoutes`, so dropping or reordering `withMigratedBrandedPaths` in the production chain fails here instead of in production
- Existing route tests that request the `/api/zero/**` form of a moved route are left as-is: they now exercise the new table rows end to end

## Verification

Run locally against a fresh Postgres:

- `pnpm check-types` — 14/14 tasks pass
- `pnpm turbo run lint --filter=api --filter=@okouai/cli --filter=@okouai/api-contracts --filter=@okouai/app` — 0 errors
- `pnpm knip` — clean
- `prettier --check` on every changed file (3.8.1, the lockfile version) — clean
- `apps/api`: `migrated-branded-paths`, `api-namespace-compatibility`, `provider-console-paths` — 27/27 pass
- `apps/cli`: every changed command suite — 76/76 pass
- `@okouai/api-contracts` — 593/593 pass
- Platform Slack/Teams connect and Feishu OAuth callback pages — pass

Some `apps/api` integration suites that poll the runner job queue (`integrations.bdd`, `integrations-telegram-post`, `integrations-slack-upload-complete`, `strapi-integration`, `feishu-integration`, `teams-bot`) fail in this sandbox. They fail identically on `main` with the same counts (23 and 21 failures respectively), so they are environment gaps here, not regressions.

## Rebase note

Nine sibling slices append to the same `MIGRATED_BRANDED_PATHS` block. Conflicts with them are appended rows only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
