### PR TITLE
test(api): isolate run time budget cron cases

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -31,7 +31,6 @@ import {
   type UserMessageInputDocument,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { isChatRunTerminalEventType } from "@okouai/api-contracts/contracts/chat-events";
-import { cronSteerRunTimeBudgetContract } from "@okouai/api-contracts/contracts/cron";
 import {
   ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES,
   CANCELLATION_RECOVERY_STALE_AFTER_MS,
@@ -67,7 +66,6 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
 import {
-  backdateRunStartedAtFixture,
   readRunModelRuntimeRouteFixture,
   setRunModelRuntimeRouteFixture,
 } from "../../../test-fixtures/agent-runs";
@@ -123,6 +121,7 @@ import {
   readThreadSessionBinding,
   seedVm0ManagedModelKey as seedVm0ManagedModelKeyState,
   setRunAutonomyBudgetFixture,
+  steerRunTimeBudgetFixture,
 } from "./helpers/runtime-state";
 import { createRouteMocks } from "./helpers/route-test";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
@@ -157,7 +156,6 @@ import {
   setChatCallbackGitHubDeliveryFixture,
   timeoutRunWithoutCallbacksFixture,
 } from "../../../test-fixtures/chat-events";
-import { cronSteerRunTimeBudgetRoutes } from "../cron-steer-run-time-budget";
 import { chatEventsRoutes } from "../chat-events";
 import { chatThreadRoutes } from "../chat-threads";
 import { mailRoutes } from "../mail";
@@ -598,26 +596,12 @@ async function expectRunPublicBrandTransport(args: {
   });
 }
 
-/**
- * The time-budget sweep is global, so it can only be driven from a file that
- * ages its own runs through `backdateRunStartedAtFixture`. Every other suite
- * claims runs at the current time and therefore stays outside the window.
- */
-async function runSteerRunTimeBudgetCron(): Promise<void> {
-  await accept(
-    setupApp({ context, routes: cronSteerRunTimeBudgetRoutes })(
-      cronSteerRunTimeBudgetContract,
-    ).steer({ headers: { authorization: "Bearer test-cron-secret" } }),
-    [200],
-  );
-}
-
-/** Age one claimed run to the given elapsed runtime. */
-async function ageClaimedRun(runId: string, elapsedMs: number): Promise<void> {
-  await backdateRunStartedAtFixture({
-    runId,
-    startedAt: new Date(now() - elapsedMs),
-  });
+/** Steer one owned run without scanning rows owned by other test files. */
+async function steerOwnedRunAtElapsedTime(
+  runId: string,
+  elapsedMs: number,
+): Promise<{ readonly scanned: number; readonly steered: number }> {
+  return await steerRunTimeBudgetFixture(context, runId, elapsedMs);
 }
 
 function claimEnvironment(claim: RunnerClaim): Record<string, string> {
@@ -2601,8 +2585,7 @@ describe("CHAT-02: queueing and recalling messages", () => {
       },
       [201],
     );
-    await ageClaimedRun(active.runId, RUN_TIME_BUDGET_STEER_AT_MS);
-    await runSteerRunTimeBudgetCron();
+    await steerOwnedRunAtElapsedTime(active.runId, RUN_TIME_BUDGET_STEER_AT_MS);
     const reserved = await api.reserveRunnerActiveInputs(
       claimed.claim.sandboxToken,
       active.runId,
@@ -3147,8 +3130,9 @@ describe("CHAT-02: queueing and recalling messages", () => {
       prompt: "reserve the time budget warning",
     });
     const claimed = await claimChatRun(runnerGroup, active.runId);
-    await ageClaimedRun(active.runId, RUN_TIME_BUDGET_STEER_AT_MS);
-    await runSteerRunTimeBudgetCron();
+    await expect(
+      steerOwnedRunAtElapsedTime(active.runId, RUN_TIME_BUDGET_STEER_AT_MS),
+    ).resolves.toStrictEqual({ scanned: 1, steered: 1 });
     const reserved = await api.reserveRunnerActiveInputs(
       claimed.claim.sandboxToken,
       active.runId,
@@ -3189,14 +3173,19 @@ describe("CHAT-02: queueing and recalling messages", () => {
     });
     const claimed = await claimChatRun(runnerGroup, active.runId);
 
-    await ageClaimedRun(active.runId, RUN_TIME_BUDGET_STEER_AT_MS - 60_000);
-    await runSteerRunTimeBudgetCron();
+    await expect(
+      steerOwnedRunAtElapsedTime(
+        active.runId,
+        RUN_TIME_BUDGET_STEER_AT_MS - 60_000,
+      ),
+    ).resolves.toStrictEqual({ scanned: 0, steered: 0 });
     await expect(
       api.reserveRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
     ).resolves.toStrictEqual({ outcome: "empty" });
 
-    await ageClaimedRun(active.runId, RUN_TIME_BUDGET_STEER_AT_MS);
-    await runSteerRunTimeBudgetCron();
+    await expect(
+      steerOwnedRunAtElapsedTime(active.runId, RUN_TIME_BUDGET_STEER_AT_MS),
+    ).resolves.toStrictEqual({ scanned: 1, steered: 1 });
     const budgetReservation = await api.reserveRunnerActiveInputs(
       claimed.claim.sandboxToken,
       active.runId,
@@ -3231,7 +3220,9 @@ describe("CHAT-02: queueing and recalling messages", () => {
       }),
     ).toBeFalsy();
 
-    await runSteerRunTimeBudgetCron();
+    await expect(
+      steerOwnedRunAtElapsedTime(active.runId, RUN_TIME_BUDGET_STEER_AT_MS),
+    ).resolves.toStrictEqual({ scanned: 1, steered: 0 });
     await expect(
       api.reserveRunnerActiveInputs(claimed.claim.sandboxToken, active.runId),
     ).resolves.toStrictEqual({ outcome: "empty" });
@@ -3248,8 +3239,7 @@ describe("CHAT-02: queueing and recalling messages", () => {
       prompt: "leave the budget input unclaimed",
     });
     const firstClaim = await claimChatRun(runnerGroup, first.runId);
-    await ageClaimedRun(first.runId, RUN_TIME_BUDGET_STEER_AT_MS);
-    await runSteerRunTimeBudgetCron();
+    await steerOwnedRunAtElapsedTime(first.runId, RUN_TIME_BUDGET_STEER_AT_MS);
     const firstBudget = await api.reserveRunnerActiveInputs(
       firstClaim.claim.sandboxToken,
       first.runId,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -663,6 +663,26 @@ export async function readRunApiStart(
   return response.api_started_at ?? null;
 }
 
+/**
+ * Move one owned running run to an elapsed-time boundary and execute the
+ * production steering flow without scanning rows owned by other test files.
+ */
+export async function steerRunTimeBudgetFixture(
+  context: TestContext,
+  runId: string,
+  elapsedMs: number,
+): Promise<NonNullable<TestRuntimeStateActionResponse["run_time_budget"]>> {
+  const response = await postAction(context, {
+    action: "steer-run-time-budget",
+    run_id: runId,
+    elapsed_ms: elapsedMs,
+  });
+  if (!response.run_time_budget) {
+    throw new Error("steerRunTimeBudgetFixture missing run_time_budget");
+  }
+  return response.run_time_budget;
+}
+
 export async function readThreadSessionBinding(
   context: TestContext,
   threadId: string,

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -67,6 +67,7 @@ import { usagePackPurchaseSerializationSchemaAvailable } from "../services/usage
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
 import { writeRunMetadata } from "../services/agent-run-metadata-write.service";
 import { saveRunSummary } from "../services/run-summary.service";
+import { steerRunNearTimeBudgetForTest } from "../services/cron-steer-run-time-budget.service";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
@@ -462,6 +463,28 @@ async function readRunApiStart(
     throw new Error("Expected a Zero run timing row");
   }
   return run.apiStartedAt?.toISOString() ?? null;
+}
+
+/**
+ * A running run cannot reach the time-budget boundary during an integration
+ * test, so the test-only route moves exactly its owned run into that state.
+ */
+async function setRunTimeBudgetElapsed(
+  db: Db,
+  runId: string,
+  elapsedMs: number,
+  signal: AbortSignal,
+): Promise<void> {
+  const startedAt = new Date(nowDate().getTime() - elapsedMs);
+  const [updated] = await db
+    .update(agentRuns)
+    .set({ startedAt })
+    .where(and(eq(agentRuns.id, runId), eq(agentRuns.status, "running")))
+    .returning({ id: agentRuns.id });
+  signal.throwIfAborted();
+  if (!updated) {
+    throw new Error("Expected one running time-budget run fixture");
+  }
 }
 
 async function readThreadSessionBinding(
@@ -1425,7 +1448,12 @@ async function readRunClaimOwnerActionResponse(
 
 type TimingStateAction = Extract<
   TestRuntimeStateActionBody,
-  { action: "clear-run-api-start" | "read-run-api-start" }
+  {
+    action:
+      | "clear-run-api-start"
+      | "read-run-api-start"
+      | "steer-run-time-budget";
+  }
 >;
 
 function isTimingStateAction(
@@ -1433,7 +1461,8 @@ function isTimingStateAction(
 ): body is TimingStateAction {
   return (
     body.action === "clear-run-api-start" ||
-    body.action === "read-run-api-start"
+    body.action === "read-run-api-start" ||
+    body.action === "steer-run-time-budget"
   );
 }
 
@@ -1453,6 +1482,20 @@ async function timingStateActionResponse(
         body: {
           ok: true as const,
           api_started_at: await readRunApiStart(db, body.run_id, signal),
+        },
+      };
+    }
+    case "steer-run-time-budget": {
+      await setRunTimeBudgetElapsed(db, body.run_id, body.elapsed_ms, signal);
+      return {
+        status: 200 as const,
+        body: {
+          ok: true as const,
+          run_time_budget: await steerRunNearTimeBudgetForTest(
+            db,
+            body.run_id,
+            signal,
+          ),
         },
       };
     }

--- a/turbo/apps/api/src/signals/services/cron-steer-run-time-budget.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-steer-run-time-budget.service.ts
@@ -34,9 +34,14 @@ interface RunTimeBudgetCandidate {
   readonly chatThreadId: string;
 }
 
+interface RunTimeBudgetCandidateScope {
+  readonly runId: string;
+}
+
 async function loadRunTimeBudgetCandidates(
   db: Db,
   startedBefore: Date,
+  scope: RunTimeBudgetCandidateScope | undefined,
 ): Promise<readonly RunTimeBudgetCandidate[]> {
   return await db
     .select({
@@ -50,10 +55,11 @@ async function loadRunTimeBudgetCandidates(
         eq(agentRuns.status, "running"),
         lte(agentRuns.startedAt, startedBefore),
         isNotNull(agentRuns.triggerSource),
+        scope ? eq(agentRuns.id, scope.runId) : undefined,
       ),
     )
     .orderBy(agentRuns.startedAt)
-    .limit(RUN_TIME_BUDGET_SCAN_LIMIT);
+    .limit(scope ? 1 : RUN_TIME_BUDGET_SCAN_LIMIT);
 }
 
 /**
@@ -117,6 +123,41 @@ async function persistRunTimeBudgetInput(
   });
 }
 
+async function steerRunsNearTimeBudget(
+  db: Db,
+  scope: RunTimeBudgetCandidateScope | undefined,
+  signal: AbortSignal,
+): Promise<{ readonly scanned: number; readonly steered: number }> {
+  const createdAt = nowDate();
+  const startedBefore = new Date(
+    createdAt.getTime() - RUN_TIME_BUDGET_STEER_AT_MS,
+  );
+  const candidates = await loadRunTimeBudgetCandidates(
+    db,
+    startedBefore,
+    scope,
+  );
+  signal.throwIfAborted();
+
+  let steered = 0;
+  for (const candidate of candidates) {
+    if (
+      await persistRunTimeBudgetInput(db, {
+        candidate,
+        startedBefore,
+        createdAt,
+      })
+    ) {
+      steered += 1;
+    }
+    signal.throwIfAborted();
+    await notifyRunningChatRunOfPendingInput(db, candidate.chatThreadId);
+    signal.throwIfAborted();
+  }
+
+  return { scanned: candidates.length, steered };
+}
+
 /**
  * Steer every chat run that reached its time budget. A run stays a candidate
  * until it ends, so an unclaimed steer is re-announced to the runner on the
@@ -124,30 +165,15 @@ async function persistRunTimeBudgetInput(
  */
 export const steerRunsNearTimeBudget$ = command(
   async ({ set }, signal: AbortSignal) => {
-    const db = set(writeDb$);
-    const createdAt = nowDate();
-    const startedBefore = new Date(
-      createdAt.getTime() - RUN_TIME_BUDGET_STEER_AT_MS,
-    );
-    const candidates = await loadRunTimeBudgetCandidates(db, startedBefore);
-    signal.throwIfAborted();
-
-    let steered = 0;
-    for (const candidate of candidates) {
-      if (
-        await persistRunTimeBudgetInput(db, {
-          candidate,
-          startedBefore,
-          createdAt,
-        })
-      ) {
-        steered += 1;
-      }
-      signal.throwIfAborted();
-      await notifyRunningChatRunOfPendingInput(db, candidate.chatThreadId);
-      signal.throwIfAborted();
-    }
-
-    return { scanned: candidates.length, steered };
+    return await steerRunsNearTimeBudget(set(writeDb$), undefined, signal);
   },
 );
+
+/** Scope the global sweep to one owned run for shared-database route tests. */
+export async function steerRunNearTimeBudgetForTest(
+  db: Db,
+  runId: string,
+  signal: AbortSignal,
+): Promise<{ readonly scanned: number; readonly steered: number }> {
+  return await steerRunsNearTimeBudget(db, { runId }, signal);
+}

--- a/turbo/apps/api/src/test-fixtures/agent-runs.ts
+++ b/turbo/apps/api/src/test-fixtures/agent-runs.ts
@@ -218,25 +218,6 @@ export async function readRunIdentityMismatchWriteCountsFixture(args: {
   };
 }
 
-/**
- * Age one claimed run without moving the shared test clock. Sweeps that select
- * runs by elapsed runtime are global, so a mocked clock would also age every
- * concurrent test file's rows in the shared database.
- */
-export async function backdateRunStartedAtFixture(args: {
-  readonly runId: string;
-  readonly startedAt: Date;
-}): Promise<void> {
-  const updated = await db()
-    .update(agentRuns)
-    .set({ startedAt: args.startedAt })
-    .where(and(eq(agentRuns.id, args.runId), eq(agentRuns.status, "running")))
-    .returning({ id: agentRuns.id });
-  if (updated.length !== 1) {
-    throw new Error("Expected one running run to become historical");
-  }
-}
-
 export async function readRunModelRuntimeRouteFixture(runId: string) {
   const [run] = await db()
     .select({

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -180,6 +180,11 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     run_id: z.uuid(),
   }),
   z.object({
+    action: z.literal("steer-run-time-budget"),
+    run_id: z.uuid(),
+    elapsed_ms: z.int().nonnegative(),
+  }),
+  z.object({
     action: z.literal("read-run-launch-snapshot"),
     run_id: z.uuid(),
   }),
@@ -283,6 +288,12 @@ export const testRuntimeStateActionResponseSchema = z.object({
     .nullable()
     .optional(),
   api_started_at: z.string().nullable().optional(),
+  run_time_budget: z
+    .object({
+      scanned: z.int().nonnegative(),
+      steered: z.int().nonnegative(),
+    })
+    .optional(),
   run_launch_snapshot: z
     .object({
       exists: z.boolean(),


### PR DESCRIPTION
## Summary

- add a test-only, exact-run entry point that reuses the production run time budget steering implementation
- update chat event integration cases to steer only the run owned by each test instead of invoking the global cron sweep
- remove the obsolete direct database backdating fixture

## Behavior

Production cron selection, ordering, scan limit, persistence, notification, and idempotency behavior are unchanged. The new scoped path is only reachable through the guarded test runtime state route and never scans or mutates unrelated shared test rows.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts --maxWorkers=1 --silent=passed-only` (120 passed)
- `pnpm -F @okouai/api-contracts test -- --run` (593 passed)
- `pnpm knip`
- pre-commit full workspace type checks (14/14 passed)

Closes #28443
