### PR TITLE
feat(composer): offer one model per family in the media pickers

### DIFF
--- a/turbo/apps/api/src/signals/services/video-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/video-generation.service.ts
@@ -661,14 +661,12 @@ function normalizeVideoModel(value: string): VideoModel | null {
   return null;
 }
 
+// Every catalog model is accepted here, so the hint names them all. `public`
+// only decides which of them the composer picker offers.
 function videoModelList(): string {
-  return VIDEO_MODELS.filter((model) => {
-    return VIDEO_MODEL_CONFIGS[model].public;
-  })
-    .map((model) => {
-      return VIDEO_MODEL_CONFIGS[model].alias;
-    })
-    .join(", ");
+  return VIDEO_MODELS.map((model) => {
+    return VIDEO_MODEL_CONFIGS[model].alias;
+  }).join(", ");
 }
 
 export function videoProviderForModel(model: VideoModel): VideoProvider {

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -4607,7 +4607,6 @@
         "loadError": "Modelle können nicht geladen werden.",
         "loading": "Modelle werden geladen...",
         "models": "Modelle",
-        "modelVariants": "Varianten von {{model}}",
         "noConfiguredModels": "Keine konfigurierten Modelle",
         "priceTiers": {
           "balanced": "Ausgewogene Kosten und Leistung",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -4607,7 +4607,6 @@
         "loadError": "Unable to load models.",
         "loading": "Loading models...",
         "models": "Models",
-        "modelVariants": "{{model}} variants",
         "noConfiguredModels": "No configured models",
         "priceTiers": {
           "balanced": "Balanced cost and performance",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -4657,7 +4657,6 @@
         "loadError": "No se pudieron cargar los modelos.",
         "loading": "Cargando modelos...",
         "models": "Modelos",
-        "modelVariants": "Variantes de {{model}}",
         "noConfiguredModels": "Sin modelos configurados",
         "priceTiers": {
           "balanced": "Coste y rendimiento equilibrados",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -4657,7 +4657,6 @@
         "loadError": "Impossible de charger les modèles.",
         "loading": "Chargement des modèles...",
         "models": "Modèles",
-        "modelVariants": "Variantes de {{model}}",
         "noConfiguredModels": "Aucun modèle configuré",
         "priceTiers": {
           "balanced": "Coût et performance équilibrés",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -4607,7 +4607,6 @@
         "loadError": "मॉडल लोड करने में असमर्थ.",
         "loading": "मॉडल लोड हो रहे हैं...",
         "models": "मॉडल",
-        "modelVariants": "{{model}} के वेरिएंट",
         "noConfiguredModels": "कोई कॉन्फ़िगर मॉडल नहीं",
         "priceTiers": {
           "balanced": "संतुलित लागत और प्रदर्शन",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -4606,7 +4606,6 @@
         "loadError": "Tidak dapat memuat model.",
         "loading": "Memuat model...",
         "models": "Model",
-        "modelVariants": "Varian {{model}}",
         "noConfiguredModels": "Tidak ada model yang dikonfigurasi",
         "priceTiers": {
           "balanced": "Biaya dan performa seimbang",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -4657,7 +4657,6 @@
         "loadError": "Impossibile caricare i modelli.",
         "loading": "Caricamento modelli...",
         "models": "Modelli",
-        "modelVariants": "Varianti di {{model}}",
         "noConfiguredModels": "Nessun modello configurato",
         "priceTiers": {
           "balanced": "Costo e prestazioni equilibrati",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -4606,7 +4606,6 @@
         "loadError": "モデルをロードできません。",
         "loading": "モデルをロード中...",
         "models": "モデル",
-        "modelVariants": "{{model}} のバリエーション",
         "noConfiguredModels": "設定されたモデルはありません",
         "priceTiers": {
           "balanced": "バランスの取れたコストとパフォーマンス",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -4606,7 +4606,6 @@
         "loadError": "모델을 불러올 수 없습니다.",
         "loading": "모델 불러오는 중...",
         "models": "모델",
-        "modelVariants": "{{model}} 변형",
         "noConfiguredModels": "구성된 모델 없음",
         "priceTiers": {
           "balanced": "비용과 성능의 균형",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -4657,7 +4657,6 @@
         "loadError": "Não foi possível carregar os modelos.",
         "loading": "Carregando modelos...",
         "models": "Modelos",
-        "modelVariants": "Variantes de {{model}}",
         "noConfiguredModels": "Nenhum modelo configurado",
         "priceTiers": {
           "balanced": "Custo e desempenho equilibrados",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -4063,15 +4063,6 @@ describe("chat composer image model", () => {
     expect(within(listbox).queryByText("Flux Pro v1.1 Ultra")).toBeNull();
     expect(within(listbox).queryByText("Seedream 5 Lite")).toBeNull();
     expect(within(listbox).queryByText("Qwen Image")).toBeNull();
-    // No row carries a variant segment any more, so the only radios left in the
-    // list are the category tabs.
-    expect(
-      queryAllByRoleFast("radio", listbox).filter((candidate) => {
-        // Exclude category-tab radios: their grandparent wrapper has .sticky.
-        const el = candidate as HTMLElement;
-        return !el.parentElement?.parentElement?.classList.contains("sticky");
-      }),
-    ).toStrictEqual([]);
     const openAiIcon = imageModelBrandIcon("GPT Image 2").outerHTML;
     expect(openAiIcon).toContain("openai");
     expect(imageModelBrandIcon("GPT Image 1").outerHTML).toBe(openAiIcon);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -3568,37 +3568,10 @@ describe("chat composer image model", () => {
   function selectedImageModelLabel(
     root: ParentNode = document,
   ): string | undefined {
-    // Every family segment fills one variant by default, so a checked radio no
-    // longer proves selection. `aria-current` marks the one row that is truly
-    // selected -- the same cue the checkmark gives sighted users. A family row
-    // then names the exact variant from its checked segment, and a plain row
-    // carries the label itself.
+    // `aria-current` marks the selected row -- the same cue the checkmark gives
+    // sighted users.
     const selected = root.querySelector("[aria-current='true']");
-    if (!selected) {
-      return undefined;
-    }
-    const checkedVariant = Array.from(
-      selected.querySelectorAll("[role='radio']"),
-    ).find((candidate) => {
-      return candidate.getAttribute("aria-checked") === "true";
-    });
-    return (checkedVariant ?? selected).getAttribute("aria-label") ?? undefined;
-  }
-
-  function imageVariantSegment(label: string): HTMLElement | undefined {
-    return queryAllByRoleFast("radio").find((candidate) => {
-      return candidate.getAttribute("aria-label") === label;
-    });
-  }
-
-  function findImageVariantSegment(label: string): Promise<HTMLElement> {
-    return waitFor(() => {
-      const item = imageVariantSegment(label);
-      if (!item) {
-        throw new Error(`${label} image variant not found`);
-      }
-      return item;
-    });
+    return selected?.getAttribute("aria-label") ?? undefined;
   }
 
   function imageModelBrandIcon(label: string): Element {
@@ -3615,7 +3588,7 @@ describe("chat composer image model", () => {
     const initialPreference: UserModelPreferenceResponse = {
       selectedModel: null,
       serviceTier: null,
-      selectedImageModel: "fal-ai/qwen-image",
+      selectedImageModel: "fal-ai/nano-banana-2",
       updatedAt: "2026-08-18T00:00:00Z",
     };
     let createdImageModel: string | undefined;
@@ -3637,7 +3610,7 @@ describe("chat composer image model", () => {
 
     await openImageModels(user);
     await waitFor(() => {
-      expect(selectedImageModelLabel()).toBe("Qwen Image");
+      expect(selectedImageModelLabel()).toBe("Nano Banana 2");
     });
 
     context.mocks.data.userModelPreference({
@@ -3684,7 +3657,7 @@ describe("chat composer image model", () => {
     context.mocks.data.userModelPreference({
       selectedModel: null,
       serviceTier: null,
-      selectedImageModel: "fal-ai/qwen-image",
+      selectedImageModel: "fal-ai/nano-banana-2",
       selectedVideoModel: "MiniMax-H3",
       updatedAt: "2026-08-18T00:00:00Z",
     });
@@ -3719,7 +3692,7 @@ describe("chat composer image model", () => {
     await user.click(await findComposerModel("Claude Fable 5"));
     await user.click(await findCategoryTab("Image"));
     expect(
-      screen.queryByText("Temporarily switched to Qwen Image for images"),
+      screen.queryByText("Temporarily switched to Nano Banana 2 for images"),
     ).not.toBeInTheDocument();
     await user.click(await findMediaPanelButton("GPT Image 2"));
 
@@ -3757,10 +3730,9 @@ describe("chat composer image model", () => {
     });
     await user.click(await findComposerModel("Claude Fable 5"));
     await user.click(await findCategoryTab("Image"));
-    await expect(findMediaPanelButton("Qwen Image")).resolves.toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    await expect(
+      findMediaPanelButton("Nano Banana 2"),
+    ).resolves.toHaveAttribute("aria-pressed", "true");
     expect(updates).toStrictEqual([]);
   });
 
@@ -3774,7 +3746,7 @@ describe("chat composer image model", () => {
     context.mocks.data.userModelPreference({
       selectedModel: null,
       serviceTier: null,
-      selectedImageModel: "fal-ai/qwen-image",
+      selectedImageModel: "fal-ai/nano-banana-2",
       selectedVideoModel: "MiniMax-H3",
       updatedAt: "2026-08-18T00:00:00Z",
     });
@@ -3831,7 +3803,7 @@ describe("chat composer image model", () => {
     let stored: UserModelPreferenceResponse = {
       selectedModel: "claude-fable-5",
       serviceTier: null,
-      selectedImageModel: "fal-ai/qwen-image",
+      selectedImageModel: "fal-ai/nano-banana-2",
       selectedVideoModel: "MiniMax-H3",
       updatedAt: "2026-08-18T00:00:00Z",
     };
@@ -3919,7 +3891,7 @@ describe("chat composer image model", () => {
     context.mocks.data.userModelPreference({
       selectedModel: "claude-fable-5",
       serviceTier: null,
-      selectedImageModel: "fal-ai/qwen-image",
+      selectedImageModel: "fal-ai/nano-banana-2",
       selectedVideoModel: "MiniMax-H3",
       updatedAt: "2026-08-18T00:00:00Z",
     });
@@ -3998,7 +3970,7 @@ describe("chat composer image model", () => {
     context.mocks.data.userModelPreference({
       selectedModel: null,
       serviceTier: null,
-      selectedImageModel: "fal-ai/qwen-image",
+      selectedImageModel: "fal-ai/nano-banana-2",
       updatedAt: "2026-08-18T00:00:00Z",
     });
     context.mocks.api(
@@ -4053,7 +4025,7 @@ describe("chat composer image model", () => {
       selectedModel: null,
       serviceTier: null,
       selectedVideoModel: null,
-      selectedImageModel: "fal-ai/qwen-image",
+      selectedImageModel: "fal-ai/nano-banana-2",
       updatedAt: "2026-08-18T00:00:00Z",
     });
     mockAgent();
@@ -4083,79 +4055,42 @@ describe("chat composer image model", () => {
 
     expect(imageTab).toHaveAttribute("aria-checked", "true");
     await waitFor(() => {
-      expect(selectedImageModelLabel()).toBe("Qwen Image");
+      expect(selectedImageModelLabel()).toBe("Nano Banana 2");
     });
     const listbox = screen.getByRole("listbox");
-    // Both variants are on the row at once, and neither is marked while a
-    // different family is the selection.
-    const variantSegments = queryAllByRoleFast("radio", listbox)
-      .filter((candidate) => {
-        return candidate.hasAttribute("aria-label");
-      })
-      .filter((candidate) => {
+    // One row per family: the secondary variants and Qwen stay generatable by
+    // alias but are no longer offered as a choice here.
+    expect(within(listbox).queryByText("Flux Pro v1.1 Ultra")).toBeNull();
+    expect(within(listbox).queryByText("Seedream 5 Lite")).toBeNull();
+    expect(within(listbox).queryByText("Qwen Image")).toBeNull();
+    // No row carries a variant segment any more, so the only radios left in the
+    // list are the category tabs.
+    expect(
+      queryAllByRoleFast("radio", listbox).filter((candidate) => {
         // Exclude category-tab radios: their grandparent wrapper has .sticky.
         const el = candidate as HTMLElement;
         return !el.parentElement?.parentElement?.classList.contains("sticky");
-      });
-    expect(
-      variantSegments.map((candidate) => {
-        return candidate.getAttribute("aria-label");
       }),
-    ).toStrictEqual([
-      "Flux Pro v1.1",
-      "Flux Pro v1.1 Ultra",
-      "Seedream 5 Pro",
-      "Seedream 5 Lite",
-    ]);
-    expect(
-      variantSegments.map((candidate) => {
-        return candidate.textContent;
-      }),
-    ).toStrictEqual(["Standard", "Ultra", "Pro", "Lite"]);
-    // Qwen is the selection, so no family carries the checkmark, yet each
-    // segment still fills its base variant so the control never reads as empty.
-    expect(
-      variantSegments
-        .filter((candidate) => {
-          return candidate.getAttribute("aria-checked") === "true";
-        })
-        .map((candidate) => {
-          return candidate.getAttribute("aria-label");
-        }),
-    ).toStrictEqual(["Flux Pro v1.1", "Seedream 5 Pro"]);
-    expect(within(listbox).queryByText("Flux Pro v1.1 Ultra")).toBeNull();
-    expect(within(listbox).queryByText("Seedream 5 Lite")).toBeNull();
+    ).toStrictEqual([]);
     const openAiIcon = imageModelBrandIcon("GPT Image 2").outerHTML;
     expect(openAiIcon).toContain("openai");
     expect(imageModelBrandIcon("GPT Image 1").outerHTML).toBe(openAiIcon);
     const fluxIcon = imageModelBrandIcon("Flux Pro v1.1").outerHTML;
-    const qwenIcon = imageModelBrandIcon("Qwen Image").outerHTML;
-    expect(qwenIcon).toContain("image-model-qwen-gradient");
     const nanoBananaIcon = imageModelBrandIcon("Nano Banana 2").outerHTML;
     expect(nanoBananaIcon).toContain("#f94543");
     expect(
       new Set([
         openAiIcon,
         fluxIcon,
-        qwenIcon,
-        imageModelBrandIcon("Seedream 5").outerHTML,
+        imageModelBrandIcon("Seedream 5 Pro").outerHTML,
         nanoBananaIcon,
       ]).size,
-    ).toBe(5);
+    ).toBe(4);
     expect(within(listbox).queryByText(/birefnet/i)).not.toBeInTheDocument();
     expect(
       within(listbox).queryByText(/clarity upscaler/i),
     ).not.toBeInTheDocument();
     expect(within(listbox).queryByText("BYOK")).not.toBeInTheDocument();
-    // "Pro" is a Seedream 5 variant chip here, so the run-model price tier is
-    // ruled out by role rather than by the bare word.
-    expect(
-      within(listbox)
-        .queryAllByText("Pro")
-        .filter((candidate) => {
-          return candidate.role !== "radio";
-        }),
-    ).toStrictEqual([]);
     expect(
       within(listbox).queryByText(/aspect ratio/i),
     ).not.toBeInTheDocument();
@@ -4178,14 +4113,14 @@ describe("chat composer image model", () => {
       "aria-pressed",
       "true",
     );
-    expect(mediaPanelButton("Qwen Image")).toHaveAttribute(
+    expect(mediaPanelButton("Nano Banana 2")).toHaveAttribute(
       "aria-pressed",
       "false",
     );
     updateGate.resolve();
   });
 
-  it("selects Flux and Seedream 5 variants from their family rows", async () => {
+  it("selects the one model each family offers", async () => {
     const user = userEvent.setup({ delay: null });
     const updates: { threadId: string; model: string | null }[] = [];
     context.mocks.browser.matchMedia(true);
@@ -4209,46 +4144,38 @@ describe("chat composer image model", () => {
       path: `/chats/${THREAD_ID}`,
     });
 
-    // The family row carries the shared name; the variant name lives on the
-    // segment, so picking Lite is one click rather than a drill-in.
+    // Each family is one row naming the exact model it pins, so picking it is
+    // a single click with no variant step in between.
     await openImageModels(user);
-    await user.click(await findImageVariantSegment("Seedream 5 Lite"));
+    await user.click(await findMediaPanelButton("Seedream 5 Pro"));
 
     await waitFor(() => {
       expect(updates).toStrictEqual([
-        { threadId: THREAD_ID, model: "seedream-5-0-lite-260128" },
+        { threadId: THREAD_ID, model: "dola-seedream-5-0-pro-260628" },
       ]);
     });
     // Any click closes the popover, so the follow-up read reopens it.
     await openImageModels(user);
     await waitFor(() => {
-      expect(selectedImageModelLabel()).toBe("Seedream 5 Lite");
+      expect(selectedImageModelLabel()).toBe("Seedream 5 Pro");
     });
-    expect(mediaPanelButton("Seedream 5")).toHaveAttribute(
-      "aria-pressed",
-      "false",
-    );
 
-    await user.click(await findImageVariantSegment("Flux Pro v1.1 Ultra"));
+    await user.click(await findMediaPanelButton("Flux Pro v1.1"));
 
     await waitFor(() => {
       expect(updates).toStrictEqual([
-        { threadId: THREAD_ID, model: "seedream-5-0-lite-260128" },
-        { threadId: THREAD_ID, model: "fal-ai/flux-pro/v1.1-ultra" },
+        { threadId: THREAD_ID, model: "dola-seedream-5-0-pro-260628" },
+        { threadId: THREAD_ID, model: "fal-ai/flux-pro/v1.1" },
       ]);
     });
     await openImageModels(user);
     await waitFor(() => {
-      expect(selectedImageModelLabel()).toBe("Flux Pro v1.1 Ultra");
+      expect(selectedImageModelLabel()).toBe("Flux Pro v1.1");
     });
-    // Seedream 5 is no longer the selection, so its segment falls back to the
-    // filled base (Pro) rather than holding the Lite picked earlier.
-    await expect(
-      findImageVariantSegment("Seedream 5 Pro"),
-    ).resolves.toHaveAttribute("aria-checked", "true");
-    await expect(
-      findImageVariantSegment("Seedream 5 Lite"),
-    ).resolves.toHaveAttribute("aria-checked", "false");
+    expect(mediaPanelButton("Seedream 5 Pro")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
   });
 
   it("shows no selection when the pinned model is no longer offered", async () => {
@@ -4271,16 +4198,13 @@ describe("chat composer image model", () => {
 
     await openImageModels(user);
     await waitFor(() => {
-      expect(mediaPanelButton("Qwen Image")).toBeInTheDocument();
+      expect(mediaPanelButton("Seedream 5 Pro")).toBeInTheDocument();
     });
     const listbox = screen.getByRole("listbox");
-    // Nothing claims the pin, so no row is current and every family shows its
-    // default base chip rather than a stale highlight.
+    // Nothing claims the pin, so no row is current rather than one of the
+    // offered models carrying a stale highlight.
     expect(selectedImageModelLabel()).toBeUndefined();
     expect(listbox.querySelector("[aria-current='true']")).toBeNull();
-    await expect(
-      findImageVariantSegment("Seedream 5 Pro"),
-    ).resolves.toHaveAttribute("aria-checked", "true");
   });
 
   it("switches category from the same strip on mobile", async () => {
@@ -4318,7 +4242,7 @@ describe("chat composer image model", () => {
       "aria-pressed",
       "true",
     );
-    expect(mediaPanelButton("Seedream 5")).toBeInTheDocument();
+    expect(mediaPanelButton("Seedream 5 Pro")).toBeInTheDocument();
 
     await user.click(await findCategoryTab("Chat"));
 
@@ -4349,7 +4273,7 @@ describe("chat composer image model", () => {
         agentId: AGENT_ID,
         title: "Second image thread",
         selectedModel: "claude-fable-5",
-        selectedImageModel: "fal-ai/qwen-image",
+        selectedImageModel: "fal-ai/nano-banana-2",
       },
     ]);
     context.mocks.api(
@@ -4398,7 +4322,7 @@ describe("chat composer image model", () => {
 
     await openImageModels(user, secondThread);
     await waitFor(() => {
-      expect(selectedImageModelLabel()).toBe("Qwen Image");
+      expect(selectedImageModelLabel()).toBe("Nano Banana 2");
     });
   });
 });
@@ -4420,24 +4344,13 @@ describe("chat composer video model", () => {
 
   /**
    * The composer no longer prints the video model, so the selection is read
-   * from the open panel: a plain row carries `aria-pressed`, while Seedance 2.0
-   * marks the choice on its variant segment instead.
+   * from the open panel's pressed row.
    */
   function selectedVideoModelLabel(): string | undefined {
     const row = queryAllByRoleFast("button").find((candidate) => {
       return candidate.getAttribute("aria-pressed") === "true";
     });
-    if (row) {
-      return row.getAttribute("aria-label") ?? undefined;
-    }
-    const variant = queryAllByRoleFast("radio").find((candidate) => {
-      return (
-        candidate.getAttribute("aria-checked") === "true" &&
-        candidate.hasAttribute("aria-label") &&
-        candidate.textContent?.trim()
-      );
-    });
-    return variant?.getAttribute("aria-label") ?? undefined;
+    return row?.getAttribute("aria-label") ?? undefined;
   }
 
   function videoPanelButton(label: string): HTMLElement | undefined {
@@ -4453,22 +4366,6 @@ describe("chat composer video model", () => {
         throw new Error(`${label} button not found`);
       }
       return button;
-    });
-  }
-
-  function videoVariantSegment(label: string): HTMLElement | undefined {
-    return queryAllByRoleFast("radio").find((candidate) => {
-      return candidate.getAttribute("aria-label") === label;
-    });
-  }
-
-  function findVideoVariantSegment(label: string): Promise<HTMLElement> {
-    return waitFor(() => {
-      const item = videoVariantSegment(label);
-      if (!item) {
-        throw new Error(`${label} video variant not found`);
-      }
-      return item;
     });
   }
 
@@ -4690,20 +4587,14 @@ describe("chat composer video model", () => {
     expect(videoPanelButton("Veo 3.1 fast")).toBeInTheDocument();
     expect(videoPanelButton("Kling v3 4K")).toBeInTheDocument();
     expect(videoPanelButton("MiniMax H3")).toBeInTheDocument();
-    // The three Seedance 2.0 siblings collapse onto one row's segment.
+    // Seedance 2.0 is one row for the Standard model; its Fast and Mini
+    // siblings stay generatable by alias but are no longer offered here.
+    expect(videoPanelButton("Seedance 2.0")).toBeInTheDocument();
     expect(videoPanelButton("Seedance 2.0 fast")).toBeUndefined();
     expect(videoPanelButton("Seedance 2.0 Mini")).toBeUndefined();
-    const variantSegments = queryAllByRoleFast("radio").filter((candidate) => {
-      return (
-        candidate.hasAttribute("aria-label") && candidate.textContent?.trim()
-      );
-    });
-    expect(
-      variantSegments.map((candidate) => {
-        return candidate.textContent;
-      }),
-    ).toStrictEqual(["Standard", "Fast", "Mini"]);
-    expect(selectedVideoModelLabel()).toBe("Seedance 2.0 fast");
+    // The system default is still Seedance 2.0 fast, which the picker no longer
+    // offers, so no row claims the untouched thread.
+    expect(selectedVideoModelLabel()).toBeUndefined();
 
     await user.click(await findVideoPanelButton("Veo 3.1 fast"));
 
@@ -4805,25 +4696,10 @@ describe("chat composer video model", () => {
     expect(videoPanelButton("MiniMax H3")).toBeUndefined();
     await user.click(await findCategoryTab("Video"));
 
-    // All three siblings sit on the row, so the pick is a single click.
-    expect(
-      queryAllByRoleFast("radio")
-        .filter((candidate) => {
-          return (
-            candidate.hasAttribute("aria-label") &&
-            candidate.textContent?.trim()
-          );
-        })
-        .map((candidate) => {
-          return candidate.getAttribute("aria-label");
-        }),
-    ).toStrictEqual(["Seedance 2.0", "Seedance 2.0 fast", "Seedance 2.0 Mini"]);
-    await user.click(await findVideoVariantSegment("Seedance 2.0 fast"));
+    await user.click(await findVideoPanelButton("Seedance 2.0"));
 
     await waitFor(() => {
-      expect(bodies).toStrictEqual([
-        { model: "dreamina-seedance-2-0-fast-260128" },
-      ]);
+      expect(bodies).toStrictEqual([{ model: "dreamina-seedance-2-0-260128" }]);
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -77,29 +77,12 @@ export interface ModelProviderSelection {
   codexServiceTier?: CodexServiceTier;
 }
 
-/**
- * Sibling variants of one model family (GPT Image 1 Standard/Mini, Seedance 2.0
- * Standard/Fast/Mini). They render as a segment control on the model's own row:
- * every variant stays visible, one click is a complete selection, and nothing
- * overlays the rest of the list the way a nested menu did.
- */
-interface MediaModelPanelVariantControl {
-  readonly label: string;
-  readonly options: readonly {
-    readonly label: string;
-    readonly chipLabel: string;
-    readonly selected: boolean;
-    readonly onSelect: () => void;
-  }[];
-}
-
 export interface MediaModelPanelOption {
   readonly key: string;
   readonly label: string;
   readonly icon: ReactNode;
   readonly selected: boolean;
   readonly onSelect: () => void;
-  readonly variant?: MediaModelPanelVariantControl;
 }
 
 export type MediaModelCategoryId = "image" | "video";
@@ -1025,75 +1008,6 @@ export function VideoModelBrandIcon({ model }: { model: VideoModel }) {
 }
 
 function MediaModelPanelRow({ option }: { option: MediaModelPanelOption }) {
-  if (option.variant) {
-    const variant = option.variant;
-    const groupSelected =
-      option.selected ||
-      variant.options.some((candidate) => {
-        return candidate.selected;
-      });
-    const selectedVariant = variant.options.find((candidate) => {
-      return candidate.selected;
-    });
-    // A segment control reads as "one of these", so a family that is not the
-    // active model still fills its base variant instead of leaving the whole
-    // segment blank. The checkmark, gated on `groupSelected`, is what marks a
-    // real selection.
-    const highlightedVariant = selectedVariant ?? variant.options[0];
-    return (
-      // The segment is `xs` (h-7), so this row drops to `py-0.5` to land on the
-      // same 32px as the plain rows around it -- `py-1.5` would make the one row
-      // that carries variants 8px taller than its neighbours.
-      <div
-        // The segment always fills one variant, so its checked state no longer
-        // separates the active family from a default fill. `aria-current` is
-        // what the checkmark means, so assistive technology gets the same
-        // "this is the current model" cue sighted users get from the check.
-        // `aria-pressed` on the label button keeps its narrower meaning: the
-        // base model specifically, not the family.
-        aria-current={groupSelected ? "true" : undefined}
-        className="relative flex w-full select-none items-center gap-2 rounded-lg py-0.5 pl-2 pr-8 text-sm transition-colors hover:bg-state-hover hover:text-accent-foreground"
-      >
-        <button
-          type="button"
-          aria-label={option.label}
-          aria-pressed={option.selected}
-          className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-lg text-left outline-none"
-          onClick={option.onSelect}
-        >
-          {option.icon}
-          <span className="min-w-0 flex-1 truncate">{option.label}</span>
-        </button>
-        <SegmentControl
-          size="xs"
-          aria-label={variant.label}
-          value={highlightedVariant?.label ?? null}
-          onValueChange={(next: string | null) => {
-            variant.options
-              .find((candidate) => {
-                return candidate.label === next;
-              })
-              ?.onSelect();
-          }}
-        >
-          {variant.options.map((candidate) => {
-            return (
-              <SegmentControlItem
-                key={candidate.label}
-                value={candidate.label}
-                aria-label={candidate.label}
-              >
-                {candidate.chipLabel}
-              </SegmentControlItem>
-            );
-          })}
-        </SegmentControl>
-        {groupSelected && (
-          <Check size={15} className="absolute right-2 text-foreground" />
-        )}
-      </div>
-    );
-  }
   return (
     <button
       type="button"
@@ -1245,14 +1159,13 @@ function ModelFirstModelPickerContentLayout({
     <SelectContent
       className={cn(
         mediaModelPanel
-          ? // Wide enough for the longest row this popover has to render: a
-            // model name beside a three-up variant segment (Seedance 2.0 with
-            // Standard/Fast/Mini). One width for every category, so switching
-            // tabs never resizes the popover. The 294px bordered cap leaves a
-            // 292px scroll viewport: enough for the compact header and seven
-            // model rows, while an eighth adds one 32px row plus its 4px gap.
-            // The max-width only bites below a 348px viewport, where 332px
-            // would otherwise run past the screen edge.
+          ? // One width for every category, so switching tabs never resizes the
+            // popover: it is sized for the chat rows, which carry a provider
+            // label and a price tier badge beside the model name. The 294px
+            // bordered cap leaves a 292px scroll viewport: enough for the
+            // compact header and seven model rows, while an eighth adds one
+            // 32px row plus its 4px gap. The max-width only bites below a 348px
+            // viewport, where 332px would otherwise run past the screen edge.
             "max-h-[294px] min-w-[332px] max-w-[calc(100vw-1rem)]"
           : "max-h-[280px] min-w-[260px]",
       )}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -234,7 +234,6 @@ import {
 import {
   DEFAULT_IMAGE_MODEL,
   IMAGE_MODEL_CONFIGS,
-  IMAGE_MODEL_VARIANT_GROUPS,
   PUBLIC_IMAGE_MODELS,
   type ImageModel,
 } from "@okouai/core/image-model-catalog";
@@ -7564,59 +7563,25 @@ function composerImageModelPanelCategory({
   onChange,
   label,
   tabLabel,
-  variantLabel,
 }: {
   selectedModel: ImageModel;
   onChange: (next: ImageModel | null) => void;
   label: string;
   tabLabel: string;
-  /** Segment aria-label, resolved per family rather than for a single one. */
-  variantLabel: (family: string) => string;
 }): MediaModelPanelCategory {
-  // Only base models get a row; the rest of a family lives on that row's
-  // segment control.
-  const variantOnlyModels = new Set<ImageModel>(
-    IMAGE_MODEL_VARIANT_GROUPS.flatMap((group) => {
-      return group.models.slice(1);
-    }),
-  );
   return {
     id: "image",
     label,
     tabLabel,
-    options: PUBLIC_IMAGE_MODELS.filter((candidate) => {
-      return !variantOnlyModels.has(candidate);
-    }).map((candidate) => {
-      const group = IMAGE_MODEL_VARIANT_GROUPS.find((candidateGroup) => {
-        return candidateGroup.models[0] === candidate;
-      });
-      const rowLabel = group?.label ?? IMAGE_MODEL_CONFIGS[candidate].label;
+    options: PUBLIC_IMAGE_MODELS.map((candidate) => {
       return {
         key: candidate,
-        label: rowLabel,
+        label: IMAGE_MODEL_CONFIGS[candidate].label,
         icon: <ImageModelBrandIcon model={candidate} />,
         selected: selectedModel === candidate,
         onSelect: () => {
           onChange(candidate);
         },
-        ...(group
-          ? {
-              variant: {
-                label: variantLabel(rowLabel),
-                options: group.models.map((variantModel) => {
-                  const variantConfig = IMAGE_MODEL_CONFIGS[variantModel];
-                  return {
-                    label: variantConfig.label,
-                    chipLabel: variantConfig.variantLabel,
-                    selected: selectedModel === variantModel,
-                    onSelect: () => {
-                      onChange(variantModel);
-                    },
-                  };
-                }),
-              },
-            }
-          : {}),
       };
     }),
   };
@@ -7627,32 +7592,17 @@ function composerVideoModelPanelCategory({
   onChange,
   label,
   tabLabel,
-  variantLabel,
 }: {
   selectedModel: VideoModel;
   onChange: (next: VideoModel | null) => void;
   label: string;
   tabLabel: string;
-  variantLabel: string;
 }): MediaModelPanelCategory {
-  const seedance2Models = [
-    "dreamina-seedance-2-0-260128",
-    "dreamina-seedance-2-0-fast-260128",
-    "dreamina-seedance-2-0-mini-260615",
-  ] as const satisfies readonly VideoModel[];
-  const seedance2Model = seedance2Models[0];
   return {
     id: "video",
     label,
     tabLabel,
-    options: PUBLIC_VIDEO_MODELS.filter((candidate) => {
-      return (
-        candidate === seedance2Model ||
-        !seedance2Models.some((seedance2Candidate) => {
-          return candidate === seedance2Candidate;
-        })
-      );
-    }).map((candidate) => {
+    options: PUBLIC_VIDEO_MODELS.map((candidate) => {
       return {
         key: candidate,
         label: VIDEO_MODEL_CONFIGS[candidate].label,
@@ -7661,24 +7611,6 @@ function composerVideoModelPanelCategory({
         onSelect: () => {
           onChange(candidate);
         },
-        ...(candidate === seedance2Model
-          ? {
-              variant: {
-                label: variantLabel,
-                options: seedance2Models.map((variantModel) => {
-                  const variantConfig = VIDEO_MODEL_CONFIGS[variantModel];
-                  return {
-                    label: variantConfig.label,
-                    chipLabel: variantConfig.variantLabel,
-                    selected: selectedModel === variantModel,
-                    onSelect: () => {
-                      onChange(variantModel);
-                    },
-                  };
-                }),
-              },
-            }
-          : {}),
       };
     }),
   };
@@ -7715,14 +7647,6 @@ function ComposerModelPickerControls({
         tabLabel: t(($) => {
           return $.settings.models.picker.categoryImage;
         }),
-        variantLabel: (family: string) => {
-          return t(
-            ($) => {
-              return $.settings.models.picker.modelVariants;
-            },
-            { model: family },
-          );
-        },
       }),
     );
   }
@@ -7737,12 +7661,6 @@ function ComposerModelPickerControls({
         tabLabel: t(($) => {
           return $.settings.models.picker.categoryVideo;
         }),
-        variantLabel: t(
-          ($) => {
-            return $.settings.models.picker.modelVariants;
-          },
-          { model: VIDEO_MODEL_CONFIGS["dreamina-seedance-2-0-260128"].label },
-        ),
       }),
     );
   }

--- a/turbo/packages/core/src/image-model-catalog.ts
+++ b/turbo/packages/core/src/image-model-catalog.ts
@@ -15,8 +15,6 @@ interface ImageModelConfig {
   readonly alias: string;
   /** Human-facing name for pickers. */
   readonly label: string;
-  /** Compact label used when the model is shown as a sibling variant. */
-  readonly variantLabel?: string;
 }
 
 export const IMAGE_MODEL_CONFIGS = {
@@ -31,12 +29,10 @@ export const IMAGE_MODEL_CONFIGS = {
   "fal-ai/flux-pro/v1.1": {
     alias: "flux-pro-1.1",
     label: "Flux Pro v1.1",
-    variantLabel: "Standard",
   },
   "fal-ai/flux-pro/v1.1-ultra": {
     alias: "flux-pro-1.1-ultra",
     label: "Flux Pro v1.1 Ultra",
-    variantLabel: "Ultra",
   },
   "fal-ai/qwen-image": {
     alias: "qwen-image",
@@ -49,12 +45,10 @@ export const IMAGE_MODEL_CONFIGS = {
   "dola-seedream-5-0-pro-260628": {
     alias: "seedream5-pro",
     label: "Seedream 5 Pro",
-    variantLabel: "Pro",
   },
   "seedream-5-0-lite-260128": {
     alias: "seedream5-lite",
     label: "Seedream 5 Lite",
-    variantLabel: "Lite",
   },
   "fal-ai/nano-banana-2": {
     alias: "nano-banana-2",
@@ -71,47 +65,19 @@ export const DEFAULT_IMAGE_MODEL_ENV = "OKOU_DEFAULT_IMAGE_MODEL";
 export const IMAGE_MODELS: readonly ImageModel[] = IMAGE_MODEL_IDS;
 
 /**
- * Catalog models offered by the user-facing picker, in display order. Seedream 4
- * is deliberately absent: it stays generatable through its `seedream4` alias and
- * through defaults that already point at it, but it is superseded by Seedream 5
- * as a choice worth presenting.
+ * Catalog models offered by the user-facing picker, in display order. The
+ * picker presents one model per family rather than every catalog entry:
+ * Seedream 4, the Flux Ultra and Seedream Lite siblings, and Qwen Image are all
+ * deliberately absent. Every one of them stays generatable through its alias
+ * and through defaults that already point at it.
  */
 export const PUBLIC_IMAGE_MODELS = [
   "gpt-image-1",
   "gpt-image-2",
   "fal-ai/nano-banana-2",
   "fal-ai/flux-pro/v1.1",
-  "fal-ai/flux-pro/v1.1-ultra",
   "dola-seedream-5-0-pro-260628",
-  "seedream-5-0-lite-260128",
-  "fal-ai/qwen-image",
 ] as const satisfies readonly ImageModel[];
-
-interface ImageModelVariantGroup {
-  /**
-   * Family name for the row. It is stated rather than taken from the base
-   * model's own label, which would repeat the variant name the segment control
-   * already shows ("Seedream 5 Pro" next to a "Pro" chip).
-   */
-  readonly label: string;
-  /** Base model first: it owns the row, the rest are reachable only from it. */
-  readonly models: readonly [ImageModel, ...ImageModel[]];
-}
-
-/**
- * Sibling models that collapse into one picker row with a variant segment, so
- * one family costs one row instead of one row per variant.
- */
-export const IMAGE_MODEL_VARIANT_GROUPS = [
-  {
-    label: "Flux Pro v1.1",
-    models: ["fal-ai/flux-pro/v1.1", "fal-ai/flux-pro/v1.1-ultra"],
-  },
-  {
-    label: "Seedream 5",
-    models: ["dola-seedream-5-0-pro-260628", "seedream-5-0-lite-260128"],
-  },
-] as const satisfies readonly ImageModelVariantGroup[];
 
 export const IMAGE_MODEL_ALIASES = {
   "gpt-image-2": "gpt-image-2",

--- a/turbo/packages/core/src/video-model-catalog.ts
+++ b/turbo/packages/core/src/video-model-catalog.ts
@@ -131,8 +131,6 @@ interface BaseVideoModelConfig {
   readonly alias: string;
   /** Human-facing name for pickers. */
   readonly label: string;
-  /** Compact label used when the model is shown as a sibling variant. */
-  readonly variantLabel?: string;
   readonly aspectRatios: readonly VideoAspectRatio[];
   readonly durations: readonly VideoDuration[];
   readonly resolutions: readonly VideoResolution[];
@@ -147,6 +145,11 @@ interface BaseVideoModelConfig {
   readonly supportsReferenceAudio: boolean;
   readonly supportsFirstFrame: boolean;
   readonly supportsLastFrame: boolean;
+  /**
+   * Whether the user-facing picker offers the model. A private model still
+   * generates through its alias and through defaults that name it; the flag
+   * only decides whether it is worth presenting as a choice.
+   */
   readonly public: boolean;
 }
 
@@ -195,7 +198,6 @@ export const VIDEO_MODEL_CONFIGS = {
     provider: "byteplus",
     alias: "dreamina-seedance-2.0",
     label: "Seedance 2.0",
-    variantLabel: "Standard",
     family: "seedance-2",
     aspectRatios: VIDEO_ASPECT_RATIOS,
     durations: SEEDANCE_2_DURATIONS,
@@ -217,7 +219,6 @@ export const VIDEO_MODEL_CONFIGS = {
     provider: "byteplus",
     alias: "dreamina-seedance-2.0-fast",
     label: "Seedance 2.0 fast",
-    variantLabel: "Fast",
     family: "seedance-2",
     aspectRatios: VIDEO_ASPECT_RATIOS,
     durations: SEEDANCE_2_DURATIONS,
@@ -233,13 +234,12 @@ export const VIDEO_MODEL_CONFIGS = {
     supportsReferenceAudio: true,
     supportsFirstFrame: true,
     supportsLastFrame: true,
-    public: true,
+    public: false,
   },
   "dreamina-seedance-2-0-mini-260615": {
     provider: "byteplus",
     alias: "dreamina-seedance-2.0-mini",
     label: "Seedance 2.0 Mini",
-    variantLabel: "Mini",
     family: "seedance-2",
     aspectRatios: VIDEO_ASPECT_RATIOS,
     durations: SEEDANCE_2_DURATIONS,
@@ -255,7 +255,7 @@ export const VIDEO_MODEL_CONFIGS = {
     supportsReferenceAudio: true,
     supportsFirstFrame: true,
     supportsLastFrame: true,
-    public: true,
+    public: false,
   },
   "seedance-1-5-pro-251215": {
     provider: "byteplus",


### PR DESCRIPTION
## What

Collapses each model family in the composer's image and video pickers down to a single row, removing the variant segment controls that were shown on the Flux Pro v1.1, Seedream 5, and Seedance 2.0 rows.

**Image picker** — GPT Image 1, GPT Image 2, Nano Banana 2, Flux Pro v1.1, Seedream 5 Pro.
Removed from the list: the Standard/Ultra and Pro/Lite segments, plus Qwen Image.

**Video picker** — Seedance 2.5, Seedance 2.0, Seedance 1.5 pro, Veo 3.1 fast, Kling v3 4K, MiniMax H3.
Removed from the list: the Standard/Fast/Mini segment, so Seedance 2.0 is the Standard model only.

## Scope

This changes what the picker *offers*, not what the platform can generate. Flux Ultra, Seedream 5 Lite, Qwen Image, Seedance 2.0 fast, and Seedance 2.0 Mini all stay reachable through their CLI aliases and through defaults that already name them. Their `public` flag / catalog entry is what changed.

One consequence worth a decision: `DEFAULT_VIDEO_MODEL` is still `dreamina-seedance-2.0-fast`, which the picker no longer offers. A thread with no pin therefore shows no checked row in the video panel. Flipping the default to Seedance 2.0 Standard would fix that, but it changes what every default video generation runs (CLI and API included), so it is deliberately left out of this PR.

`videoModelList()` filtered by `public` to build the "Available models" hint on an unsupported-model error. With `public` now meaning picker visibility only, that hint would have understated what the endpoint accepts, so it lists every catalog alias — matching what the image service already does.

## Checks

- `pnpm format`, `pnpm turbo run lint`, `pnpm check-types`, `pnpm knip` — all pass
- `chat-composer-model-selection-and-providers.test.tsx` (81), `chat-composer-template-picker.test.tsx` + `chat-thread-emoji-category-rail.test.tsx` (44) — all pass
- API tests need a local Postgres that this environment does not have; relying on the PR pipeline for those

🤖 Generated with [Claude Code](https://claude.com/claude-code)