### PR TITLE
fix(platform): keep deck import alive across the new-thread navigation

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -3491,7 +3491,7 @@ describe("chat composer templates", () => {
         createdThreadId = body.clientThreadId;
       },
       onSendRequest(body) {
-        sentThreadId = body.clientThreadId;
+        sentThreadId = body.threadId;
         sentPrompt = body.prompt;
       },
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -38,6 +38,8 @@ import {
   tabByText,
   presentationTemplateGridScrollContainer,
   mockActiveTemplateThread,
+  mockAgent,
+  mockOrgModelRoutes,
   trackTemplatePreviewImagePreloads,
   mockImmediateIdleCallback,
   mockUrlObjectMethods,
@@ -3474,6 +3476,64 @@ describe("chat composer templates", () => {
 
     await waitFor(() => {
       expect(sentPrompts).toStrictEqual(["Never mind the deck"]);
+    });
+  });
+
+  it("creates the thread and starts the run when importing from a new chat", async () => {
+    const user = userEvent.setup({ delay: null });
+    let createdThreadId: string | undefined;
+    let sentThreadId: string | undefined;
+    let sentPrompt: string | undefined;
+    mockOrgModelRoutes("claude-fable-5");
+    mockAgent();
+    mockChatLifecycle(context, {
+      onThreadCreate(body) {
+        createdThreadId = body.clientThreadId;
+      },
+      onSendRequest(body) {
+        sentThreadId = body.clientThreadId;
+        sentPrompt = body.prompt;
+      },
+    });
+    context.mocks.upload.success({
+      id: "upload-deck",
+      filename: "brand-system.pptx",
+      contentType:
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      size: 2048,
+      url: "https://cdn.vm7.io/artifacts/test/upload-deck/brand-system.pptx",
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.PresentationTemplates]: true },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Template");
+      }),
+    );
+    const importInput = await waitFor(() => {
+      return screen.getByLabelText("Import your own deck");
+    });
+
+    await user.upload(
+      importInput,
+      new File(["deck"], "brand-system.pptx", {
+        type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      }),
+    );
+
+    // Importing from the new-thread composer creates the thread and then
+    // navigates into it. Both calls have to survive that navigation: a signal
+    // the navigation aborts leaves the user on a thread the server never
+    // recorded, with no run to answer them and nothing on screen saying so.
+    await waitFor(() => {
+      expect(createdThreadId).toBeDefined();
+      expect(sentPrompt).toContain("reusable presentation template");
+      expect(sentThreadId).toBe(createdThreadId);
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4820,6 +4820,12 @@ function IllustrationTemplateGrid({
  * Hands the chosen deck to the composer, which attaches it, sends it, and
  * navigates into the new thread. Importing is the ordinary chat path with the
  * message written for the user, not a separate upload flow.
+ *
+ * The import owns the root signal, like the ordinary send and upload controls:
+ * from the new-thread composer it outlives the page it started on. A page
+ * signal is aborted by the very navigation this send performs, which would kill
+ * the in-flight thread create and the run that follows it, leaving a thread the
+ * user can see but the server never recorded.
  */
 function PptImportCard({
   signals,
@@ -4829,7 +4835,7 @@ function PptImportCard({
   onImported: () => void;
 }) {
   const { t } = useTranslation();
-  const pageSignal = useGet(pageSignal$);
+  const rootSignal = useGet(rootSignal$);
   const importDeck = useSet(importPresentationTemplateDeck$);
   const label = t(($) => {
     return $.artifacts.templates.importDeck;
@@ -4865,7 +4871,7 @@ function PptImportCard({
             }
             onImported();
             detach(
-              importDeck({ signals, file }, pageSignal),
+              importDeck({ signals, file }, rootSignal),
               Reason.DomCallback,
             );
           }}


### PR DESCRIPTION
## Problem

Importing a deck through **Import your own deck** from the *new-thread* composer (`/agents/:agentId/chat`) produces a thread the server never recorded: the page navigates into it, but no thread row and no run exist. The user sees a thread that never replies, and the console shows

```
GET /api/okou/chat-threads/<id>/event-rows?sinceSeqId=0&limit=50  404 (Not Found)
[W][Realtime] ably catch-up failed ApiError: Chat thread not found
```

Confirmed against a real thread id from a reported session: `okou chat messages --thread-id <id>` also returns `404: Chat thread not found`, so the row genuinely does not exist — this is not a transient catch-up race.

## Root cause

`PptImportCard` bound the import to `pageSignal$`. Every other control in the same composer uses `rootSignal$` (ordinary send at `zero-chat-composer.tsx:7402`, attachment upload at `:7226`).

The import reuses the ordinary send path, which for a new thread is `sendNewThread$`:

1. `optimistic-chat-thread-page.ts:620` fires `POST /chat-threads` with the caller's signal and does **not** await it
2. `:663` immediately navigates to `/chats/:threadId`
3. `:648` sends `POST /chat/events` only after the create resolves

`pageSignal$` is the current route's signal (`route.ts:272`), and `loadRoute$` aborts the previous route's controller through `resetRouteSignal$` (`route.ts:102`) — `navigate$` even documents this at `route.ts:205-211`. So the navigation performed by the send aborts the create that is still in flight, and the run request that is sequenced after it never goes out at all.

Nothing surfaces: `detach` swallows `AbortError` (`utils.ts:45-52`). The only trace is the realtime warning plus `notifyRealtimeDegraded$` (`realtime.ts:500`).

## Fix

Own `rootSignal$` in `PptImportCard`, consistent with the ordinary send and upload controls. The import is a message that deliberately takes the user off the current page, so its lifetime belongs to the app, not the page.

## Why CI did not catch it

Both existing import tests set up on `/chats/:threadId` (an existing thread), where sending does not navigate and the page signal is never aborted. Added a regression test that imports from `/agents/:agentId/chat` and asserts the thread create and the run send both complete, with the run carrying the created thread id.

## Notes

Introduced by #28344 / #28362. Importing from an existing thread page was never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)