### PR TITLE
perf(runner): reduce workspace cache path allocations

### DIFF
--- a/crates/runner/src/workspace_image_cache/entry.rs
+++ b/crates/runner/src/workspace_image_cache/entry.rs
@@ -48,18 +48,8 @@ impl CacheEntryPaths {
         entry_dir
     }
 
-    fn metadata_for(cache_dir: &Path, cache_key: &str) -> PathBuf {
-        Self::child_path(
-            Self::entry_dir_for(cache_dir, cache_key),
-            METADATA_FILE_NAME,
-        )
-    }
-
-    fn current_image_for(cache_dir: &Path, cache_key: &str) -> PathBuf {
-        Self::child_path(
-            Self::entry_dir_for(cache_dir, cache_key),
-            CURRENT_IMAGE_FILE_NAME,
-        )
+    fn child_for(cache_dir: &Path, cache_key: &str, file_name: &str) -> PathBuf {
+        Self::child_path(Self::entry_dir_for(cache_dir, cache_key), file_name)
     }
 
     fn temporary_path(entry_dir: PathBuf, file_name: &str, run_id: RunId) -> PathBuf {
@@ -117,11 +107,19 @@ impl WorkspaceImageCache {
     }
 
     pub(super) fn workspace_image_cache_metadata(&self, cache_key: &str) -> PathBuf {
-        CacheEntryPaths::metadata_for(self.workspace_image_cache_dir(), cache_key)
+        CacheEntryPaths::child_for(
+            self.workspace_image_cache_dir(),
+            cache_key,
+            METADATA_FILE_NAME,
+        )
     }
 
     pub(super) fn workspace_image_cache_current_image(&self, cache_key: &str) -> PathBuf {
-        CacheEntryPaths::current_image_for(self.workspace_image_cache_dir(), cache_key)
+        CacheEntryPaths::child_for(
+            self.workspace_image_cache_dir(),
+            cache_key,
+            CURRENT_IMAGE_FILE_NAME,
+        )
     }
 
     pub(super) fn workspace_image_cache_tmp_sidecar(

--- a/crates/runner/src/workspace_image_cache/entry.rs
+++ b/crates/runner/src/workspace_image_cache/entry.rs
@@ -9,6 +9,11 @@ use crate::paths::{
 use super::WorkspaceImageCache;
 use super::metadata::WorkspaceCacheMetadata;
 
+const METADATA_FILE_NAME: &str = "metadata.json";
+const CURRENT_IMAGE_FILE_NAME: &str = "current.ext4";
+const SESSION_HISTORY_SIDECAR_FILE_NAME: &str = "session-history.blob";
+const SESSION_HISTORY_SIDECAR_METADATA_FILE_NAME: &str = "session-history.metadata.json";
+
 #[derive(Clone, Debug)]
 pub(crate) struct CacheEntryPaths {
     entry_dir: PathBuf,
@@ -19,13 +24,50 @@ pub(crate) struct CacheEntryPaths {
 
 impl CacheEntryPaths {
     pub(crate) fn new(cache_dir: &Path, cache_key: &str) -> Self {
-        let entry_dir = cache_dir.join(cache_key);
+        Self::from_entry_dir(Self::entry_dir_for(cache_dir, cache_key))
+    }
+
+    pub(super) fn from_entry_dir(entry_dir: PathBuf) -> Self {
         Self {
-            metadata: entry_dir.join("metadata.json"),
-            current_image: entry_dir.join("current.ext4"),
-            session_history_sidecar_metadata: entry_dir.join("session-history.metadata.json"),
+            metadata: entry_dir.join(METADATA_FILE_NAME),
+            current_image: entry_dir.join(CURRENT_IMAGE_FILE_NAME),
+            session_history_sidecar_metadata: entry_dir
+                .join(SESSION_HISTORY_SIDECAR_METADATA_FILE_NAME),
             entry_dir,
         }
+    }
+
+    fn entry_dir_for(cache_dir: &Path, cache_key: &str) -> PathBuf {
+        let mut entry_dir = cache_dir.to_path_buf();
+        entry_dir.push(cache_key);
+        entry_dir
+    }
+
+    fn child_path(mut entry_dir: PathBuf, file_name: &str) -> PathBuf {
+        entry_dir.push(file_name);
+        entry_dir
+    }
+
+    fn metadata_for(cache_dir: &Path, cache_key: &str) -> PathBuf {
+        Self::child_path(
+            Self::entry_dir_for(cache_dir, cache_key),
+            METADATA_FILE_NAME,
+        )
+    }
+
+    fn current_image_for(cache_dir: &Path, cache_key: &str) -> PathBuf {
+        Self::child_path(
+            Self::entry_dir_for(cache_dir, cache_key),
+            CURRENT_IMAGE_FILE_NAME,
+        )
+    }
+
+    fn temporary_path(entry_dir: PathBuf, file_name: &str, run_id: RunId) -> PathBuf {
+        Self::child_path(entry_dir, &format!("{file_name}.tmp.{run_id}"))
+    }
+
+    fn temporary_for(cache_dir: &Path, cache_key: &str, file_name: &str, run_id: RunId) -> PathBuf {
+        Self::temporary_path(Self::entry_dir_for(cache_dir, cache_key), file_name, run_id)
     }
 
     pub(super) fn lock_path(lock_dir: &Path, cache_key: &str) -> PathBuf {
@@ -49,21 +91,19 @@ impl CacheEntryPaths {
     }
 
     pub(crate) fn tmp_image(&self, run_id: RunId) -> PathBuf {
-        self.entry_dir.join(format!("current.ext4.tmp.{run_id}"))
+        Self::temporary_path(self.entry_dir.clone(), CURRENT_IMAGE_FILE_NAME, run_id)
     }
 
     pub(crate) fn tmp_metadata(&self, run_id: RunId) -> PathBuf {
-        self.entry_dir.join(format!("metadata.json.tmp.{run_id}"))
-    }
-
-    pub(super) fn tmp_session_history_sidecar(&self, run_id: RunId) -> PathBuf {
-        self.entry_dir
-            .join(format!("session-history.blob.tmp.{run_id}"))
+        Self::temporary_path(self.entry_dir.clone(), METADATA_FILE_NAME, run_id)
     }
 
     pub(super) fn tmp_session_history_sidecar_metadata(&self, run_id: RunId) -> PathBuf {
-        self.entry_dir
-            .join(format!("session-history.metadata.json.tmp.{run_id}"))
+        Self::temporary_path(
+            self.entry_dir.clone(),
+            SESSION_HISTORY_SIDECAR_METADATA_FILE_NAME,
+            run_id,
+        )
     }
 }
 
@@ -77,23 +117,15 @@ impl WorkspaceImageCache {
     }
 
     pub(super) fn workspace_image_cache_entry_dir(&self, cache_key: &str) -> PathBuf {
-        self.entry_paths(cache_key).entry_dir().to_path_buf()
+        CacheEntryPaths::entry_dir_for(self.workspace_image_cache_dir(), cache_key)
     }
 
     pub(super) fn workspace_image_cache_metadata(&self, cache_key: &str) -> PathBuf {
-        self.entry_paths(cache_key).metadata().to_path_buf()
+        CacheEntryPaths::metadata_for(self.workspace_image_cache_dir(), cache_key)
     }
 
     pub(super) fn workspace_image_cache_current_image(&self, cache_key: &str) -> PathBuf {
-        self.entry_paths(cache_key).current_image().to_path_buf()
-    }
-
-    pub(super) fn workspace_image_cache_tmp_image(
-        &self,
-        cache_key: &str,
-        run_id: RunId,
-    ) -> PathBuf {
-        self.entry_paths(cache_key).tmp_image(run_id)
+        CacheEntryPaths::current_image_for(self.workspace_image_cache_dir(), cache_key)
     }
 
     pub(super) fn workspace_image_cache_tmp_sidecar(
@@ -101,17 +133,12 @@ impl WorkspaceImageCache {
         cache_key: &str,
         run_id: RunId,
     ) -> PathBuf {
-        self.entry_paths(cache_key)
-            .tmp_session_history_sidecar(run_id)
-    }
-
-    pub(super) fn workspace_image_cache_tmp_sidecar_metadata(
-        &self,
-        cache_key: &str,
-        run_id: RunId,
-    ) -> PathBuf {
-        self.entry_paths(cache_key)
-            .tmp_session_history_sidecar_metadata(run_id)
+        CacheEntryPaths::temporary_for(
+            self.workspace_image_cache_dir(),
+            cache_key,
+            SESSION_HISTORY_SIDECAR_FILE_NAME,
+            run_id,
+        )
     }
 
     pub(super) fn scoped_cache_key(

--- a/crates/runner/src/workspace_image_cache/entry.rs
+++ b/crates/runner/src/workspace_image_cache/entry.rs
@@ -66,10 +66,6 @@ impl CacheEntryPaths {
         Self::child_path(entry_dir, &format!("{file_name}.tmp.{run_id}"))
     }
 
-    fn temporary_for(cache_dir: &Path, cache_key: &str, file_name: &str, run_id: RunId) -> PathBuf {
-        Self::temporary_path(Self::entry_dir_for(cache_dir, cache_key), file_name, run_id)
-    }
-
     pub(super) fn lock_path(lock_dir: &Path, cache_key: &str) -> PathBuf {
         workspace_image_cache_lock_path(lock_dir, cache_key)
     }
@@ -133,9 +129,8 @@ impl WorkspaceImageCache {
         cache_key: &str,
         run_id: RunId,
     ) -> PathBuf {
-        CacheEntryPaths::temporary_for(
-            self.workspace_image_cache_dir(),
-            cache_key,
+        CacheEntryPaths::temporary_path(
+            CacheEntryPaths::entry_dir_for(self.workspace_image_cache_dir(), cache_key),
             SESSION_HISTORY_SIDECAR_FILE_NAME,
             run_id,
         )

--- a/crates/runner/src/workspace_image_cache/gc.rs
+++ b/crates/runner/src/workspace_image_cache/gc.rs
@@ -1,7 +1,6 @@
 use std::fs::File;
 use std::io::Write;
 use std::os::unix::fs::MetadataExt;
-use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
 use nix::fcntl::Flock;
@@ -11,7 +10,7 @@ use tracing::{info, warn};
 use crate::error::{RunnerError, RunnerResult};
 use crate::types::MAX_HELD_WORKSPACE_STATES;
 
-use super::entry::is_cache_key_name;
+use super::entry::{CacheEntryPaths, is_cache_key_name};
 use super::fs::{
     allocated_bytes, cache_entry_dir_is_dir, entry_file_type_is_dir,
     fs_stats_with_additional_available, is_workspace_tmp_path_name,
@@ -34,7 +33,7 @@ pub(super) struct GcCandidate {
 
 struct GcCacheEntry {
     cache_key: String,
-    entry_dir: PathBuf,
+    paths: CacheEntryPaths,
 }
 
 #[derive(Default)]
@@ -210,7 +209,7 @@ impl WorkspaceImageCache {
                     result?
                 }
                 None => GcEntryInventory {
-                    candidate: self.gc_candidate(entry.cache_key.clone()).await,
+                    candidate: self.gc_candidate_for_entry(&entry).await,
                     ..GcEntryInventory::default()
                 },
             };
@@ -229,8 +228,8 @@ impl WorkspaceImageCache {
         entry: &GcCacheEntry,
         dry_run: bool,
     ) -> RunnerResult<GcEntryInventory> {
-        let current = self.workspace_image_cache_current_image(&entry.cache_key);
-        let current_metadata = match fs::symlink_metadata(&current).await {
+        let current = entry.paths.current_image();
+        let current_metadata = match fs::symlink_metadata(current).await {
             Ok(metadata) => metadata,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 return self
@@ -239,8 +238,8 @@ impl WorkspaceImageCache {
             }
             Err(e) => return Err(e.into()),
         };
-        let metadata_path = self.workspace_image_cache_metadata(&entry.cache_key);
-        let metadata = match self.read_metadata_file(&metadata_path).await {
+        let metadata_path = entry.paths.metadata();
+        let metadata = match self.read_metadata_file(metadata_path).await {
             Ok(metadata) => metadata,
             Err(RunnerError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
                 return self
@@ -282,6 +281,7 @@ impl WorkspaceImageCache {
         let candidate = self
             .gc_candidate_from_observation(
                 entry.cache_key.clone(),
+                &entry.paths,
                 current_metadata,
                 metadata.last_used_at,
             )
@@ -298,7 +298,7 @@ impl WorkspaceImageCache {
         dry_run: bool,
         reason: GcWholeEntryReason,
     ) -> RunnerResult<GcEntryInventory> {
-        let allocated = workspace_cache_path_allocated_bytes(&entry.entry_dir).await;
+        let allocated = workspace_cache_path_allocated_bytes(entry.paths.entry_dir()).await;
         if dry_run {
             match &reason {
                 GcWholeEntryReason::Stale => info!(
@@ -319,7 +319,7 @@ impl WorkspaceImageCache {
             });
         }
 
-        match fs::remove_dir_all(&entry.entry_dir).await {
+        match fs::remove_dir_all(entry.paths.entry_dir()).await {
             Ok(()) => {
                 match &reason {
                     GcWholeEntryReason::Stale => info!(
@@ -342,14 +342,14 @@ impl WorkspaceImageCache {
             Err(e) => match &reason {
                 GcWholeEntryReason::Stale => warn!(
                     cache_key = entry.cache_key,
-                    path = %entry.entry_dir.display(),
+                    path = %entry.paths.entry_dir().display(),
                     error = %e,
                     "failed to delete stale workspace image cache entry"
                 ),
                 GcWholeEntryReason::Unusable(reason) => warn!(
                     cache_key = entry.cache_key,
                     reason,
-                    path = %entry.entry_dir.display(),
+                    path = %entry.paths.entry_dir().display(),
                     error = %e,
                     "failed to delete unusable workspace image cache entry"
                 ),
@@ -357,7 +357,7 @@ impl WorkspaceImageCache {
         }
 
         let pre_cleanup_freed_bytes = self.gc_temporary_paths(entry, false).await?;
-        let candidate = self.gc_candidate(entry.cache_key.clone()).await;
+        let candidate = self.gc_candidate_for_entry(entry).await;
         Ok(GcEntryInventory {
             pre_cleanup_freed_bytes,
             candidate,
@@ -404,7 +404,7 @@ impl WorkspaceImageCache {
             }
             return Ok(Some(GcCacheEntry {
                 cache_key,
-                entry_dir: entry.path(),
+                paths: CacheEntryPaths::from_entry_dir(entry.path()),
             }));
         }
         Ok(None)
@@ -418,7 +418,7 @@ impl WorkspaceImageCache {
         else {
             return Ok(None);
         };
-        if !cache_entry_dir_is_dir(&entry.entry_dir).await? {
+        if !cache_entry_dir_is_dir(entry.paths.entry_dir()).await? {
             return Ok(None);
         }
         Ok(Some(lock))
@@ -458,7 +458,7 @@ impl WorkspaceImageCache {
 
     async fn gc_temporary_paths(&self, entry: &GcCacheEntry, dry_run: bool) -> RunnerResult<u64> {
         let mut freed: u64 = 0;
-        let mut files = match fs::read_dir(&entry.entry_dir).await {
+        let mut files = match fs::read_dir(entry.paths.entry_dir()).await {
             Ok(files) => files,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
             Err(e) => return Err(e.into()),
@@ -512,7 +512,7 @@ impl WorkspaceImageCache {
         };
         let mut candidates = Vec::new();
         while let Some(entry) = Self::next_gc_cache_entry(&mut entries).await? {
-            let Some(candidate) = self.gc_candidate(entry.cache_key).await else {
+            let Some(candidate) = self.gc_candidate_for_entry(&entry).await else {
                 continue;
             };
             candidates.push(candidate);
@@ -523,12 +523,11 @@ impl WorkspaceImageCache {
     async fn gc_candidate_from_observation(
         &self,
         cache_key: String,
+        paths: &CacheEntryPaths,
         file_metadata: std::fs::Metadata,
         last_used_at: String,
     ) -> GcCandidate {
-        let sidecar_allocated = self
-            .session_history_sidecar_allocated_bytes(&cache_key)
-            .await;
+        let sidecar_allocated = self.session_history_sidecar_allocated_bytes(paths).await;
         GcCandidate {
             cache_key,
             allocated_bytes: allocated_bytes(&file_metadata).saturating_add(sidecar_allocated),
@@ -538,25 +537,37 @@ impl WorkspaceImageCache {
         }
     }
 
-    pub(super) async fn gc_candidate(&self, cache_key: String) -> Option<GcCandidate> {
-        let entry_dir = self.workspace_image_cache_entry_dir(&cache_key);
-        if !cache_entry_dir_is_dir(&entry_dir).await.ok()? {
+    async fn gc_candidate_for_entry(&self, entry: &GcCacheEntry) -> Option<GcCandidate> {
+        if !cache_entry_dir_is_dir(entry.paths.entry_dir()).await.ok()? {
             return None;
         }
-        let metadata_path = self.workspace_image_cache_metadata(&cache_key);
-        let current_path = self.workspace_image_cache_current_image(&cache_key);
-        let file_metadata = fs::symlink_metadata(&current_path).await.ok()?;
+        let file_metadata = fs::symlink_metadata(entry.paths.current_image())
+            .await
+            .ok()?;
         if !file_metadata.is_file() {
             return None;
         }
-        let last_used_at = match self.read_metadata_file(&metadata_path).await {
+        let last_used_at = match self.read_metadata_file(entry.paths.metadata()).await {
             Ok(metadata) => metadata.last_used_at,
             Err(_) if self.inner.cache_scope.is_empty() => String::new(),
             Err(_) => return None,
         };
         Some(
-            self.gc_candidate_from_observation(cache_key, file_metadata, last_used_at)
-                .await,
+            self.gc_candidate_from_observation(
+                entry.cache_key.clone(),
+                &entry.paths,
+                file_metadata,
+                last_used_at,
+            )
+            .await,
         )
+    }
+
+    pub(super) async fn gc_candidate(&self, cache_key: String) -> Option<GcCandidate> {
+        let entry = GcCacheEntry {
+            paths: self.entry_paths(&cache_key),
+            cache_key,
+        };
+        self.gc_candidate_for_entry(&entry).await
     }
 }

--- a/crates/runner/src/workspace_image_cache/inspection.rs
+++ b/crates/runner/src/workspace_image_cache/inspection.rs
@@ -116,14 +116,15 @@ impl WorkspaceImageCache {
                 }));
             }
         };
-        if !cache_entry_dir_is_dir(&entry_dir).await? {
+        let entry_paths = super::entry::CacheEntryPaths::from_entry_dir(entry_dir);
+        if !cache_entry_dir_is_dir(entry_paths.entry_dir()).await? {
             drop(lock);
             return Ok(None);
         }
-        let temporary = inspect_temporary_paths(&entry_dir).await?;
+        let temporary = inspect_temporary_paths(entry_paths.entry_dir()).await?;
 
-        let current = self.workspace_image_cache_current_image(&cache_key);
-        let current_metadata = match fs::symlink_metadata(&current).await {
+        let current = entry_paths.current_image();
+        let current_metadata = match fs::symlink_metadata(current).await {
             Ok(metadata) => Some(metadata),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
             Err(e) => {
@@ -131,8 +132,8 @@ impl WorkspaceImageCache {
                 return Err(e.into());
             }
         };
-        let metadata_path = self.workspace_image_cache_metadata(&cache_key);
-        let (metadata, metadata_read_error) = match self.read_metadata_file(&metadata_path).await {
+        let metadata_path = entry_paths.metadata();
+        let (metadata, metadata_read_error) = match self.read_metadata_file(metadata_path).await {
             Ok(metadata) => (Some(metadata), None),
             Err(RunnerError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => (None, None),
             Err(RunnerError::Internal(_)) => (None, None),
@@ -140,13 +141,13 @@ impl WorkspaceImageCache {
         };
         let current_allocated_bytes = match current_metadata.as_ref() {
             Some(metadata) if metadata.is_dir() => {
-                workspace_cache_path_allocated_bytes(&current).await
+                workspace_cache_path_allocated_bytes(current).await
             }
             Some(metadata) => allocated_bytes(metadata),
             None => 0,
         };
         let persistent_allocated_bytes = current_allocated_bytes.saturating_add(
-            self.session_history_sidecar_allocated_bytes(&cache_key)
+            self.session_history_sidecar_allocated_bytes(&entry_paths)
                 .await,
         );
 

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -754,8 +754,10 @@ impl WorkspaceImageCache {
                     if collect_locked_commits
                         && locked_commit_keys.len() < MAX_HELD_WORKSPACE_STATES
                     {
-                        let paths = self.entry_paths(cache_key);
-                        if self.classify_metadata_scope(cache_key, &paths).await
+                        let metadata_path = self.workspace_image_cache_metadata(cache_key);
+                        if self
+                            .classify_metadata_scope(cache_key, &metadata_path)
+                            .await
                             == WorkspaceCacheScopeClassification::Relevant
                         {
                             locked_commit_keys.insert(cache_key.to_owned());

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -753,10 +753,13 @@ impl WorkspaceImageCache {
                 Ok(crate::lock::TryLock::Busy) => {
                     if collect_locked_commits
                         && locked_commit_keys.len() < MAX_HELD_WORKSPACE_STATES
-                        && self.classify_metadata_scope(cache_key).await
-                            == WorkspaceCacheScopeClassification::Relevant
                     {
-                        locked_commit_keys.insert(cache_key.to_owned());
+                        let paths = self.entry_paths(cache_key);
+                        if self.classify_metadata_scope(cache_key, &paths).await
+                            == WorkspaceCacheScopeClassification::Relevant
+                        {
+                            locked_commit_keys.insert(cache_key.to_owned());
+                        }
                     }
                     continue;
                 }
@@ -871,8 +874,9 @@ impl WorkspaceImageCache {
         input: WorkspaceImagePromotionInput<'_>,
     ) -> RunnerResult<WorkspaceImagePromotionOutcome> {
         let promotion_started = Instant::now();
-        let cache_dir = self.workspace_image_cache_entry_dir(input.cache_key);
-        if remove_non_directory_workspace_cache_entry(&cache_dir).await? {
+        let entry_paths = self.entry_paths(input.cache_key);
+        let cache_dir = entry_paths.entry_dir();
+        if remove_non_directory_workspace_cache_entry(cache_dir).await? {
             info!(
                 run_id = %input.run_id,
                 cache_key = input.cache_key,
@@ -880,10 +884,10 @@ impl WorkspaceImageCache {
                 "removed non-directory workspace image cache entry before promotion"
             );
         }
-        let metadata_path = self.workspace_image_cache_metadata(input.cache_key);
+        let metadata_path = entry_paths.metadata();
         match self
             .read_valid_metadata(
-                &metadata_path,
+                metadata_path,
                 input.profile_name,
                 input.reuse_key,
                 input.working_dir,
@@ -983,7 +987,7 @@ impl WorkspaceImageCache {
         self.ensure_workspace_cache_entry_dir(input.cache_key)
             .await?;
         secure_workspace_cache_publication_file(input.active_image)?;
-        let tmp = self.workspace_image_cache_tmp_image(input.cache_key, input.run_id);
+        let tmp = entry_paths.tmp_image(input.run_id);
         let _ = remove_workspace_cache_path_if_exists(&tmp).await;
         let rename_started = Instant::now();
         let (transfer_mode, transfer_duration) = match fs::rename(input.active_image, &tmp).await {
@@ -1070,28 +1074,28 @@ impl WorkspaceImageCache {
             );
             return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
         }
-        let current = self.workspace_image_cache_current_image(input.cache_key);
-        match fs::symlink_metadata(&current).await {
+        let current = entry_paths.current_image();
+        match fs::symlink_metadata(current).await {
             Ok(metadata) if metadata.is_dir() => {
-                remove_workspace_cache_path_if_exists(&current).await?;
+                remove_workspace_cache_path_if_exists(current).await?;
             }
             Ok(_) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => return Err(e.into()),
         }
-        if let Err(e) = fs::rename(&tmp, &current).await {
+        if let Err(e) = fs::rename(&tmp, current).await {
             let _ = remove_workspace_cache_path_if_exists(&tmp).await;
             return Err(e.into());
         }
-        let current_metadata = match fs::symlink_metadata(&current).await {
+        let current_metadata = match fs::symlink_metadata(current).await {
             Ok(metadata) => metadata,
             Err(e) => {
-                let _ = remove_workspace_cache_path_if_exists(&current).await;
+                let _ = remove_workspace_cache_path_if_exists(current).await;
                 return Err(e.into());
             }
         };
         if !current_metadata.is_file() {
-            let _ = remove_workspace_cache_path_if_exists(&current).await;
+            let _ = remove_workspace_cache_path_if_exists(current).await;
             return Err(RunnerError::Internal(format!(
                 "workspace image cache current image is not a file: {}",
                 current.display()
@@ -1137,7 +1141,7 @@ impl WorkspaceImageCache {
             .write_metadata(input.cache_key, input.run_id, metadata)
             .await
         {
-            let _ = remove_workspace_cache_path_if_exists(&current).await;
+            let _ = remove_workspace_cache_path_if_exists(current).await;
             let _ = self.prune_session_history_sidecar(input.cache_key).await;
             return Err(e);
         }

--- a/crates/runner/src/workspace_image_cache/metadata.rs
+++ b/crates/runner/src/workspace_image_cache/metadata.rs
@@ -13,9 +13,7 @@ use super::fs::{
     allocated_bytes, remove_workspace_cache_path_if_exists, secure_workspace_cache_publication_file,
 };
 use super::types::WorkspaceCacheTerminalStatus;
-use super::{
-    CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceImageCache, entry::CacheEntryPaths,
-};
+use super::{CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceImageCache};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -86,9 +84,9 @@ impl WorkspaceImageCache {
     pub(super) async fn classify_metadata_scope(
         &self,
         cache_key: &str,
-        paths: &CacheEntryPaths,
+        metadata_path: &Path,
     ) -> WorkspaceCacheScopeClassification {
-        let Ok(metadata) = self.read_metadata_file(paths.metadata()).await else {
+        let Ok(metadata) = self.read_metadata_file(metadata_path).await else {
             return WorkspaceCacheScopeClassification::Unclassified;
         };
         if !self.metadata_matches_cache_key(cache_key, &metadata) {

--- a/crates/runner/src/workspace_image_cache/metadata.rs
+++ b/crates/runner/src/workspace_image_cache/metadata.rs
@@ -13,7 +13,9 @@ use super::fs::{
     allocated_bytes, remove_workspace_cache_path_if_exists, secure_workspace_cache_publication_file,
 };
 use super::types::WorkspaceCacheTerminalStatus;
-use super::{CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceImageCache};
+use super::{
+    CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceImageCache, entry::CacheEntryPaths,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -84,11 +86,9 @@ impl WorkspaceImageCache {
     pub(super) async fn classify_metadata_scope(
         &self,
         cache_key: &str,
+        paths: &CacheEntryPaths,
     ) -> WorkspaceCacheScopeClassification {
-        let Ok(metadata) = self
-            .read_metadata_file(&self.workspace_image_cache_metadata(cache_key))
-            .await
-        else {
+        let Ok(metadata) = self.read_metadata_file(paths.metadata()).await else {
             return WorkspaceCacheScopeClassification::Unclassified;
         };
         if !self.metadata_matches_cache_key(cache_key, &metadata) {

--- a/crates/runner/src/workspace_image_cache/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/sidecar.rs
@@ -250,10 +250,10 @@ impl WorkspaceImageCache {
         run_id: RunId,
         publication: WorkspaceSessionHistorySidecarPublication<'_>,
     ) -> RunnerResult<()> {
-        let paths = self.entry_paths(cache_key);
         match publication {
             WorkspaceSessionHistorySidecarPublication::PreserveExisting => {}
             WorkspaceSessionHistorySidecarPublication::Replace(source) => {
+                let paths = self.entry_paths(cache_key);
                 self.publish_session_history_sidecar_source(cache_key, run_id, &paths, source)
                     .await?;
             }

--- a/crates/runner/src/workspace_image_cache/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/sidecar.rs
@@ -271,10 +271,12 @@ impl WorkspaceImageCache {
         let _ = remove_workspace_cache_path_if_exists(&source.tmp_path).await;
     }
 
-    pub(super) async fn session_history_sidecar_allocated_bytes(&self, cache_key: &str) -> u64 {
-        let paths = self.entry_paths(cache_key);
+    pub(super) async fn session_history_sidecar_allocated_bytes(
+        &self,
+        paths: &CacheEntryPaths,
+    ) -> u64 {
         let mut allocated = 0_u64;
-        for body_path in session_history_sidecar_body_paths(&paths) {
+        for body_path in session_history_sidecar_body_paths(paths) {
             allocated = allocated.saturating_add(
                 workspace_cache_existing_path_allocated_bytes(&body_path)
                     .await
@@ -324,7 +326,7 @@ impl WorkspaceImageCache {
             let _ = remove_workspace_cache_path_if_exists(&source.tmp_path).await;
             return Ok(());
         };
-        let tmp_metadata_path = self.workspace_image_cache_tmp_sidecar_metadata(cache_key, run_id);
+        let tmp_metadata_path = paths.tmp_session_history_sidecar_metadata(run_id);
         let sidecar_metadata_path = paths.session_history_sidecar_metadata();
         let sidecar_body_path = paths.entry_dir().join(body_slot.file_name());
         let _ = remove_workspace_cache_path_if_exists(&tmp_metadata_path).await;

--- a/crates/runner/src/workspace_image_cache/tests/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/tests/sidecar.rs
@@ -589,8 +589,7 @@ async fn session_history_sidecar_metadata_commit_failure_rolls_back_replacement(
     let history_b = br#"{"type":"message","content":"b"}"#;
     let identity_b = test_restored_session_identity("session-b", history_b);
     let failed_source = cache.workspace_image_cache_tmp_sidecar(&cache_key, failed_run_id);
-    let failed_metadata =
-        cache.workspace_image_cache_tmp_sidecar_metadata(&cache_key, failed_run_id);
+    let failed_metadata = entry_paths.tmp_session_history_sidecar_metadata(failed_run_id);
     let inactive_body = entry_dir.join("session-history.second.blob");
     fs::write(&failed_source, history_b).await.unwrap();
     let replacement = WorkspaceSessionHistorySidecarPromotionSource {
@@ -765,10 +764,10 @@ async fn session_history_sidecar_counts_toward_gc_candidate_and_inspection() {
     )
     .await;
     publish_test_session_history_sidecar(&cache, &cache_key, run_id, session_id, history).await;
-    let current_allocated =
-        workspace_cache_path_allocated_bytes(cache.entry_paths(&cache_key).current_image()).await;
+    let entry_paths = cache.entry_paths(&cache_key);
+    let current_allocated = workspace_cache_path_allocated_bytes(entry_paths.current_image()).await;
     let sidecar_allocated = cache
-        .session_history_sidecar_allocated_bytes(&cache_key)
+        .session_history_sidecar_allocated_bytes(&entry_paths)
         .await;
 
     let candidate = cache.gc_candidate(cache_key.clone()).await.unwrap();

--- a/crates/runner/src/workspace_image_cache/watcher.rs
+++ b/crates/runner/src/workspace_image_cache/watcher.rs
@@ -12,7 +12,7 @@ use crate::host_file::{self, DirMode};
 use crate::types::MAX_HELD_WORKSPACE_STATES;
 
 use super::WorkspaceImageCache;
-use super::entry::{CacheEntryPaths, is_cache_key_name};
+use super::entry::is_cache_key_name;
 use super::metadata::WorkspaceCacheScopeClassification;
 
 const METADATA_FILE_NAME: &str = "metadata.json";
@@ -141,9 +141,13 @@ impl WorkspaceCacheWatcher {
                 Some(EntryWatchState::Relevant) => {}
                 Some(EntryWatchState::Unclassified) => {
                     requires_refresh = true;
-                    let paths = self.cache.entry_paths(cache_key);
-                    self.classify_metadata_commit(cache_key, &paths, &mut committed_cache_keys)
-                        .await;
+                    let metadata_path = self.cache.workspace_image_cache_metadata(cache_key);
+                    self.classify_metadata_commit(
+                        cache_key,
+                        &metadata_path,
+                        &mut committed_cache_keys,
+                    )
+                    .await;
                 }
                 None => {
                     requires_refresh = true;
@@ -263,9 +267,9 @@ impl WorkspaceCacheWatcher {
                     .await?;
             }
             for cache_key in metadata_commit_keys {
-                let paths = self.cache.entry_paths(&cache_key);
+                let metadata_path = self.cache.workspace_image_cache_metadata(&cache_key);
                 changed |= self
-                    .classify_metadata_commit(&cache_key, &paths, &mut committed_cache_keys)
+                    .classify_metadata_commit(&cache_key, &metadata_path, &mut committed_cache_keys)
                     .await;
             }
             if reconcile_all_entry_watches {
@@ -309,8 +313,8 @@ impl WorkspaceCacheWatcher {
 
         let watched_cache_keys = self.watch_by_cache_key.keys().cloned().collect::<Vec<_>>();
         for cache_key in watched_cache_keys {
-            let paths = self.cache.entry_paths(&cache_key);
-            self.classify_metadata_commit(&cache_key, &paths, committed_cache_keys)
+            let metadata_path = self.cache.workspace_image_cache_metadata(&cache_key);
+            self.classify_metadata_commit(&cache_key, &metadata_path, committed_cache_keys)
                 .await;
         }
 
@@ -390,7 +394,7 @@ impl WorkspaceCacheWatcher {
         );
         self.watch_by_cache_key.insert(cache_key.clone(), watch);
         let changed = self
-            .classify_metadata_commit(&cache_key, &paths, committed_cache_keys)
+            .classify_metadata_commit(&cache_key, paths.metadata(), committed_cache_keys)
             .await;
         self.enforce_watch_limit(&cache_key);
         if !self.watch_by_cache_key.contains_key(&cache_key) {
@@ -402,13 +406,17 @@ impl WorkspaceCacheWatcher {
     async fn classify_metadata_commit(
         &mut self,
         cache_key: &str,
-        paths: &CacheEntryPaths,
+        metadata_path: &Path,
         committed_cache_keys: &mut BTreeSet<String>,
     ) -> bool {
         let Some(previous_state) = self.entry_watch_state(cache_key) else {
             return false;
         };
-        match self.cache.classify_metadata_scope(cache_key, paths).await {
+        match self
+            .cache
+            .classify_metadata_scope(cache_key, metadata_path)
+            .await
+        {
             WorkspaceCacheScopeClassification::Relevant => {
                 self.set_entry_watch_state(cache_key, EntryWatchState::Relevant);
                 if committed_cache_keys.len() < MAX_HELD_WORKSPACE_STATES {

--- a/crates/runner/src/workspace_image_cache/watcher.rs
+++ b/crates/runner/src/workspace_image_cache/watcher.rs
@@ -371,15 +371,15 @@ impl WorkspaceCacheWatcher {
         if self.watch_by_cache_key.contains_key(&cache_key) {
             return Ok(false);
         }
-        let paths = self.cache.entry_paths(&cache_key);
-        if !Self::entry_is_watchable(paths.entry_dir())? {
+        let entry_dir = self.cache.workspace_image_cache_entry_dir(&cache_key);
+        if !Self::entry_is_watchable(&entry_dir)? {
             return Ok(false);
         }
         let watch = match self
             .inotify
             .get_ref()
             .0
-            .add_watch(paths.entry_dir(), ENTRY_WATCH_FLAGS)
+            .add_watch(&entry_dir, ENTRY_WATCH_FLAGS)
         {
             Ok(watch) => watch,
             Err(Errno::ENOENT | Errno::ENOTDIR | Errno::ELOOP) => return Ok(false),
@@ -393,8 +393,9 @@ impl WorkspaceCacheWatcher {
             },
         );
         self.watch_by_cache_key.insert(cache_key.clone(), watch);
+        let metadata_path = self.cache.workspace_image_cache_metadata(&cache_key);
         let changed = self
-            .classify_metadata_commit(&cache_key, paths.metadata(), committed_cache_keys)
+            .classify_metadata_commit(&cache_key, &metadata_path, committed_cache_keys)
             .await;
         self.enforce_watch_limit(&cache_key);
         if !self.watch_by_cache_key.contains_key(&cache_key) {

--- a/crates/runner/src/workspace_image_cache/watcher.rs
+++ b/crates/runner/src/workspace_image_cache/watcher.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsStr;
 use std::os::fd::{AsFd, AsRawFd, RawFd};
+use std::path::Path;
 
 use nix::errno::Errno;
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify, WatchDescriptor};
@@ -11,7 +12,7 @@ use crate::host_file::{self, DirMode};
 use crate::types::MAX_HELD_WORKSPACE_STATES;
 
 use super::WorkspaceImageCache;
-use super::entry::is_cache_key_name;
+use super::entry::{CacheEntryPaths, is_cache_key_name};
 use super::metadata::WorkspaceCacheScopeClassification;
 
 const METADATA_FILE_NAME: &str = "metadata.json";
@@ -140,7 +141,8 @@ impl WorkspaceCacheWatcher {
                 Some(EntryWatchState::Relevant) => {}
                 Some(EntryWatchState::Unclassified) => {
                     requires_refresh = true;
-                    self.classify_metadata_commit(cache_key, &mut committed_cache_keys)
+                    let paths = self.cache.entry_paths(cache_key);
+                    self.classify_metadata_commit(cache_key, &paths, &mut committed_cache_keys)
                         .await;
                 }
                 None => {
@@ -261,8 +263,9 @@ impl WorkspaceCacheWatcher {
                     .await?;
             }
             for cache_key in metadata_commit_keys {
+                let paths = self.cache.entry_paths(&cache_key);
                 changed |= self
-                    .classify_metadata_commit(&cache_key, &mut committed_cache_keys)
+                    .classify_metadata_commit(&cache_key, &paths, &mut committed_cache_keys)
                     .await;
             }
             if reconcile_all_entry_watches {
@@ -306,7 +309,8 @@ impl WorkspaceCacheWatcher {
 
         let watched_cache_keys = self.watch_by_cache_key.keys().cloned().collect::<Vec<_>>();
         for cache_key in watched_cache_keys {
-            self.classify_metadata_commit(&cache_key, committed_cache_keys)
+            let paths = self.cache.entry_paths(&cache_key);
+            self.classify_metadata_commit(&cache_key, &paths, committed_cache_keys)
                 .await;
         }
 
@@ -347,8 +351,8 @@ impl WorkspaceCacheWatcher {
         Ok(())
     }
 
-    fn entry_is_watchable(&self, cache_key: &str) -> RunnerResult<bool> {
-        match std::fs::symlink_metadata(self.cache.workspace_image_cache_entry_dir(cache_key)) {
+    fn entry_is_watchable(entry_dir: &Path) -> RunnerResult<bool> {
+        match std::fs::symlink_metadata(entry_dir) {
             Ok(metadata) => Ok(metadata.is_dir()),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
             Err(error) => Err(watcher_io_error("inspect entry", error.kind())),
@@ -360,17 +364,18 @@ impl WorkspaceCacheWatcher {
         cache_key: String,
         committed_cache_keys: &mut BTreeSet<String>,
     ) -> RunnerResult<bool> {
-        if self.watch_by_cache_key.contains_key(&cache_key)
-            || !self.entry_is_watchable(&cache_key)?
-        {
+        if self.watch_by_cache_key.contains_key(&cache_key) {
             return Ok(false);
         }
-        let entry_dir = self.cache.workspace_image_cache_entry_dir(&cache_key);
+        let paths = self.cache.entry_paths(&cache_key);
+        if !Self::entry_is_watchable(paths.entry_dir())? {
+            return Ok(false);
+        }
         let watch = match self
             .inotify
             .get_ref()
             .0
-            .add_watch(&entry_dir, ENTRY_WATCH_FLAGS)
+            .add_watch(paths.entry_dir(), ENTRY_WATCH_FLAGS)
         {
             Ok(watch) => watch,
             Err(Errno::ENOENT | Errno::ENOTDIR | Errno::ELOOP) => return Ok(false),
@@ -385,7 +390,7 @@ impl WorkspaceCacheWatcher {
         );
         self.watch_by_cache_key.insert(cache_key.clone(), watch);
         let changed = self
-            .classify_metadata_commit(&cache_key, committed_cache_keys)
+            .classify_metadata_commit(&cache_key, &paths, committed_cache_keys)
             .await;
         self.enforce_watch_limit(&cache_key);
         if !self.watch_by_cache_key.contains_key(&cache_key) {
@@ -397,12 +402,13 @@ impl WorkspaceCacheWatcher {
     async fn classify_metadata_commit(
         &mut self,
         cache_key: &str,
+        paths: &CacheEntryPaths,
         committed_cache_keys: &mut BTreeSet<String>,
     ) -> bool {
         let Some(previous_state) = self.entry_watch_state(cache_key) else {
             return false;
         };
-        match self.cache.classify_metadata_scope(cache_key).await {
+        match self.cache.classify_metadata_scope(cache_key, paths).await {
             WorkspaceCacheScopeClassification::Relevant => {
                 self.set_entry_watch_state(cache_key, EntryWatchState::Relevant);
                 if committed_cache_keys.len() < MAX_HELD_WORKSPACE_STATES {


### PR DESCRIPTION
## Summary

- derive flat workspace-cache paths directly instead of constructing and cloning an eager four-path bundle
- reuse operation-owned `CacheEntryPaths` values in multi-path GC, inspection, sidecar accounting, and promotion flows
- pass direct entry or metadata paths through watcher and lifecycle flows that do not need a complete bundle
- avoid constructing sidecar path bundles for preserve and prune dispatch paths that do not consume them
- keep valid filenames centralized while preserving cache roots, locks, on-disk layout, symlink checks, and validation semantics

## Scope

This is an internal runner allocation refactor. It does not change cache keys, persisted metadata, APIs, queue payloads, database state, or deployment compatibility. It does not claim a measured end-to-end latency improvement or add allocator instrumentation.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner workspace_image_cache --quiet` (145 passed, 1 ignored)
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --quiet` (3,221 passed, 20 ignored)
- repository pre-commit and commit-message hooks

Closes #28469
