### PR TITLE
refactor(python): centralize streaming encoding capabilities

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -39,6 +39,10 @@ _ZSTD_VALIDATE_INPUT_CHUNK_SIZE = 32
 INVALID_COMPRESSED_BODY = "invalid compressed body"
 INCOMPLETE_COMPRESSED_BODY = "incomplete compressed body"
 DECODED_BODY_LIMIT_EXCEEDED = "decoded body limit exceeded"
+_STREAM_ZLIB_WBITS_BY_ENCODING = {
+    "gzip": 16 + zlib.MAX_WBITS,
+    "deflate": zlib.MAX_WBITS,
+}
 _SUPPORTED_ONE_SHOT_BODY_ENCODINGS = frozenset({"gzip", "deflate", "br", "zstd"})
 
 
@@ -98,11 +102,11 @@ def _no_stream_decode_error() -> str | None:
 def _create_zlib_stream_decode_session(
     feed: _StreamDecodeFeed,
     *,
-    encoding: Literal["gzip", "deflate"],
+    encoding_label: str,
+    wbits: int,
     max_decoded_chunk: int,
     should_continue: _StreamDecodeShouldContinue | None,
 ) -> StreamDecodeSession:
-    wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
     obj = zlib.decompressobj(wbits)
     compressed_bytes_seen = 0
     decode_error: str | None = None
