### PR TITLE
fix(guest-agent): redact multiline secrets in telemetry

### DIFF
--- a/crates/guest-agent/src/masker.rs
+++ b/crates/guest-agent/src/masker.rs
@@ -160,8 +160,14 @@ impl SecretMasker {
         self.masked_string(s).unwrap_or_else(|| s.to_string())
     }
 
-    pub(crate) fn mask_owned_string(&self, s: String) -> String {
-        self.masked_string(&s).unwrap_or(s)
+    /// Mask diagnostic text while preserving embedded line separators.
+    pub(crate) fn mask_diagnostic_string(&self, s: String) -> String {
+        if self.diagnostic_matcher.is_none() && self.diagnostic_url_encoded_matcher.is_none() {
+            return s;
+        }
+
+        self.mask_diagnostic_lines(s.split('\n').map(String::from).collect())
+            .join("\n")
     }
 
     /// Mask diagnostic text while preserving the caller's line boundaries.
@@ -677,27 +683,17 @@ mod tests {
     }
 
     #[test]
-    fn mask_owned_string_preserves_unmatched_allocation() {
-        let masker = masker_with(vec!["secret123"]);
-        let value = String::from("ordinary stderr line");
+    fn diagnostic_string_preserves_allocation_without_matchers() {
+        let masker = SecretMasker::empty();
+        let value = String::from("ordinary diagnostic text");
         let original_ptr = value.as_ptr();
         let original_capacity = value.capacity();
 
-        let masked = masker.mask_owned_string(value);
+        let masked = masker.mask_diagnostic_string(value);
 
-        assert_eq!(masked, "ordinary stderr line");
+        assert_eq!(masked, "ordinary diagnostic text");
         assert_eq!(masked.as_ptr(), original_ptr);
         assert_eq!(masked.capacity(), original_capacity);
-    }
-
-    #[test]
-    fn mask_owned_string_masks_matched_string() {
-        let masker = masker_with(vec!["secret123"]);
-
-        assert_eq!(
-            masker.mask_owned_string("stderr has secret123".to_string()),
-            "stderr has ***"
-        );
     }
 
     #[test]
@@ -724,6 +720,21 @@ mod tests {
                 "***".to_string(),
                 "after".to_string(),
             ]
+        );
+    }
+
+    #[test]
+    fn diagnostic_string_preserves_crlf_blank_lines_and_terminal_newline() {
+        let engine = base64::engine::general_purpose::STANDARD;
+        let secret = "first-secret-line\nsecond-secret-line";
+        let encoded = engine.encode(secret);
+        let masker = SecretMasker::from_raw(&encoded);
+
+        assert_eq!(
+            masker.mask_diagnostic_string(
+                "before\r\nfirst-secret-line\r\n\r\nsecond-secret-line\r\nafter\n".to_string(),
+            ),
+            "before\r\n***\r\n\r\n***\r\nafter\n"
         );
     }
 
@@ -941,19 +952,6 @@ mod tests {
         masker.mask_value(&mut val);
 
         assert_eq!(val["outer"]["inner"], "contains *** here");
-    }
-
-    #[test]
-    fn mask_owned_string_masks_lowercase_percent_encoded_variant() {
-        let engine = base64::engine::general_purpose::STANDARD;
-        let secret = "token/a";
-        let encoded = engine.encode(secret);
-        let masker = SecretMasker::from_raw(&encoded);
-
-        assert_eq!(
-            masker.mask_owned_string("system log token%2fa".to_string()),
-            "system log ***"
-        );
     }
 
     #[test]

--- a/crates/guest-agent/src/masker.rs
+++ b/crates/guest-agent/src/masker.rs
@@ -166,8 +166,28 @@ impl SecretMasker {
             return s;
         }
 
-        self.mask_diagnostic_lines(s.split('\n').map(String::from).collect())
-            .join("\n")
+        let mut line_endings = Vec::new();
+        let lines = s
+            .split_inclusive('\n')
+            .map(|segment| {
+                let (line, line_ending) = if let Some(line) = segment.strip_suffix("\r\n") {
+                    (line, "\r\n")
+                } else if let Some(line) = segment.strip_suffix('\n') {
+                    (line, "\n")
+                } else {
+                    (segment, "")
+                };
+                line_endings.push(line_ending);
+                line.to_string()
+            })
+            .collect();
+        let lines = self.mask_diagnostic_lines(lines);
+        let mut masked = String::with_capacity(s.len());
+        for (line, line_ending) in lines.into_iter().zip(line_endings) {
+            masked.push_str(&line);
+            masked.push_str(line_ending);
+        }
+        masked
     }
 
     /// Mask diagnostic text while preserving the caller's line boundaries.
