### PR TITLE
feat(connectors): enable box oauth

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -308,6 +308,7 @@ runs:
           FIGMA
           DEEL
           DOCUSIGN
+          BOX
           DROPBOX
           NEON
           REDDIT

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -227,6 +227,8 @@ assert_env_value "$success_env_file" GH_OAUTH_CLIENT_ID "doppler-GH_OAUTH_CLIENT
 assert_env_value "$success_env_file" GH_OAUTH_CLIENT_SECRET "doppler-GH_OAUTH_CLIENT_SECRET"
 assert_env_value "$success_env_file" SLACK_OAUTH_CLIENT_ID "doppler-SLACK_OAUTH_CLIENT_ID"
 assert_env_value "$success_env_file" SLACK_OAUTH_CLIENT_SECRET "doppler-SLACK_OAUTH_CLIENT_SECRET"
+assert_env_value "$success_env_file" BOX_OAUTH_CLIENT_ID "doppler-BOX_OAUTH_CLIENT_ID"
+assert_env_value "$success_env_file" BOX_OAUTH_CLIENT_SECRET "doppler-BOX_OAUTH_CLIENT_SECRET"
 assert_env_value "$success_env_file" QUICKBOOKS_OAUTH_CLIENT_ID "doppler-QUICKBOOKS_OAUTH_CLIENT_ID"
 assert_env_value "$success_env_file" QUICKBOOKS_OAUTH_CLIENT_SECRET "doppler-QUICKBOOKS_OAUTH_CLIENT_SECRET"
 assert_env_value "$success_env_file" TIKTOK_ADS_OAUTH_CLIENT_ID "doppler-TIKTOK_ADS_OAUTH_CLIENT_ID"

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -11,6 +11,7 @@ import {
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.BoxConnector, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.TeamsIntegration, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.JoggAiBuiltIn, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.MetaAdsConnector, {})).toBe(true);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -61,7 +61,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.BoxConnector]: {
     maintainer: "yuma@vm0.ai",
     description: "Enable the Box file storage connector",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.CanvaConnector]: {
     maintainer: "yuma@vm0.ai",


### PR DESCRIPTION
## Summary

- enable the Box OAuth connector globally
- inject Box OAuth client credentials from Doppler into Web/API deployment environments
- cover the Box OAuth environment values in the shared CI renderer test

## Operational verification

- confirmed `BOX_OAUTH_CLIENT_ID` and `BOX_OAUTH_CLIENT_SECRET` are present in both Doppler `dev` and `prd`
- confirmed Box accepts `https://app.vm0.ai/connectors/box/callback`; an unregistered control URL returns `redirect_uri_mismatch`

## Verification

- `bash .github/scripts/tests/web-api-env-action-test.sh`
- `npx --yes prettier@3.8.1 --check .github/actions/web-api-env/action.yml turbo/packages/core/src/feature-switch.ts turbo/packages/core/src/__tests__/feature-switch.test.ts`
- `cd turbo && pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts`
- `cd turbo && pnpm -F @okouai/core check-types`
- `cd turbo && pnpm -F @okouai/core lint`
