### PR TITLE
fix(runner): guard connector runtime publications

### DIFF
--- a/crates/runner/src/provider/connector_runtime_sync.rs
+++ b/crates/runner/src/provider/connector_runtime_sync.rs
@@ -52,8 +52,8 @@ use super::api::{ApiClient, ConnectorRuntimeSyncOutcome};
 use crate::error::RunnerError;
 use crate::ids::RunId;
 use crate::proxy::{
-    ConnectorRuntimeFailCloseOutcome, ConnectorRuntimeRegistryTransaction,
-    ConnectorRuntimeRegistryUpdate, CustomConnectorRuntimeRegistryState, ProxyRegistryHandle,
+    ConnectorRuntimeFailCloseOutcome, ConnectorRuntimeRegistryUpdate,
+    CustomConnectorRuntimeRegistryState, ProxyRegistryHandle,
 };
 use crate::types::{
     ConnectorRuntimeSyncBatchResponse, ConnectorRuntimeSyncState, ConnectorRuntimeTarget,
@@ -863,11 +863,10 @@ impl ConnectorRuntimeSyncCore {
             return false;
         };
         if !prepared_publications.is_empty() {
-            let transaction: Result<ConnectorRuntimeRegistryTransaction<'_>, RunnerError> =
-                snapshot
-                    .registry
-                    .connector_runtime_registry_transaction()
-                    .await;
+            let transaction = snapshot
+                .registry
+                .connector_runtime_registry_transaction()
+                .await;
             let (prepared_publications, publication) = match transaction {
                 Ok(transaction) => {
                     // Acquire the registry transaction before active state so notifications can

--- a/crates/runner/src/provider/connector_runtime_sync.rs
+++ b/crates/runner/src/provider/connector_runtime_sync.rs
@@ -10,7 +10,8 @@
 //!
 //! A sync response must contain each requested target exactly once. Valid
 //! builtin policy and custom firewall updates are prepared independently, then
-//! committed through one checked registry transaction. Authoritative custom
+//! committed through one registry transaction that holds their registration
+//! and generations current through the atomic write. Authoritative custom
 //! absence removes only that candidate, while unresolved results retain
 //! last-known-good state and retry. Transport, validation, queue, and registry
 //! publication failures also retain last-known-good state and install a capped,
@@ -51,8 +52,8 @@ use super::api::{ApiClient, ConnectorRuntimeSyncOutcome};
 use crate::error::RunnerError;
 use crate::ids::RunId;
 use crate::proxy::{
-    ConnectorRuntimeFailCloseOutcome, ConnectorRuntimeRegistryUpdate,
-    CustomConnectorRuntimeRegistryState, ProxyRegistryHandle,
+    ConnectorRuntimeFailCloseOutcome, ConnectorRuntimeRegistryTransaction,
+    ConnectorRuntimeRegistryUpdate, CustomConnectorRuntimeRegistryState, ProxyRegistryHandle,
 };
 use crate::types::{
     ConnectorRuntimeSyncBatchResponse, ConnectorRuntimeSyncState, ConnectorRuntimeTarget,
@@ -862,18 +863,56 @@ impl ConnectorRuntimeSyncCore {
             return false;
         };
         if !prepared_publications.is_empty() {
-            let updates = prepared_publications
-                .iter()
-                .map(|publication| publication.update.clone())
-                .collect::<Vec<_>>();
-            let publication = snapshot
-                .registry
-                .apply_connector_runtime_updates_if_run_matches(
-                    &snapshot.source_ip,
-                    &run_id.to_string(),
-                    &updates,
-                )
-                .await;
+            let transaction: Result<ConnectorRuntimeRegistryTransaction<'_>, RunnerError> =
+                snapshot
+                    .registry
+                    .connector_runtime_registry_transaction()
+                    .await;
+            let (prepared_publications, publication) = match transaction {
+                Ok(transaction) => {
+                    // Acquire the registry transaction before active state so notifications can
+                    // advance while the registry lock is contended. Holding both through the
+                    // write orders every commit against generation and registration changes.
+                    let active_runs = self.inner.active_runs.lock().await;
+                    let Some(active) = active_runs.get(&run_id) else {
+                        return false;
+                    };
+                    if &active.cancel != registration_cancel {
+                        return false;
+                    }
+                    let prepared_publications = prepared_publications
+                        .into_iter()
+                        .filter(|publication| {
+                            active
+                                .connectors
+                                .get(&publication.target.target)
+                                .is_some_and(|connector| {
+                                    connector.generation == publication.target.generation
+                                })
+                        })
+                        .collect::<Vec<_>>();
+                    if prepared_publications.is_empty() {
+                        drop(active_runs);
+                        drop(transaction);
+                        (prepared_publications, Ok(Some(Vec::new())))
+                    } else {
+                        let updates = prepared_publications
+                            .iter()
+                            .map(|publication| publication.update.clone())
+                            .collect::<Vec<_>>();
+                        let publication = transaction
+                            .apply_updates_if_run_matches(
+                                &snapshot.source_ip,
+                                &run_id.to_string(),
+                                &updates,
+                            )
+                            .await;
+                        drop(active_runs);
+                        (prepared_publications, publication)
+                    }
+                }
+                Err(error) => (prepared_publications, Err(error)),
+            };
             match publication {
                 Ok(Some(outcomes)) => {
                     for (prepared, published) in prepared_publications.into_iter().zip(outcomes) {
@@ -2469,8 +2508,10 @@ mod tests {
         core: &ConnectorRuntimeSyncCore,
         run_id: RunId,
         connector_slugs: &[&str],
+        update_attempt_tx: Option<tokio::sync::mpsc::UnboundedSender<()>>,
     ) -> (
         tempfile::TempDir,
+        std::path::PathBuf,
         std::path::PathBuf,
         Vec<ConnectorRuntimeTarget>,
     ) {
@@ -2506,6 +2547,11 @@ mod tests {
             .collect::<HashMap<_, _>>();
         let (dir, registry, registry_path) =
             registered_runtime_registry(run_id, &firewalls, &policies).await;
+        let lock_path = dir.path().join("proxy-registry.lock");
+        let registry = match update_attempt_tx {
+            Some(tx) => registry.with_connector_runtime_update_attempt_tx(tx),
+            None => registry,
+        };
         core.register_run(ConnectorRuntimeSyncRegistration {
             run_id,
             source_ip: "10.200.0.2",
@@ -2514,7 +2560,7 @@ mod tests {
             refreshes: None,
         })
         .await;
-        (dir, registry_path, targets)
+        (dir, registry_path, lock_path, targets)
     }
 
     async fn slack_policy(registry_path: &std::path::Path) -> serde_json::Value {
@@ -3426,8 +3472,8 @@ mod tests {
         let server = MockServer::start();
         let (core, _requests) = core_without_worker(&server);
         let run_id = RunId::nil();
-        let (_dir, registry_path, targets) =
-            register_builtin_runtime(&core, run_id, &["slack", "github", "linear"]).await;
+        let (_dir, registry_path, _lock_path, targets) =
+            register_builtin_runtime(&core, run_id, &["slack", "github", "linear"], None).await;
         let unexpected_target = builtin_target("notion");
         let runtime_sync = server.mock(|when, then| {
             when.method(POST)
@@ -3527,8 +3573,8 @@ mod tests {
         let server = MockServer::start();
         let (core, _requests) = core_without_worker(&server);
         let run_id = RunId::nil();
-        let (_dir, registry_path, targets) =
-            register_builtin_runtime(&core, run_id, &["slack", "github"]).await;
+        let (_dir, registry_path, _lock_path, targets) =
+            register_builtin_runtime(&core, run_id, &["slack", "github"], None).await;
         let stale_batch = targets
             .iter()
             .cloned()
@@ -3576,6 +3622,103 @@ mod tests {
             registry_json["vms"]["10.200.0.2"]["networkPolicies"]["github"]["allow"],
             json!(["issues:write"])
         );
+        core.unregister_run(run_id).await;
+    }
+
+    #[tokio::test]
+    async fn batch_drops_target_superseded_while_registry_transaction_waits() {
+        let server = MockServer::start();
+        let (core, mut requests) = core_without_worker(&server);
+        let run_id = RunId::nil();
+        let (update_attempt_tx, mut update_attempt_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_dir, registry_path, lock_path, targets) =
+            register_builtin_runtime(&core, run_id, &["slack", "github"], Some(update_attempt_tx))
+                .await;
+        let old_batch = targets
+            .iter()
+            .cloned()
+            .map(|target| ConnectorSyncTarget {
+                target,
+                generation: 0,
+            })
+            .collect::<Vec<_>>();
+        let runtime_sync = server.mock(|when, then| {
+            when.method(POST)
+                .path(format!("/api/runners/runs/{run_id}/connector-runtime/sync"))
+                .json_body(json!({ "targets": targets }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "results": [
+                        {
+                            "target": targets[0],
+                            "state": "available",
+                            "networkPolicy": {
+                                "allow": ["stale:write"],
+                                "deny": [],
+                                "ask": [],
+                                "unknownPolicy": "allow",
+                            },
+                        },
+                        {
+                            "target": targets[1],
+                            "state": "available",
+                            "networkPolicy": {
+                                "allow": ["current:write"],
+                                "deny": [],
+                                "ask": [],
+                                "unknownPolicy": "deny",
+                            },
+                        },
+                    ],
+                }));
+        });
+        let registry_guard = crate::lock::acquire(lock_path)
+            .await
+            .expect("registry lock should be acquired");
+        let sync_task = tokio::spawn({
+            let core = core.clone();
+            async move {
+                core.sync_connector_runtime_batch_now(run_id, &old_batch)
+                    .await
+            }
+        });
+
+        tokio::time::timeout(SYNC_PUBLICATION_TEST_TIMEOUT, update_attempt_rx.recv())
+            .await
+            .expect("old publication should reach the registry transaction before timeout")
+            .expect("old publication should attempt the registry transaction");
+        core.notify_connector_runtime_sync(run_id, targets[0].clone())
+            .await;
+        drop(registry_guard);
+
+        assert!(
+            sync_task
+                .await
+                .expect("old connector runtime sync task should finish")
+        );
+        runtime_sync.assert_calls(1);
+        let newer_request = recv_sync_request(&mut requests).await;
+        assert_eq!(
+            newer_request.targets,
+            vec![ConnectorSyncTarget {
+                target: targets[0].clone(),
+                generation: 1,
+            }]
+        );
+        let registry_json: serde_json::Value = serde_json::from_str(
+            &tokio::fs::read_to_string(registry_path)
+                .await
+                .expect("registry should be readable"),
+        )
+        .expect("registry should be valid JSON");
+        let policies = &registry_json["vms"]["10.200.0.2"]["networkPolicies"];
+        assert_eq!(policies["slack"]["allow"], json!(["last-known-good"]));
+        assert_eq!(policies["github"]["allow"], json!(["current:write"]));
+        let active_runs = core.inner.active_runs.lock().await;
+        assert_eq!(active_runs[&run_id].connectors[&targets[0]].generation, 1);
+        assert_eq!(active_runs[&run_id].connectors[&targets[1]].generation, 0);
+        drop(active_runs);
         core.unregister_run(run_id).await;
     }
 

--- a/crates/runner/src/proxy/mod.rs
+++ b/crates/runner/src/proxy/mod.rs
@@ -67,7 +67,7 @@ pub use flush::{
 pub(crate) use managed_process::ManagedMitmdump;
 pub use process::{MitmProxy, ProxyConfig};
 pub(crate) use registry::{
-    ConnectorRuntimeFailCloseOutcome, ConnectorRuntimeRegistryTransaction,
-    ConnectorRuntimeRegistryUpdate, CustomConnectorRuntimeRegistryState,
+    ConnectorRuntimeFailCloseOutcome, ConnectorRuntimeRegistryUpdate,
+    CustomConnectorRuntimeRegistryState,
 };
 pub use registry::{ProxyRegistryHandle, VmRegistration};

--- a/crates/runner/src/proxy/mod.rs
+++ b/crates/runner/src/proxy/mod.rs
@@ -67,7 +67,7 @@ pub use flush::{
 pub(crate) use managed_process::ManagedMitmdump;
 pub use process::{MitmProxy, ProxyConfig};
 pub(crate) use registry::{
-    ConnectorRuntimeFailCloseOutcome, ConnectorRuntimeRegistryUpdate,
-    CustomConnectorRuntimeRegistryState,
+    ConnectorRuntimeFailCloseOutcome, ConnectorRuntimeRegistryTransaction,
+    ConnectorRuntimeRegistryUpdate, CustomConnectorRuntimeRegistryState,
 };
 pub use registry::{ProxyRegistryHandle, VmRegistration};

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -188,6 +188,8 @@ impl MitmProxy {
         ProxyRegistryHandle {
             registry_path: self.config.registry_path.clone(),
             lock_path: self.config.registry_lock_path.clone(),
+            #[cfg(test)]
+            connector_runtime_update_attempt_tx: None,
         }
     }
 

--- a/crates/runner/src/proxy/registry.rs
+++ b/crates/runner/src/proxy/registry.rs
@@ -1,8 +1,10 @@
 //! Proxy registry schema and file persistence.
 //!
 use std::collections::{HashMap, HashSet};
+use std::fs::File;
 use std::path::{Path, PathBuf};
 
+use nix::fcntl::Flock;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
@@ -156,6 +158,13 @@ fn fail_closed_capacity_bytes(value: &ProxyRegistry) -> RunnerResult<u64> {
 pub struct ProxyRegistryHandle {
     pub(super) registry_path: PathBuf,
     pub(super) lock_path: PathBuf,
+    #[cfg(test)]
+    pub(super) connector_runtime_update_attempt_tx: Option<tokio::sync::mpsc::UnboundedSender<()>>,
+}
+
+pub(crate) struct ConnectorRuntimeRegistryTransaction<'a> {
+    registry_path: &'a Path,
+    _guard: Flock<File>,
 }
 
 #[derive(Clone)]
@@ -557,7 +566,17 @@ impl ProxyRegistryHandle {
         Self {
             registry_path,
             lock_path,
+            connector_runtime_update_attempt_tx: None,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_connector_runtime_update_attempt_tx(
+        mut self,
+        tx: tokio::sync::mpsc::UnboundedSender<()>,
+    ) -> Self {
+        self.connector_runtime_update_attempt_tx = Some(tx);
+        self
     }
 
     /// Register a VM in the proxy registry.
@@ -631,52 +650,32 @@ impl ProxyRegistryHandle {
     /// run; otherwise each boolean reports whether the same-index update was
     /// accepted. Accepted batches persist only when the resulting VM state
     /// changes.
+    #[cfg(test)]
     pub(crate) async fn apply_connector_runtime_updates_if_run_matches(
         &self,
         source_ip: &str,
         run_id: &str,
         updates: &[ConnectorRuntimeRegistryUpdate],
     ) -> RunnerResult<Option<Vec<bool>>> {
-        let _guard = lock::acquire(self.lock_path.clone()).await?;
-        let mut registry = read_registry(&self.registry_path).await?;
-        let Some(vm) = registry.vms.get_mut(source_ip) else {
-            return Ok(None);
-        };
-        if vm.run_id != run_id {
-            return Ok(None);
-        }
+        self.connector_runtime_registry_transaction()
+            .await?
+            .apply_updates_if_run_matches(source_ip, run_id, updates)
+            .await
+    }
 
-        // Keep this snapshot aligned with every VM field mutated by
-        // `apply_connector_runtime_update`.
-        let previous_firewalls = vm.firewalls.clone();
-        let previous_network_policies = vm.network_policies.clone();
-        let previous_omitted_custom_connector_ids = vm.omitted_custom_connector_ids.clone();
-        let previous_connector_routing_variables = vm.connector_routing_variables.clone();
-        let accepted = updates
-            .iter()
-            .map(|update| apply_connector_runtime_update(vm, update))
-            .collect::<RunnerResult<Vec<_>>>()?;
-        if !accepted.iter().any(|accepted| *accepted) {
-            return Ok(Some(accepted));
+    pub(crate) async fn connector_runtime_registry_transaction(
+        &self,
+    ) -> RunnerResult<ConnectorRuntimeRegistryTransaction<'_>> {
+        #[cfg(test)]
+        if let Some(tx) = &self.connector_runtime_update_attempt_tx {
+            tx.send(())
+                .expect("connector runtime update observer should remain available");
         }
-
-        validate_custom_connector_resource_ownership(vm.firewalls.as_deref().unwrap_or_default())?;
-        if previous_firewalls == vm.firewalls
-            && previous_network_policies == vm.network_policies
-            && previous_omitted_custom_connector_ids == vm.omitted_custom_connector_ids
-            && previous_connector_routing_variables == vm.connector_routing_variables
-        {
-            return Ok(Some(accepted));
-        }
-        registry.updated_at = chrono::Utc::now().timestamp_millis();
-        write_registry(&self.registry_path, &registry).await?;
-        info!(
-            source_ip,
-            run_id,
-            update_count = updates.len(),
-            "applied connector runtime updates to proxy registry"
-        );
-        Ok(Some(accepted))
+        let guard = lock::acquire(self.lock_path.clone()).await?;
+        Ok(ConnectorRuntimeRegistryTransaction {
+            registry_path: &self.registry_path,
+            _guard: guard,
+        })
     }
 
     #[cfg(test)]
@@ -779,6 +778,55 @@ impl ProxyRegistryHandle {
             "failed closed connector runtime targets in proxy registry"
         );
         Ok(Some(outcomes))
+    }
+}
+
+impl ConnectorRuntimeRegistryTransaction<'_> {
+    pub(crate) async fn apply_updates_if_run_matches(
+        self,
+        source_ip: &str,
+        run_id: &str,
+        updates: &[ConnectorRuntimeRegistryUpdate],
+    ) -> RunnerResult<Option<Vec<bool>>> {
+        let mut registry = read_registry(self.registry_path).await?;
+        let Some(vm) = registry.vms.get_mut(source_ip) else {
+            return Ok(None);
+        };
+        if vm.run_id != run_id {
+            return Ok(None);
+        }
+
+        // Keep this snapshot aligned with every VM field mutated by
+        // `apply_connector_runtime_update`.
+        let previous_firewalls = vm.firewalls.clone();
+        let previous_network_policies = vm.network_policies.clone();
+        let previous_omitted_custom_connector_ids = vm.omitted_custom_connector_ids.clone();
+        let previous_connector_routing_variables = vm.connector_routing_variables.clone();
+        let accepted = updates
+            .iter()
+            .map(|update| apply_connector_runtime_update(vm, update))
+            .collect::<RunnerResult<Vec<_>>>()?;
+        if !accepted.iter().any(|accepted| *accepted) {
+            return Ok(Some(accepted));
+        }
+
+        validate_custom_connector_resource_ownership(vm.firewalls.as_deref().unwrap_or_default())?;
+        if previous_firewalls == vm.firewalls
+            && previous_network_policies == vm.network_policies
+            && previous_omitted_custom_connector_ids == vm.omitted_custom_connector_ids
+            && previous_connector_routing_variables == vm.connector_routing_variables
+        {
+            return Ok(Some(accepted));
+        }
+        registry.updated_at = chrono::Utc::now().timestamp_millis();
+        write_registry(self.registry_path, &registry).await?;
+        info!(
+            source_ip,
+            run_id,
+            update_count = updates.len(),
+            "applied connector runtime updates to proxy registry"
+        );
+        Ok(Some(accepted))
     }
 }
 


### PR DESCRIPTION
## Summary

- split connector runtime registry publication into an explicit locked transaction
- revalidate registration and target generations after registry-lock acquisition and hold currentness through the atomic write
- omit targets superseded during lock contention while still publishing current siblings from the same batch
- add a deterministic real-registry/flock regression that preserves last-known-good state and the newer queued generation

## Compatibility and scope

- preserves existing source IP/run ownership checks, per-update outcomes, retries, idempotent writes, and completion scheduling
- does not change APIs, queue payloads, runner protocols, the persisted registry schema, or the Python addon
- does not add per-run publication fences; the existing state mutex is held only during post-contention registry I/O

## Validation

- `cargo fmt --check`
- `cargo test -p runner provider::connector_runtime_sync::tests` (49 passed)
- `cargo clippy -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --no-deps`
- `cargo test -p runner` (3221 passed, 20 existing ignored; integration test 1 passed)
- repository pre-commit Rust format, documentation, Clippy, file-size, and commit-message hooks

Closes #28467
