### PR TITLE
fix(platform): lighten the model picker's variant control

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -1024,6 +1024,18 @@ export function VideoModelBrandIcon({ model }: { model: VideoModel }) {
   );
 }
 
+// The variant control sits inside a list whose only other paint is a 5% hover
+// layer, so a filled `bg-muted` track plus a raised white pill made it the
+// heaviest thing in the popover -- the eye landed on the control instead of the
+// model names. Stripped to text, the state is carried by weight and colour
+// alone, and the group drops from 28px to the 20px line box.
+const VARIANT_SEGMENT_CLASS = "h-5 bg-transparent p-0";
+
+// `text-[13px]` steps up from the segment's usual `text-xs`: without a track to
+// lend it presence, 12px read as detached from the 14px row it belongs to.
+const VARIANT_SEGMENT_ITEM_CLASS =
+  "h-5 rounded-md px-1.5 text-[13px] font-normal data-checked:bg-transparent data-checked:font-medium data-checked:shadow-none";
+
 function MediaModelPanelRow({ option }: { option: MediaModelPanelOption }) {
   if (option.variant) {
     const variant = option.variant;
@@ -1041,9 +1053,9 @@ function MediaModelPanelRow({ option }: { option: MediaModelPanelOption }) {
     // real selection.
     const highlightedVariant = selectedVariant ?? variant.options[0];
     return (
-      // The segment is `xs` (h-7), so this row drops to `py-0.5` to land on the
-      // same 32px as the plain rows around it -- `py-1.5` would make the one row
-      // that carries variants 8px taller than its neighbours.
+      // Now that the variant group is a 20px line box rather than an h-7
+      // control, this row keeps the same `py-1.5` as every other row instead of
+      // compensating with `py-0.5`.
       <div
         // The segment always fills one variant, so its checked state no longer
         // separates the active family from a default fill. `aria-current` is
@@ -1052,7 +1064,7 @@ function MediaModelPanelRow({ option }: { option: MediaModelPanelOption }) {
         // `aria-pressed` on the label button keeps its narrower meaning: the
         // base model specifically, not the family.
         aria-current={groupSelected ? "true" : undefined}
-        className="relative flex w-full select-none items-center gap-2 rounded-lg py-0.5 pl-2 pr-8 text-sm transition-colors hover:bg-state-hover hover:text-accent-foreground"
+        className="relative flex w-full select-none items-center gap-2 rounded-lg py-1.5 pl-2 pr-8 text-sm transition-colors hover:bg-state-hover hover:text-accent-foreground"
       >
         <button
           type="button"
@@ -1066,6 +1078,7 @@ function MediaModelPanelRow({ option }: { option: MediaModelPanelOption }) {
         </button>
         <SegmentControl
           size="xs"
+          className={VARIANT_SEGMENT_CLASS}
           aria-label={variant.label}
           value={highlightedVariant?.label ?? null}
           onValueChange={(next: string | null) => {
@@ -1082,6 +1095,7 @@ function MediaModelPanelRow({ option }: { option: MediaModelPanelOption }) {
                 key={candidate.label}
                 value={candidate.label}
                 aria-label={candidate.label}
+                className={VARIANT_SEGMENT_ITEM_CLASS}
               >
                 {candidate.chipLabel}
               </SegmentControlItem>


### PR DESCRIPTION
## Problem

The variant segment was the heaviest element in the model picker, for four compounding reasons:

1. **Filled track** — `bg-muted` is gray-100 in light mode, while the rest of the list is white plus a 5% hover layer. It was the darkest block in the popover.
2. **Raised pill** — the checked variant is a white fill with a two-layer shadow, i.e. a floating element inside a flat list.
3. **Nearly full row height** — a 28px control in a 32px row leaves 2px above and below, so it visually *is* the row.
4. **Always on, and stacked** — every variant family renders one, so the video panel shows two in a six-row list and the eye lands on the controls instead of the model names.

![before / after](https://cdn.vm0.io/artifacts/zm9ve3x9rb.png)

## Change

Strip the control to text at the same position:

- root gets `h-5 bg-transparent p-0` — no track
- items get `font-normal ... data-checked:bg-transparent data-checked:font-medium data-checked:shadow-none` — state is carried by weight and colour instead of a pill
- the base `not-data-checked:hover:bg-state-hover` rule already in `segmentControlItemVariants` is what now reveals the hit area on hover
- the group falls from a 28px control to a 20px line box, so the row returns to the same `py-1.5` as every other row instead of compensating with `py-0.5`

Measured on the worst row (Seedance 2.0, three variants): painted control area falls from **42% of the row to 0%** at rest; the group narrows from 155px to 147px.

`text-[13px]` is one step up from the segment's usual `text-xs`. Without a track to lend it presence, 12px read as detached from the 14px row it belongs to. This is the one off-scale value in the diff and is easy to drop back to `text-xs` if reviewers prefer.

**Interaction is unchanged** — one click per variant, same `aria-label`, `aria-checked` and `aria-current` semantics.

`SegmentControl` itself is untouched. The overrides are applied at this call site only, exactly the way `MEDIA_MODEL_CATEGORY_SEGMENT_CLASS` already does it for the category switch, so every other segment control in the app keeps its default appearance.

## Design reference

Four directions were mocked at 1:1 against the real tokens and geometry; this PR implements the one that was picked (A). Comparison page, with the measured numbers per direction: https://model-variant-weight.sites.vm0.io

## Testing

- `chat-composer-model-selection-and-providers.test.tsx` already covers this control through the page — it asserts every variant radio's `aria-label`, text content and `aria-checked`, all of which this change preserves. No test needed updating.
- No new test: the change is Tailwind classes only, and `docs/testing/testing-external-behavior.md` excludes CSS-class assertions from the platform test boundary.
- Local checks could not run in this environment (no npm registry access, so dependencies are not installed); relying on the PR pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)