@@ -726,7 +746,7 @@ mod tests {
     #[test]
     fn diagnostic_string_preserves_crlf_blank_lines_and_terminal_newline() {
         let engine = base64::engine::general_purpose::STANDARD;
-        let secret = "first-secret-line\nsecond-secret-line";
+        let secret = "first-secret-line\r\nsecond-secret-line";
         let encoded = engine.encode(secret);
         let masker = SecretMasker::from_raw(&encoded);
 

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -196,7 +196,7 @@ async fn upload_telemetry(
     let masked_log = if system_log.content.is_empty() {
         String::new()
     } else {
-        masker.mask_owned_string(system_log.content)
+        masker.mask_diagnostic_string(system_log.content)
     };
     let metrics_entries = metrics.entries;
     let sandbox_ops_entries = sandbox_ops.entries;

--- a/crates/guest-agent/tests/integration/telemetry.rs
+++ b/crates/guest-agent/tests/integration/telemetry.rs
@@ -2,6 +2,7 @@ use crate::support::*;
 use base64::Engine;
 use guest_agent::masker::SecretMasker;
 use httpmock::prelude::*;
+use std::io::Write;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -296,6 +297,89 @@ async fn telemetry_preserves_runtime_session_id_and_masks_secrets() {
     event_mock.delete_async().await;
     raw_telemetry_mock.delete_async().await;
     masked_telemetry_mock.delete_async().await;
+    remove_telemetry_files(paths);
+}
+
+#[tokio::test]
+async fn telemetry_redacts_multiline_secret_across_flushes() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+    let files = ExplicitTelemetryFiles::new("multiline-secret-across-flushes").unwrap();
+    let paths = &files.paths;
+    let system_log = paths.system_log_file();
+    ensure_parent_dir(system_log);
+
+    let secret_lines = [
+        "first-telemetry-secret-line",
+        "second-telemetry-secret-line",
+    ];
+    let secret = secret_lines.join("\n");
+    let request_bodies = Arc::new(Mutex::new(Vec::new()));
+    let request_bodies_for_mock = Arc::clone(&request_bodies);
+    let upload_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/telemetry");
+        then.respond_with(move |request| {
+            request_bodies_for_mock
+                .lock()
+                .unwrap()
+                .push(request.body_vec());
+            http_status(200)
+        });
+    });
+
+    let encoded_secret = base64::engine::general_purpose::STANDARD.encode(secret);
+    let masker = Arc::new(SecretMasker::from_raw(&encoded_secret));
+    let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
+        "test-run-001".to_string(),
+        paths,
+        masker,
+        http_client!(),
+    );
+
+    std::fs::write(system_log, format!("{}\n", secret_lines[0]))
+        .expect("first secret line should be written");
+    telemetry
+        .flush(guest_agent::telemetry::UploadMode::Live)
+        .await
+        .expect("first secret line should be uploaded");
+
+    {
+        let mut log = std::fs::OpenOptions::new()
+            .append(true)
+            .open(system_log)
+            .expect("system log should open for append");
+        writeln!(log, "{}", secret_lines[1]).expect("second secret line should be appended");
+    }
+    telemetry
+        .flush(guest_agent::telemetry::UploadMode::Live)
+        .await
+        .expect("second secret line should be uploaded");
+    telemetry.shutdown().await;
+
+    upload_mock.assert_calls_async(2).await;
+    {
+        let request_bodies = request_bodies.lock().unwrap();
+        assert_eq!(request_bodies.len(), 2, "expected two telemetry uploads");
+
+        let first_payload: serde_json::Value = serde_json::from_slice(&request_bodies[0])
+            .expect("first telemetry request should contain valid JSON");
+        let second_payload: serde_json::Value = serde_json::from_slice(&request_bodies[1])
+            .expect("second telemetry request should contain valid JSON");
+        assert_eq!(first_payload["systemLog"], "***\n");
+        assert_eq!(second_payload["systemLog"], "***\n");
+
+        for request_body in request_bodies.iter() {
+            let request_body = String::from_utf8_lossy(request_body);
+            for secret_line in secret_lines {
+                assert!(
+                    !request_body.contains(secret_line),
+                    "telemetry request leaked multiline secret component: {secret_line}"
+                );
+            }
+        }
+    }
+
+    upload_mock.delete_async().await;
     remove_telemetry_files(paths);
 }
 


### PR DESCRIPTION
## Summary

- classify system-log telemetry as diagnostic text so sufficiently long lines derived from configured multiline secrets are redacted independently in every delta
- preserve CRLF, blank lines, terminal newlines, and the existing 256 KiB read/position behavior by reusing diagnostic line-range projection
- remove the now-unused normal owned-string masking helper and add consecutive-flush integration coverage

## Scope

- no telemetry schema, delta reader, position file, retry, or backend changes
- normal event and structured-payload matcher behavior remains unchanged

## Validation

- `cargo fmt --check` (from `crates/`)
- `cargo test -p guest-agent telemetry_redacts_multiline_secret_across_flushes`
- `cargo test -p guest-agent diagnostic_string`
- `cargo clippy -p guest-agent --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent --no-deps`
- `cargo test -p guest-agent`
- pre-commit workspace Rust format, docs, Clippy, file-size, and commitlint hooks

Closes #28474
