### PR TITLE
feat(monitoring): expose runner lifecycle metrics

### DIFF
--- a/.github/scripts/tests/vm0-runner-status-collect-test.sh
+++ b/.github/scripts/tests/vm0-runner-status-collect-test.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+script="$repo_root/ansible/files/vm0-runner-status-collect.py"
+playbook="$repo_root/ansible/playbooks/provision-monitoring.yml"
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+runners_dir="$tmp_root/runners"
+textfile_dir="$tmp_root/textfile"
+output_file="$textfile_dir/runner-status.prom"
+stderr_file="$tmp_root/stderr.log"
+
+uuid_a="00000000-0000-4000-8000-000000000001"
+uuid_b="00000000-0000-4000-8000-000000000002"
+uuid_c="00000000-0000-4000-8000-000000000003"
+uuid_d="00000000-0000-4000-8000-000000000004"
+uuid_e="00000000-0000-4000-8000-000000000005"
+uuid_f="00000000-0000-4000-8000-000000000006"
+uuid_g="00000000-0000-4000-8000-000000000007"
+uuid_h="00000000-0000-4000-8000-000000000008"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+reset_dirs() {
+  rm -rf "$runners_dir" "$textfile_dir" "$stderr_file"
+  mkdir -p "$textfile_dir"
+}
+
+run_collector() {
+  VM0_RUNNERS_DIR="$runners_dir" \
+    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir" \
+    python3 "$script" 2>"$stderr_file"
+
+  [ -f "$output_file" ] || fail "metrics output file was not created"
+}
+
+assert_line() {
+  local expected="$1"
+  grep -qxF "$expected" "$output_file" || fail "missing line: $expected"
+}
+
+assert_playbook_contains() {
+  local expected="$1"
+  grep -qF "$expected" "$playbook" || fail "playbook is missing: $expected"
+}
+
+assert_zero_snapshot() {
+  local state
+  local mode
+  local result
+
+  for state in active idle preparing unknown; do
+    assert_line "vm0_runner_sandboxes{state=\"$state\"} 0"
+  done
+  for mode in starting running draining stopping unknown; do
+    assert_line "vm0_runner_instances{mode=\"$mode\"} 0"
+  done
+  for result in included stopped invalid; do
+    assert_line "vm0_runner_status_files{result=\"$result\"} 0"
+  done
+  assert_line "vm0_runner_status_collection_success 1"
+}
+
+test_missing_and_empty_runner_roots_emit_zero_metrics() {
+  reset_dirs
+  run_collector
+  assert_zero_snapshot
+
+  mkdir -p "$runners_dir"
+  run_collector
+  assert_zero_snapshot
+}
+
+test_aggregates_current_legacy_and_future_statuses() {
+  reset_dirs
+  mkdir -p \
+    "$runners_dir/current" \
+    "$runners_dir/legacy" \
+    "$runners_dir/future" \
+    "$runners_dir/stopped"
+
+  cat >"$runners_dir/current/status.json" <<EOF
+{
+  "mode": "running",
+  "active_runs": [
+    {"sandbox_id": "$uuid_a", "phase": "running"},
+    {"sandbox_id": "$uuid_b", "phase": "preparing"},
+    {"sandbox_id": "$uuid_b", "phase": "waiting"},
+    {"sandbox_id": "$uuid_c", "phase": "waiting"},
+    {"sandbox_id": "$uuid_e", "phase": "running"},
+    {"sandbox_id": "$uuid_e", "phase": "preparing"}
+  ],
+  "idle_vms": [
+    {"sandbox_id": "$uuid_a", "reuse_key": "overlap"},
+    {"sandbox_id": "$uuid_d", "reuse_key": "idle"}
+  ]
+}
+EOF
+
+  cat >"$runners_dir/legacy/status.json" <<EOF
+{
+  "mode": "draining",
+  "active_runs": [
+    {"run_id": "legacy-run", "sandbox_id": "$uuid_f"},
+    {"run_id": "duplicate-idle", "sandbox_id": "$uuid_d"}
+  ],
+  "idle_vms": [
+    {"sandbox_id": "$uuid_g", "session_id": "legacy-session"}
+  ]
+}
+EOF
+
+  cat >"$runners_dir/future/status.json" <<EOF
+{
+  "mode": "paused",
+  "active_runs": [
+    {"sandbox_id": "$uuid_h", "phase": "running"}
+  ]
+}
+EOF
+
+  cat >"$runners_dir/stopped/status.json" <<'EOF'
+{
+  "mode": "stopped",
+  "active_runs": "ignored because the runner is stopped"
+}
+EOF
+
+  run_collector
+
+  assert_line 'vm0_runner_sandboxes{state="active"} 3'
+  assert_line 'vm0_runner_sandboxes{state="idle"} 3'
+  assert_line 'vm0_runner_sandboxes{state="preparing"} 1'
+  assert_line 'vm0_runner_sandboxes{state="unknown"} 1'
+  assert_line 'vm0_runner_instances{mode="running"} 1'
+  assert_line 'vm0_runner_instances{mode="draining"} 1'
+  assert_line 'vm0_runner_instances{mode="unknown"} 1'
+  assert_line 'vm0_runner_status_files{result="included"} 3'
+  assert_line 'vm0_runner_status_files{result="stopped"} 1'
+  assert_line 'vm0_runner_status_files{result="invalid"} 0'
+  assert_line 'vm0_runner_status_collection_success 1'
+  if grep -qE "sandbox_id|run_id|reuse_key|session_id|$uuid_a|legacy-run" \
+    "$output_file"; then
+    fail "identity-level data leaked into metrics"
+  fi
+}
+
+test_invalid_files_publish_partial_metrics() {
+  reset_dirs
+  mkdir -p \
+    "$runners_dir/valid" \
+    "$runners_dir/malformed-json" \
+    "$runners_dir/malformed-shape" \
+    "$runners_dir/invalid-id"
+
+  cat >"$runners_dir/valid/status.json" <<EOF
+{"mode":"starting","active_runs":[{"sandbox_id":"$uuid_a","phase":"preparing"}]}
+EOF
+  printf '{' >"$runners_dir/malformed-json/status.json"
+  printf '%s\n' '{"mode":"running","active_runs":{}}' \
+    >"$runners_dir/malformed-shape/status.json"
+  printf '%s\n' \
+    '{"mode":"running","idle_vms":[{"sandbox_id":"not-a-uuid"}]}' \
+    >"$runners_dir/invalid-id/status.json"
+
+  run_collector
+
+  assert_line 'vm0_runner_sandboxes{state="preparing"} 1'
+  assert_line 'vm0_runner_instances{mode="starting"} 1'
+  assert_line 'vm0_runner_status_files{result="included"} 1'
+  assert_line 'vm0_runner_status_files{result="invalid"} 3'
+  assert_line 'vm0_runner_status_collection_success 0'
+  grep -q 'malformed-json/status.json' "$stderr_file" ||
+    fail "malformed JSON diagnostic was not reported"
+  grep -q 'malformed-shape/status.json' "$stderr_file" ||
+    fail "malformed shape diagnostic was not reported"
+  grep -q 'invalid-id/status.json' "$stderr_file" ||
+    fail "invalid UUID diagnostic was not reported"
+}
+
+test_rejects_runner_and_status_symlinks() {
+  reset_dirs
+  mkdir -p "$runners_dir" "$tmp_root/outside-runner" "$runners_dir/status-link"
+  printf '%s\n' '{"mode":"running"}' >"$tmp_root/outside-runner/status.json"
+  ln -s "$tmp_root/outside-runner" "$runners_dir/runner-link"
+  ln -s "$tmp_root/outside-runner/status.json" \
+    "$runners_dir/status-link/status.json"
+
+  run_collector
+
+  assert_line 'vm0_runner_status_files{result="included"} 0'
+  assert_line 'vm0_runner_status_files{result="invalid"} 2'
+  assert_line 'vm0_runner_status_collection_success 0'
+  grep -q 'runner directory symlink' "$stderr_file" ||
+    fail "runner symlink diagnostic was not reported"
+  grep -q 'status file symlink' "$stderr_file" ||
+    fail "status symlink diagnostic was not reported"
+}
+
+test_output_is_deterministic_and_replaced_atomically() {
+  reset_dirs
+  mkdir -p "$runners_dir/current"
+  printf '%s\n' \
+    "{\"mode\":\"running\",\"idle_vms\":[{\"sandbox_id\":\"$uuid_a\"}]}" \
+    >"$runners_dir/current/status.json"
+  printf '%s\n' 'stale output' >"$output_file"
+
+  run_collector
+  cp "$output_file" "$tmp_root/first-output.prom"
+  run_collector
+
+  cmp -s "$tmp_root/first-output.prom" "$output_file" ||
+    fail "collector output changed between identical runs"
+  [ "$(stat -c '%a' "$output_file")" = "644" ] ||
+    fail "metrics output permissions are not 0644"
+  if find "$textfile_dir" -maxdepth 1 -name '.runner-status.prom.*' | grep -q .; then
+    fail "temporary metric files were not cleaned up"
+  fi
+  assert_line 'vm0_runner_sandboxes{state="idle"} 1'
+}
+
+test_missing_textfile_dir_fails() {
+  rm -rf "$runners_dir" "$textfile_dir"
+
+  if VM0_RUNNERS_DIR="$runners_dir" \
+    VM0_MONITORING_TEXTFILE_DIR="$textfile_dir" \
+    python3 "$script" 2>"$stderr_file"; then
+    fail "expected missing textfile directory to fail"
+  fi
+
+  grep -q 'missing textfile directory' "$stderr_file" ||
+    fail "missing textfile directory error was not reported"
+}
+
+test_playbook_provisions_independent_collector_cadence() {
+  assert_playbook_contains 'src: ../files/vm0-runner-status-collect.py'
+  assert_playbook_contains 'dest: /usr/local/bin/vm0-runner-status-collect'
+  assert_playbook_contains 'ExecStart=/usr/local/bin/vm0-runner-status-collect'
+  assert_playbook_contains 'dest: /etc/systemd/system/vm0-runner-status-collect.timer'
+  assert_playbook_contains 'OnUnitActiveSec=15s'
+  assert_playbook_contains 'AccuracySec=1s'
+  assert_playbook_contains 'OnUnitActiveSec=1min'
+}
+
+test_missing_and_empty_runner_roots_emit_zero_metrics
+test_aggregates_current_legacy_and_future_statuses
+test_invalid_files_publish_partial_metrics
+test_rejects_runner_and_status_symlinks
+test_output_is_deterministic_and_replaced_atomically
+test_missing_textfile_dir_fails
+test_playbook_provisions_independent_collector_cadence
+
+echo "vm0 runner status collector tests passed"

