### PR TITLE
test(python): cover usage-free conflicting websocket terminal ids

### DIFF
--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
@@ -958,6 +958,66 @@ class TestModelProviderWebSocketPrewarmUsage:
             entry.get("disposition") == "ignored" for entry in model_usage_source_entries(flow)
         )
 
+    def test_model_websocket_usage_free_conflicting_terminal_id_fails_open(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+        sensitive_marker = "conflicting-terminal-sensitive-marker"
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(
+                flow,
+                _openai_websocket_created_frame("warm-active"),
+            )
+            feed_websocket_server_message(
+                flow,
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "other-response",
+                            "output": [
+                                {
+                                    "type": "message",
+                                    "content": [{"type": "output_text", "text": sensitive_marker}],
+                                }
+                            ],
+                        },
+                    }
+                ).encode(),
+            )
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame(
+                    "warm-active",
+                    input_tokens=17,
+                    output_tokens=0,
+                ),
+            )
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [("gpt-5.5", "tokens.input", 17)]
+        assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+        assert not any(
+            entry.get("disposition") == "ignored" for entry in model_usage_source_entries(flow)
+        )
+        correlation_entries = _correlation_entries(flow)
+        assert len(correlation_entries) == 1
+        assert correlation_entries[0]["reason"] == "invalid_lifecycle"
+        assert sensitive_marker not in json.dumps(correlation_entries)
+
     def test_model_websocket_malformed_client_frame_retires_unbound_prewarm(
         self,
         tmp_path,


### PR DESCRIPTION
## Summary

- add a full-pipeline regression test for a usage-free terminal event whose response ID conflicts with an active OpenAI Responses WebSocket prewarm response
- verify later billable usage for the active response is reported by both provider and model-observation pipelines and is never marked ignored
- verify the fail-open transition emits exactly one content-free `invalid_lifecycle` correlation diagnostic

## Scope

- test-only change in the mitm-addon package
- no production logic, protocol, API, dependency, schema, migration, or deployment behavior changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_model_provider_websocket_prewarm.py` (28 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (6433 passed)

Closes #28475
