### PR TITLE
fix(guest-agent): mask sandbox operation telemetry

### DIFF
--- a/crates/guest-agent/src/masker.rs
+++ b/crates/guest-agent/src/masker.rs
@@ -152,6 +152,29 @@ impl SecretMasker {
         }
     }
 
+    /// Recursively mask secrets in JSON string values without changing keys.
+    pub(crate) fn mask_string_values(&self, val: &mut Value) {
+        if self.matcher.is_none() && self.url_encoded_matcher.is_none() {
+            return;
+        }
+        match val {
+            Value::String(s) => {
+                self.mask_string_in_place(s);
+            }
+            Value::Array(arr) => {
+                for item in arr {
+                    self.mask_string_values(item);
+                }
+            }
+            Value::Object(map) => {
+                for value in map.values_mut() {
+                    self.mask_string_values(value);
+                }
+            }
+            _ => {}
+        }
+    }
+
     /// Replace all secret patterns in a string with `***`.
     ///
     /// Redacts the full union of all pattern matches so overlapping configured

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -199,7 +199,10 @@ async fn upload_telemetry(
         masker.mask_owned_string(system_log.content)
     };
     let metrics_entries = metrics.entries;
-    let sandbox_ops_entries = sandbox_ops.entries;
+    let mut sandbox_ops_entries = sandbox_ops.entries;
+    for entry in &mut sandbox_ops_entries {
+        masker.mask_string_values(entry);
+    }
 
     let payload = json!({
         "runId": run_id,

--- a/crates/guest-agent/tests/integration/telemetry.rs
+++ b/crates/guest-agent/tests/integration/telemetry.rs
@@ -259,11 +259,17 @@ async fn telemetry_preserves_runtime_session_id_and_masks_secrets() {
     let masked_telemetry_mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/telemetry")
-            .body_includes(format!("system log {session_id} ***"));
+            .body_includes(format!("system log {session_id} ***"))
+            .body_includes(r#""action_type":"telemetry_secret_mask""#)
+            .body_includes(r#""duration_ms":17"#)
+            .body_includes(r#""success":false"#)
+            .body_includes(r#""error":"sandbox failure: ***""#);
         then.status(200);
     });
 
-    let secret_values = base64::engine::general_purpose::STANDARD.encode(secret);
+    let secret_values = [secret, "error"]
+        .map(|value| base64::engine::general_purpose::STANDARD.encode(value))
+        .join(",");
     let masker = std::sync::Arc::new(SecretMasker::from_raw(&secret_values));
     let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
         "test-run-001".to_string(),
@@ -283,6 +289,13 @@ async fn telemetry_preserves_runtime_session_id_and_masks_secrets() {
 
     std::fs::write(system_log, format!("system log {session_id} {secret}\n"))
         .expect("system log should be written");
+    let sandbox_error = format!("sandbox failure: {secret}");
+    guest_common::telemetry::record_sandbox_op(
+        "telemetry_secret_mask",
+        Duration::from_millis(17),
+        false,
+        Some(&sandbox_error),
+    );
     telemetry
         .flush(guest_agent::telemetry::UploadMode::Final)
         .await


### PR DESCRIPTION
## Summary

- recursively mask string values in sandbox-operation telemetry before upload
- preserve fixed JSON keys, structure, numbers, booleans, delta positions, and retry behavior
- extend the telemetry HTTP integration test to cover error redaction and a secret/key collision

## Scope

- no API contract or persisted JSONL format changes
- no database migration or feature switch
- local telemetry files remain unchanged; redaction applies to the outbound in-memory copy

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p guest-agent --test integration telemetry::telemetry_preserves_runtime_session_id_and_masks_secrets -- --exact`
- `cargo test -p guest-agent --all-targets --all-features`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-agent --no-deps --all-features`
- pre-commit workspace Rust formatting, documentation, Clippy, and file-size checks

Closes #28473