--- a/ansible/files/vm0-runner-status-collect.py
+++ b/ansible/files/vm0-runner-status-collect.py
@@ -1,0 +1,234 @@
+#!/usr/bin/python3
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import uuid
+from collections import Counter
+from pathlib import Path
+
+SANDBOX_STATES = ("active", "idle", "preparing", "unknown")
+RUNNER_MODES = ("starting", "running", "draining", "stopping", "unknown")
+STATUS_RESULTS = ("included", "stopped", "invalid")
+STATE_PRECEDENCE = {"unknown": 0, "preparing": 1, "active": 2, "idle": 3}
+
+
+class InvalidStatus(ValueError):
+    pass
+
+
+def parse_sandbox_entry(entry: object) -> tuple[dict[object, object], str]:
+    if not isinstance(entry, dict):
+        raise InvalidStatus("sandbox entry must be an object")
+
+    value = entry.get("sandbox_id")
+    if not isinstance(value, str):
+        raise InvalidStatus("sandbox_id must be a string")
+
+    try:
+        return entry, str(uuid.UUID(value))
+    except ValueError as error:
+        raise InvalidStatus("sandbox_id must be a UUID") from error
+
+
+def parse_collection(status: dict[object, object], field: str) -> list[object]:
+    value = status.get(field, [])
+    if not isinstance(value, list):
+        raise InvalidStatus(f"{field} must be an array")
+    return value
+
+
+def parse_status(path: Path) -> tuple[str, list[tuple[str, str]]]:
+    with path.open(encoding="utf-8") as status_file:
+        status: object = json.load(status_file)
+
+    if not isinstance(status, dict):
+        raise InvalidStatus("status must be an object")
+
+    mode = status.get("mode")
+    if not isinstance(mode, str) or not mode:
+        raise InvalidStatus("mode must be a non-empty string")
+
+    if mode == "stopped":
+        return mode, []
+
+    sandbox_states: list[tuple[str, str]] = []
+    for entry in parse_collection(status, "active_runs"):
+        active_run, sandbox_id = parse_sandbox_entry(entry)
+        if "phase" not in active_run:
+            state = "active"
+        else:
+            phase = active_run["phase"]
+            if not isinstance(phase, str):
+                raise InvalidStatus("active run phase must be a string")
+            state = {"running": "active", "preparing": "preparing"}.get(
+                phase, "unknown"
+            )
+        sandbox_states.append((sandbox_id, state))
+
+    for entry in parse_collection(status, "idle_vms"):
+        _, sandbox_id = parse_sandbox_entry(entry)
+        sandbox_states.append((sandbox_id, "idle"))
+
+    return mode, sandbox_states
+
+
+def record_state(states: dict[str, str], sandbox_id: str, state: str) -> None:
+    current = states.get(sandbox_id)
+    if current is None or STATE_PRECEDENCE[state] > STATE_PRECEDENCE[current]:
+        states[sandbox_id] = state
+
+
+def collect(
+    runners_dir: Path,
+) -> tuple[Counter[str], Counter[str], Counter[str], int]:
+    sandbox_states: dict[str, str] = {}
+    runner_modes: Counter[str] = Counter()
+    status_results: Counter[str] = Counter()
+    collection_success = 1
+
+    if runners_dir.is_symlink():
+        print(f"invalid runners directory symlink: {runners_dir}", file=sys.stderr)
+        return Counter(), runner_modes, status_results, 0
+
+    if not runners_dir.exists():
+        return Counter(), runner_modes, status_results, collection_success
+
+    if not runners_dir.is_dir():
+        print(f"invalid runners directory: {runners_dir}", file=sys.stderr)
+        return Counter(), runner_modes, status_results, 0
+
+    try:
+        runner_dirs = sorted(runners_dir.iterdir(), key=lambda path: path.name)
+    except OSError as error:
+        print(f"cannot scan runners directory {runners_dir}: {error}", file=sys.stderr)
+        return Counter(), runner_modes, status_results, 0
+
+    for runner_dir in runner_dirs:
+        if runner_dir.is_symlink():
+            print(f"invalid runner directory symlink: {runner_dir}", file=sys.stderr)
+            status_results["invalid"] += 1
+            collection_success = 0
+            continue
+        if not runner_dir.is_dir():
+            continue
+
+        status_path = runner_dir / "status.json"
+        if status_path.is_symlink():
+            print(f"invalid status file symlink: {status_path}", file=sys.stderr)
+            status_results["invalid"] += 1
+            collection_success = 0
+            continue
+        if not status_path.exists():
+            continue
+        if not status_path.is_file():
+            print(f"invalid status file: {status_path}", file=sys.stderr)
+            status_results["invalid"] += 1
+            collection_success = 0
+            continue
+
+        try:
+            mode, entries = parse_status(status_path)
+        except (OSError, UnicodeError, json.JSONDecodeError, InvalidStatus) as error:
+            print(f"invalid runner status {status_path}: {error}", file=sys.stderr)
+            status_results["invalid"] += 1
+            collection_success = 0
+            continue
+
+        if mode == "stopped":
+            status_results["stopped"] += 1
+            continue
+
+        status_results["included"] += 1
+        runner_modes[mode if mode in RUNNER_MODES else "unknown"] += 1
+        for sandbox_id, state in entries:
+            record_state(sandbox_states, sandbox_id, state)
+
+    return Counter(sandbox_states.values()), runner_modes, status_results, collection_success
+
+
+def render_metrics(
+    sandbox_states: Counter[str],
+    runner_modes: Counter[str],
+    status_results: Counter[str],
+    collection_success: int,
+) -> str:
+    lines = [
+        "# HELP vm0_runner_sandboxes Runner-managed sandboxes by lifecycle state.",
+        "# TYPE vm0_runner_sandboxes gauge",
+    ]
+    lines.extend(
+        f'vm0_runner_sandboxes{{state="{state}"}} {sandbox_states[state]}'
+        for state in SANDBOX_STATES
+    )
+    lines.extend(
+        [
+            "",
+            "# HELP vm0_runner_instances Live runner instances by lifecycle mode.",
+            "# TYPE vm0_runner_instances gauge",
+        ]
+    )
+    lines.extend(
+        f'vm0_runner_instances{{mode="{mode}"}} {runner_modes[mode]}'
+        for mode in RUNNER_MODES
+    )
+    lines.extend(
+        [
+            "",
+            "# HELP vm0_runner_status_files Runner status files by collection result.",
+            "# TYPE vm0_runner_status_files gauge",
+        ]
+    )
+    lines.extend(
+        f'vm0_runner_status_files{{result="{result}"}} {status_results[result]}'
+        for result in STATUS_RESULTS
+    )
+    lines.extend(
+        [
+            "",
+            "# HELP vm0_runner_status_collection_success Whether all runner "
+            "status inputs were collected successfully.",
+            "# TYPE vm0_runner_status_collection_success gauge",
+            f"vm0_runner_status_collection_success {collection_success}",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_metrics(textfile_dir: Path, metrics: str) -> None:
+    if not textfile_dir.is_dir():
+        raise FileNotFoundError(f"missing textfile directory: {textfile_dir}")
+
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=".runner-status.prom.", dir=textfile_dir
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            output.write(metrics)
+        temporary_path.chmod(0o644)
+        temporary_path.replace(textfile_dir / "runner-status.prom")
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def main() -> None:
+    runners_dir = Path(
+        os.environ.get("VM0_RUNNERS_DIR", "/var/lib/vm0-runner/runners")
+    )
+    textfile_dir = Path(
+        os.environ.get(
+            "VM0_MONITORING_TEXTFILE_DIR",
+            "/var/lib/vm0-monitoring/textfile-collector",
+        )
+    )
+
+    metrics = render_metrics(*collect(runners_dir))
+    write_metrics(textfile_dir, metrics)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible/files/vm0-runner-status-collect.py
+++ b/ansible/files/vm0-runner-status-collect.py
@@ -189,8 +189,7 @@ def render_metrics(
     lines.extend(
         [
             "",
-            "# HELP vm0_runner_status_collection_success Whether all runner "
-            "status inputs were collected successfully.",
+            "# HELP vm0_runner_status_collection_success Whether all runner status inputs were collected successfully.",
             "# TYPE vm0_runner_status_collection_success gauge",
             f"vm0_runner_status_collection_success {collection_success}",
         ]

--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -1,8 +1,8 @@
 # Provision Monitoring with Grafana Alloy
 #
 # Installs Grafana Alloy on bare metal hosts to collect system metrics
-# (via built-in prometheus.exporter.unix), workspace image cache textfile
-# metrics, and remote-write to Grafana Cloud.
+# (via built-in prometheus.exporter.unix), workspace image cache and runner
+# lifecycle textfile metrics, and remote-write to Grafana Cloud.
 #
 # Usage:
 #   ansible-playbook -i "host1,host2," playbooks/provision-monitoring.yml \
@@ -94,6 +94,15 @@
         mode: "0755"
       become: true
 
+    - name: Install VM0 runner status collector script
+      copy:
+        src: ../files/vm0-runner-status-collect.py
+        dest: /usr/local/bin/vm0-runner-status-collect
+        owner: root
+        group: root
+        mode: "0755"
+      become: true
+
     - name: Install VM0 monitoring collector service
       copy:
         content: |
@@ -104,6 +113,21 @@
           Type=oneshot
           ExecStart=/usr/local/bin/vm0-monitoring-collect
         dest: /etc/systemd/system/vm0-monitoring-collect.service
+        owner: root
+        group: root
+        mode: "0644"
+      become: true
+
+    - name: Install VM0 runner status collector service
+      copy:
+        content: |
+          [Unit]
+          Description=Collect VM0 runner lifecycle metrics
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/vm0-runner-status-collect
+        dest: /etc/systemd/system/vm0-runner-status-collect.service
         owner: root
         group: root
         mode: "0644"
@@ -129,6 +153,26 @@
         mode: "0644"
       become: true
 
+    - name: Install VM0 runner status collector timer
+      copy:
+        content: |
+          [Unit]
+          Description=Collect VM0 runner lifecycle metrics every 15 seconds
+
+          [Timer]
+          OnBootSec=15s
+          OnUnitActiveSec=15s
+          AccuracySec=1s
+          Persistent=true
+
+          [Install]
+          WantedBy=timers.target
+        dest: /etc/systemd/system/vm0-runner-status-collect.timer
+        owner: root
+        group: root
+        mode: "0644"
+      become: true
+
     - name: Generate initial VM0 host monitoring metrics
       systemd:
         name: vm0-monitoring-collect.service
@@ -137,9 +181,25 @@
       become: true
       changed_when: false
 
+    - name: Generate initial VM0 runner lifecycle metrics
+      systemd:
+        name: vm0-runner-status-collect.service
+        state: started
+        daemon_reload: true
+      become: true
+      changed_when: false
+
     - name: Enable VM0 monitoring collector timer
       systemd:
         name: vm0-monitoring-collect.timer
+        state: started
+        enabled: true
+        daemon_reload: true
+      become: true
+
+    - name: Enable VM0 runner status collector timer
+      systemd:
+        name: vm0-runner-status-collect.timer
         state: started
         enabled: true
         daemon_reload: true


### PR DESCRIPTION
## Summary

- add a standalone textfile collector that aggregates lifecycle state from all runner `status.json` files
- publish fixed-cardinality sandbox, runner mode, status-file, and collection-health gauges with legacy-schema compatibility and global sandbox deduplication
- provision an independent 15-second oneshot service and timer without changing the existing Firecracker process metric or one-minute workspace cache collector
- add real-filesystem integration coverage for current, legacy, overlapping, stopped, future, malformed, missing, and symlink inputs

## Scope

This PR provides data acquisition and Prometheus metric publication only. Grafana dashboards, PromQL panels, and alerts are intentionally deferred until the metrics are deployed and observed.

## Validation

- `python3 -c 'import ast, pathlib; ast.parse(pathlib.Path("ansible/files/vm0-runner-status-collect.py").read_text())'`
- `bash -n .github/scripts/tests/vm0-runner-status-collect-test.sh`
- `bash .github/scripts/tests/vm0-runner-status-collect-test.sh`
- `ansible-playbook -i 'localhost,' --syntax-check ansible/playbooks/provision-monitoring.yml`
- `ansible-playbook -i 'localhost,' --list-tasks ansible/playbooks/provision-monitoring.yml`
- `git diff --check`
- `lefthook run pre-commit`

Closes #28504