@@ -150,7 +154,7 @@ def _create_zlib_stream_decode_session(
                         inspection_stopped = True
                         return
                 decode_error = INVALID_COMPRESSED_BODY
-                _log_streaming_decode_error(encoding, exc)
+                _log_streaming_decode_error(encoding_label, exc)
                 return
             if probing_for_additional_output and decoded:
                 if pending_decoded:
@@ -202,10 +206,13 @@ def _create_zlib_stream_decode_session(
     return StreamDecodeSession(decode, finish_error)
 
 
+def stream_decodable_content_encodings() -> tuple[str, ...]:
+    """Return ordered content codings supported by bounded streaming decode."""
+    return (*_STREAM_ZLIB_WBITS_BY_ENCODING, "identity")
+
+
 def _stream_decode_skip_reason(encoding: str) -> str | None:
-    if not encoding or encoding == "identity":
-        return None
-    if encoding in ("gzip", "deflate"):
+    if not encoding or encoding in stream_decodable_content_encodings():
         return None
     if encoding == "zstd":
         return "zstd streaming output cannot be hard-bounded"
@@ -281,14 +288,13 @@ def create_stream_decode_session(
                 inspection_stopped = True
 
         return StreamDecodeSession(feed_until_stopped, _no_stream_decode_error)
-    if encoding in ("gzip", "deflate"):
-        return _create_zlib_stream_decode_session(
-            feed,
-            encoding=encoding,
-            max_decoded_chunk=max_decoded_chunk,
-            should_continue=should_continue,
-        )
-    return None
+    return _create_zlib_stream_decode_session(
+        feed,
+        encoding_label=encoding,
+        wbits=_STREAM_ZLIB_WBITS_BY_ENCODING[encoding],
+        max_decoded_chunk=max_decoded_chunk,
+        should_continue=should_continue,
+    )
 
 
 def decompress_body(

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -43,6 +43,7 @@ _STREAM_ZLIB_WBITS_BY_ENCODING = {
     "gzip": 16 + zlib.MAX_WBITS,
     "deflate": zlib.MAX_WBITS,
 }
+_STREAM_DECODABLE_CONTENT_ENCODINGS = (*_STREAM_ZLIB_WBITS_BY_ENCODING, "identity")
 _SUPPORTED_ONE_SHOT_BODY_ENCODINGS = frozenset({"gzip", "deflate", "br", "zstd"})
 
 
@@ -208,7 +209,7 @@ def _create_zlib_stream_decode_session(
 
 def stream_decodable_content_encodings() -> tuple[str, ...]:
     """Return ordered content codings supported by bounded streaming decode."""
-    return (*_STREAM_ZLIB_WBITS_BY_ENCODING, "identity")
+    return _STREAM_DECODABLE_CONTENT_ENCODINGS
 
 
 def _stream_decode_skip_reason(encoding: str) -> str | None:

--- a/crates/runner/mitm-addon/src/response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/src/response_encoding_negotiation.py
@@ -5,10 +5,12 @@ from decimal import Decimal, InvalidOperation
 
 from mitmproxy import http
 
+import body_decoding
+
 _ACCEPT_ENCODING = "Accept-Encoding"
 _IDENTITY = "identity"
 _WILDCARD = "*"
-_SAFE_ENCODINGS = frozenset(("gzip", "deflate", _IDENTITY))
+_STREAM_DECODABLE_ENCODINGS = body_decoding.stream_decodable_content_encodings()
 _INVALID_Q_VALUE = Decimal(-1)
 _MIN_Q_VALUE = Decimal(0)
 _MAX_Q_VALUE = Decimal(1)
@@ -67,7 +69,7 @@ def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> None
                     wildcard_accepted = True
                     wildcard_q_text = q_text
 
-            if name in _SAFE_ENCODINGS:
+            if name in _STREAM_DECODABLE_ENCODINGS:
                 if q_value == _MIN_Q_VALUE:
                     rejected_safe.add(name)
                     accepted_safe.pop(name, None)
@@ -157,7 +159,9 @@ def _add_wildcard_safe_compression_encodings(
 ) -> None:
     if not wildcard_accepted:
         return
-    for name in ("gzip", "deflate"):
+    for name in _STREAM_DECODABLE_ENCODINGS:
+        if name == _IDENTITY:
+            continue
         if name not in accepted_safe and name not in rejected_safe:
             accepted_safe[name] = wildcard_q_text
 

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from mitmproxy import http
 
+import body_decoding
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import response_encoding_negotiation
@@ -228,6 +229,52 @@ def test_normalize_accept_encoding_for_body_inspection(
         is None
     )
     assert request_headers.get_all(_ACCEPT_ENCODING) == values
+
+
+def test_explicit_normalized_encodings_create_stream_decode_sessions(headers) -> None:
+    supported_encodings = body_decoding.stream_decodable_content_encodings()
+    request_headers = headers(
+        (
+            _ACCEPT_ENCODING,
+            ", ".join((*supported_encodings, "br", "zstd")),
+        )
+    )
+
+    response_encoding_negotiation.normalize_accept_encoding_for_body_inspection(request_headers)
+
+    normalized_encodings = tuple(
+        raw_coding.strip().partition(";")[0]
+        for value in request_headers.get_all(_ACCEPT_ENCODING)
+        for raw_coding in value.split(",")
+    )
+    assert normalized_encodings == supported_encodings
+    for encoding in normalized_encodings:
+        session = body_decoding.create_stream_decode_session(
+            headers(("Content-Encoding", encoding)),
+            lambda _chunk: None,
+        )
+        assert session is not None
+
+
+def test_wildcard_expansion_uses_stream_decoder_capability_order(headers) -> None:
+    request_headers = headers((_ACCEPT_ENCODING, "br, zstd, *;q=0.5, identity;q=0"))
+
+    response_encoding_negotiation.normalize_accept_encoding_for_body_inspection(request_headers)
+
+    compression_encodings = tuple(
+        encoding
+        for encoding in body_decoding.stream_decodable_content_encodings()
+        if encoding != "identity"
+    )
+    assert request_headers.get_all(_ACCEPT_ENCODING) == [
+        ", ".join((*[f"{encoding};q=0.5" for encoding in compression_encodings], "identity;q=0"))
+    ]
+    for encoding in compression_encodings:
+        session = body_decoding.create_stream_decode_session(
+            headers(("Content-Encoding", encoding)),
+            lambda _chunk: None,
+        )
+        assert session is not None
 
 
 def _model_provider_registry(


### PR DESCRIPTION
## Summary

- make the bounded streaming decoder own the ordered content-encoding capability definition and zlib construction parameters
- derive request-side explicit coding membership and wildcard compression expansion from the decoder capability API
- add cross-module contracts proving normalized stream-safe codings create real decoder sessions

## Behavior and scope

- preserves current `Accept-Encoding` output, quality parsing, ordering, explicit rejection, and best-effort fallback behavior
- preserves response diagnostics, forwarding, and bounded decoder lifecycle
- does not add a codec or change bounded one-shot JSON support for `br` and `zstd`
- does not change APIs, persisted state, databases, queues, or deployment protocols

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_response_encoding_negotiation.py tests/test_body_decoding.py` (172 passed)
- `uv run --no-sync python -m pytest tests/` (6,435 passed)
- `git diff --check`

Closes #28477
