### PR TITLE
refactor(python): centralize openai responses event taxonomy

### DIFF
--- a/crates/runner/mitm-addon/src/codex_output_timing.py
+++ b/crates/runner/mitm-addon/src/codex_output_timing.py
@@ -22,6 +22,7 @@ from datetime import UTC, datetime
 from mitmproxy import http
 
 import flow_metadata
+import openai_responses_events
 import provider_timing_store
 
 FIRST_GENERATED_RESPONSE_CREATE_SENT = "codex_proxy_first_generated_response_create_sent"
@@ -31,13 +32,6 @@ FIRST_OUTPUT_TEXT_DELTA = "codex_proxy_first_output_text_delta"
 FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE = "codex_proxy_first_text_in_first_generated_response"
 FIRST_TEXT_IN_LATER_GENERATED_RESPONSE = "codex_proxy_first_text_in_later_generated_response"
 
-_RESPONSE_CREATE_EVENT = "response.create"
-_RESPONSE_CREATED_EVENT = "response.created"
-_OUTPUT_ITEM_ADDED_EVENT = "response.output_item.added"
-_OUTPUT_TEXT_DELTA_EVENT = "response.output_text.delta"
-_TERMINAL_EVENTS = frozenset(
-    ("response.completed", "response.done", "response.incomplete", "response.failed")
-)
 _MAX_TRACKED_RUNS = 10_000
 _LOG_TYPE = "codex_output_timing"
 
@@ -64,7 +58,7 @@ def observe_client_event(
     received_at: float,
 ) -> None:
     """Advance one run's timing state from a received client Responses event."""
-    if event_type != _RESPONSE_CREATE_EVENT:
+    if event_type != openai_responses_events.CLIENT_CREATE_EVENT:
         return
 
     run_id = flow_metadata.run_id(flow.metadata)
@@ -103,7 +97,7 @@ def observe_server_event(flow: http.HTTPFlow, event_type: str | None) -> None:
         return
 
     with _store.locked():
-        if event_type == _RESPONSE_CREATED_EVENT:
+        if event_type == openai_responses_events.SERVER_CREATED_EVENT:
             state = _store.state_for_run_locked(run_id)
             if not state.generated_response_selected:
                 state.candidate_response_created_at = _observation_time()
@@ -113,7 +107,7 @@ def observe_server_event(flow: http.HTTPFlow, event_type: str | None) -> None:
             return
 
         state = _store.get_locked(run_id)
-        if event_type == _OUTPUT_ITEM_ADDED_EVENT:
+        if event_type == openai_responses_events.OUTPUT_ITEM_ADDED_EVENT:
             if state is None:
                 state = _store.state_for_run_locked(run_id)
             else:
@@ -134,7 +128,7 @@ def observe_server_event(flow: http.HTTPFlow, event_type: str | None) -> None:
                 _store.admit_pending_locked(flow, run_id, state)
             return
 
-        if event_type == _OUTPUT_TEXT_DELTA_EVENT:
+        if event_type == openai_responses_events.OUTPUT_TEXT_DELTA_EVENT:
             if state is None or not state.generated_response_selected:
                 return
             _store.touch_locked(run_id)
@@ -151,7 +145,7 @@ def observe_server_event(flow: http.HTTPFlow, event_type: str | None) -> None:
                 _store.admit_pending_locked(flow, run_id, state)
             return
 
-        if event_type not in _TERMINAL_EVENTS or state is None:
+        if event_type not in openai_responses_events.TERMINAL_EVENTS or state is None:
             return
 
         _store.touch_locked(run_id)

--- a/crates/runner/mitm-addon/src/model_websocket_usage.py
+++ b/crates/runner/mitm-addon/src/model_websocket_usage.py
@@ -7,6 +7,7 @@ from mitmproxy import http
 
 import flow_metadata
 import flow_metadata_keys as metadata_keys
+import openai_responses_events
 import usage
 from logging_utils import log_proxy_entry
 
@@ -32,16 +33,6 @@ _WebSocketCorrelationReason = Literal[
     "server_error",
     "correlation_cap",
 ]
-_WEBSOCKET_LIFECYCLE_EVENT_TYPES = frozenset(
-    (
-        "response.created",
-        "response.completed",
-        "response.done",
-        "response.incomplete",
-        "response.failed",
-        "error",
-    )
-)
 
 
 def activate(flow: http.HTTPFlow) -> None:
@@ -238,7 +229,7 @@ def feed_usage(
             or prewarm_state.active_intent is not None
             or bool(prewarm_state.ignored_response_diagnostics)
             or event.event_type is None
-            or event.event_type in _WEBSOCKET_LIFECYCLE_EVENT_TYPES
+            or event.event_type in openai_responses_events.SERVER_LIFECYCLE_EVENTS
         )
     )
     inspection = usage.inspect_openai_responses_server_event(

--- a/crates/runner/mitm-addon/src/openai_responses_events.py
+++ b/crates/runner/mitm-addon/src/openai_responses_events.py
@@ -1,0 +1,80 @@
+"""Canonical OpenAI Responses protocol event vocabulary."""
+
+CLIENT_CREATE_EVENT = "response.create"
+SERVER_CREATED_EVENT = "response.created"
+SERVER_ERROR_EVENT = "error"
+OUTPUT_ITEM_ADDED_EVENT = "response.output_item.added"
+OUTPUT_TEXT_DELTA_EVENT = "response.output_text.delta"
+
+# Terminal Responses events whose Response object may carry usage. WebSocket
+# source eviction relies on these events being final for the logical response id;
+# protocols with mutable post-terminal usage snapshots need a source-upsert
+# contract instead of source-preserving append-only events. ``response.done`` is
+# retained as the established compatibility terminal.
+TERMINAL_EVENTS = frozenset(
+    ("response.completed", "response.done", "response.incomplete", "response.failed")
+)
+
+SERVER_LIFECYCLE_EVENTS = TERMINAL_EVENTS | {
+    SERVER_CREATED_EVENT,
+    SERVER_ERROR_EVENT,
+}
+
+# Keep exact current official Responses stream event literals plus established
+# compatibility literals. Unknown names intentionally retain full extraction so
+# schema drift cannot silently skip a future usage-bearing event.
+KNOWN_NON_USAGE_EVENTS = frozenset(
+    (
+        SERVER_ERROR_EVENT,
+        "response.audio.delta",
+        "response.audio.done",
+        "response.audio.transcript.delta",
+        "response.audio.transcript.done",
+        "response.code_interpreter_call.code.delta",
+        "response.code_interpreter_call.completed",
+        "response.code_interpreter_call.in_progress",
+        "response.code_interpreter_call.interpreting",
+        "response.code_interpreter_call_code.delta",
+        "response.code_interpreter_call_code.done",
+        "response.content_part.added",
+        "response.content_part.done",
+        SERVER_CREATED_EVENT,
+        "response.custom_tool_call_input.delta",
+        "response.custom_tool_call_input.done",
+        "response.file_search_call.completed",
+        "response.file_search_call.in_progress",
+        "response.file_search_call.searching",
+        "response.function_call_arguments.delta",
+        "response.function_call_arguments.done",
+        "response.image_generation_call.completed",
+        "response.image_generation_call.generating",
+        "response.image_generation_call.in_progress",
+        "response.image_generation_call.partial_image",
+        "response.in_progress",
+        "response.mcp_call.completed",
+        "response.mcp_call.failed",
+        "response.mcp_call.in_progress",
+        "response.mcp_call_arguments.delta",
+        "response.mcp_call_arguments.done",
+        "response.mcp_list_tools.completed",
+        "response.mcp_list_tools.failed",
+        "response.mcp_list_tools.in_progress",
+        OUTPUT_ITEM_ADDED_EVENT,
+        "response.output_item.done",
+        "response.output_text.annotation.added",
+        OUTPUT_TEXT_DELTA_EVENT,
+        "response.output_text.done",
+        "response.queued",
+        "response.reasoning_summary_part.added",
+        "response.reasoning_summary_part.done",
+        "response.reasoning_summary_text.delta",
+        "response.reasoning_summary_text.done",
+        "response.reasoning_text.delta",
+        "response.reasoning_text.done",
+        "response.refusal.delta",
+        "response.refusal.done",
+        "response.web_search_call.completed",
+        "response.web_search_call.in_progress",
+        "response.web_search_call.searching",
+    )
+)

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -29,6 +29,7 @@ from typing import Literal
 from mitmproxy import http
 
 import body_decoding
+import openai_responses_events
 from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT
 
 from .json_probe import TopLevelStringFieldProbeResult, probe_top_level_string_field
@@ -51,71 +52,6 @@ from .openai_tokens import partition_input_tokens as _partition_input_tokens
 from .quantities import MAX_USAGE_QUANTITY
 from .sse import SseUsageScanner
 
-# Terminal Responses events whose Response object may carry usage. WebSocket
-# source eviction relies on these events being final for the logical response id;
-# protocols with mutable post-terminal usage snapshots need a source-upsert
-# contract instead of source-preserving append-only events.
-_RESPONSES_TERMINAL_USAGE_EVENTS = frozenset(
-    ("response.completed", "response.done", "response.incomplete", "response.failed")
-)
-# Keep exact current official Responses stream event literals plus established
-# compatibility literals. Unknown names intentionally retain full extraction so
-# schema drift cannot silently skip a future usage-bearing event.
-_RESPONSES_KNOWN_NON_USAGE_EVENTS = frozenset(
-    (
-        "error",
-        "response.audio.delta",
-        "response.audio.done",
-        "response.audio.transcript.delta",
-        "response.audio.transcript.done",
-        "response.code_interpreter_call.code.delta",
-        "response.code_interpreter_call.completed",
-        "response.code_interpreter_call.in_progress",
-        "response.code_interpreter_call.interpreting",
-        "response.code_interpreter_call_code.delta",
-        "response.code_interpreter_call_code.done",
-        "response.content_part.added",
-        "response.content_part.done",
-        "response.created",
-        "response.custom_tool_call_input.delta",
-        "response.custom_tool_call_input.done",
-        "response.file_search_call.completed",
-        "response.file_search_call.in_progress",
-        "response.file_search_call.searching",
-        "response.function_call_arguments.delta",
-        "response.function_call_arguments.done",
-        "response.image_generation_call.completed",
-        "response.image_generation_call.generating",
-        "response.image_generation_call.in_progress",
-        "response.image_generation_call.partial_image",
-        "response.in_progress",
-        "response.mcp_call.completed",
-        "response.mcp_call.failed",
-        "response.mcp_call.in_progress",
-        "response.mcp_call_arguments.delta",
-        "response.mcp_call_arguments.done",
-        "response.mcp_list_tools.completed",
-        "response.mcp_list_tools.failed",
-        "response.mcp_list_tools.in_progress",
-        "response.output_item.added",
-        "response.output_item.done",
-        "response.output_text.annotation.added",
-        "response.output_text.delta",
-        "response.output_text.done",
-        "response.queued",
-        "response.reasoning_summary_part.added",
-        "response.reasoning_summary_part.done",
-        "response.reasoning_summary_text.delta",
-        "response.reasoning_summary_text.done",
-        "response.reasoning_text.delta",
-        "response.reasoning_text.done",
-        "response.refusal.delta",
-        "response.refusal.done",
-        "response.web_search_call.completed",
-        "response.web_search_call.in_progress",
-        "response.web_search_call.searching",
-    )
-)
 _SseUsageParseErrorCallback = Callable[[str, str], None]
 _SseTerminalUsageCallback = Callable[[dict], None]
 _ResponsesEventTypeClassification = Literal[
@@ -141,13 +77,6 @@ _RESPONSES_EVENT_PREFILTER_MAX_BYTES = 4096
 # parser's bulk-scan path for ordinary large content strings.
 _RESPONSES_MAX_WORK_UNITS = 65_536
 OPENAI_RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR = "work_limit_exceeded"
-_RESPONSES_CREATE_EVENT = "response.create"
-_RESPONSES_CREATED_EVENT = "response.created"
-_RESPONSES_ERROR_EVENT = "error"
-_RESPONSES_SERVER_LIFECYCLE_EVENTS = _RESPONSES_TERMINAL_USAGE_EVENTS | {
-    _RESPONSES_CREATED_EVENT,
-    _RESPONSES_ERROR_EVENT,
-}
 
 
 @dataclass(frozen=True)
@@ -171,15 +100,15 @@ class OpenAIResponsesServerLifecycle:
 
     @property
     def is_created(self) -> bool:
-        return self.event_type == _RESPONSES_CREATED_EVENT
+        return self.event_type == openai_responses_events.SERVER_CREATED_EVENT
 
     @property
     def is_terminal(self) -> bool:
-        return self.event_type in _RESPONSES_TERMINAL_USAGE_EVENTS
+        return self.event_type in openai_responses_events.TERMINAL_EVENTS
 
     @property
     def is_error(self) -> bool:
-        return self.event_type == _RESPONSES_ERROR_EVENT
+        return self.event_type == openai_responses_events.SERVER_ERROR_EVENT
 
 
 @dataclass(frozen=True)
@@ -262,7 +191,7 @@ def inspect_openai_responses_client_event_json(body: bytes) -> OpenAIResponsesCl
     event_type = result.values.get(("type",))
     if not type_is_consistent or not isinstance(event_type, str):
         return OpenAIResponsesClientEvent(observed_event_type, False, "unknown")
-    if event_type != _RESPONSES_CREATE_EVENT:
+    if event_type != openai_responses_events.CLIENT_CREATE_EVENT:
         return OpenAIResponsesClientEvent(observed_event_type, False, "unknown")
     if not generate_is_consistent:
         return OpenAIResponsesClientEvent(observed_event_type, False, "unknown")
@@ -313,9 +242,9 @@ def _lifecycle_from_extraction(
     event_type = result.values.get(("type",))
     if not isinstance(event_type, str):
         return OpenAIResponsesServerLifecycle(event.event_type, None, False)
-    if event_type == _RESPONSES_ERROR_EVENT:
+    if event_type == openai_responses_events.SERVER_ERROR_EVENT:
         return OpenAIResponsesServerLifecycle(event_type, None, True)
-    if event_type not in _RESPONSES_SERVER_LIFECYCLE_EVENTS:
+    if event_type not in openai_responses_events.SERVER_LIFECYCLE_EVENTS:
         return OpenAIResponsesServerLifecycle(event_type, None, True)
     response_id = result.values.get(("response", "id"))
     if (
@@ -364,7 +293,7 @@ def inspect_openai_responses_server_event(
     if (
         include_lifecycle
         and event.event_type is not None
-        and event.event_type not in _RESPONSES_SERVER_LIFECYCLE_EVENTS
+        and event.event_type not in openai_responses_events.SERVER_LIFECYCLE_EVENTS
     ):
         lifecycle = OpenAIResponsesServerLifecycle(event.event_type, None, True)
         needs_lifecycle_parse = False
@@ -431,9 +360,9 @@ def _classify_responses_event_type_result(
 
 
 def _classify_responses_event_name(event_name: str) -> _ResponsesEventTypeClassification:
-    if event_name in _RESPONSES_TERMINAL_USAGE_EVENTS:
+    if event_name in openai_responses_events.TERMINAL_EVENTS:
         return _RESPONSES_EVENT_TERMINAL
-    if event_name in _RESPONSES_KNOWN_NON_USAGE_EVENTS:
+    if event_name in openai_responses_events.KNOWN_NON_USAGE_EVENTS:
         return _RESPONSES_EVENT_KNOWN_NON_USAGE
     return _RESPONSES_EVENT_UNKNOWN
 
@@ -447,11 +376,11 @@ def _resolved_data_event_type(
 
 
 def _is_known_terminal_usage_event(value: object) -> bool:
-    return isinstance(value, str) and value in _RESPONSES_TERMINAL_USAGE_EVENTS
+    return isinstance(value, str) and value in openai_responses_events.TERMINAL_EVENTS
 
 
 def _is_known_non_usage_event(value: object) -> bool:
-    return isinstance(value, str) and value in _RESPONSES_KNOWN_NON_USAGE_EVENTS
+    return isinstance(value, str) and value in openai_responses_events.KNOWN_NON_USAGE_EVENTS
 
 
 def _store_quantity(target: dict, category: str, value: object) -> None:
@@ -687,9 +616,8 @@ def create_openai_responses_sse_usage_extractor(
 
     When captured event JSON cannot be parsed or exceeds an extractor bound,
     ``on_parse_error(event_type, error)`` is called only if the final event
-    identity is ``response.completed``, ``response.done``,
-    ``response.incomplete``, or ``response.failed``. Known non-usage events and
-    malformed non-terminal or unknown events remain silent. HTTP content
+    identity is a canonical terminal Responses event. Known non-usage events
+    and malformed non-terminal or unknown events remain silent. HTTP content
     decoding and its errors are outside this parser; callers feed decoded output
     and handle decoder completion separately.
 
@@ -797,7 +725,7 @@ class _OpenAIResponsesSseUsageHandler:
                 event_type = data_type
         if (
             event_type is not None
-            and event_type in _RESPONSES_TERMINAL_USAGE_EVENTS
+            and event_type in openai_responses_events.TERMINAL_EVENTS
             and result.error
             and self._on_parse_error is not None
         ):

--- a/crates/runner/mitm-addon/tests/test_codex_output_timing.py
+++ b/crates/runner/mitm-addon/tests/test_codex_output_timing.py
@@ -13,6 +13,7 @@ from mitmproxy import http
 import codex_output_timing
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import openai_responses_events
 import usage
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
 from tests.model_provider_flow_helpers import make_openai_responses_websocket_flow
@@ -152,6 +153,46 @@ def test_default_codex_excludes_prewarm_and_reports_content_free_milestones(
     serialized_requests = b"".join(request.body for request in requests)
     assert secret.encode() not in serialized_requests
     assert secret not in read_jsonl_text_after_flush(proxy_log)
+
+
+@pytest.mark.parametrize("terminal_event", sorted(openai_responses_events.TERMINAL_EVENTS))
+def test_responses_terminals_discard_unconfirmed_timing_candidate(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+    sync_usage_executor,
+    terminal_event: str,
+) -> None:
+    flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+
+    with mitm_ctx(api_url=usage_webhook_server.api_url):
+        mitm_addon.responseheaders(flow)
+        _feed_client_event(flow, _event("response.create"))
+        feed_websocket_server_message(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.created",
+                    "response": {"id": "unconfirmed-response"},
+                }
+            ).encode(),
+        )
+        feed_websocket_server_message(
+            flow,
+            json.dumps(
+                {
+                    "type": terminal_event,
+                    "response": {"id": "unconfirmed-response"},
+                }
+            ).encode(),
+        )
+        feed_websocket_server_message(flow, _event("response.output_item.added"))
+
+    assert [
+        operation["action_type"]
+        for operation in _operations(_timing_requests(usage_webhook_server))
+    ] == [_FIRST_OUTPUT_ITEM_ADDED]
 
 
 def test_output_first_codex_reports_only_observed_content_free_milestones(

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
@@ -9,6 +9,7 @@ from mitmproxy import http
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import model_websocket_usage
+import openai_responses_events
 import usage
 from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries_after_flush
 from tests.model_provider_flow_helpers import (
@@ -61,17 +62,21 @@ class TestModelProviderWebSocketPrewarmUsage:
     def _sync_usage_delivery(self, sync_usage_executor, usage_webhook_api):
         self._usage_webhook_api = usage_webhook_api
 
+    @pytest.mark.parametrize("terminal_event", sorted(openai_responses_events.TERMINAL_EVENTS))
     def test_model_websocket_dense_terminal_uses_one_full_body_parse(
         self,
         tmp_path,
         real_flow,
         monkeypatch: pytest.MonkeyPatch,
+        terminal_event: str,
     ):
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
         full_body_feeds = capture_openai_responses_extractor_feeds(monkeypatch)
         dense_terminal = (
-            b'{"type":"response.completed","padding":['
+            b'{"type":"'
+            + terminal_event.encode()
+            + b'","padding":['
             + b",".join([b"0"] * 20_000)
             + b'],"response":{"id":"dense-prewarm","model":"gpt-5.5",'
             b'"usage":{"input_tokens":9,"output_tokens":4}}}'


### PR DESCRIPTION
## Summary

- add a dependency-neutral canonical OpenAI Responses event vocabulary
- make bounded usage inspection, WebSocket lifecycle correlation, and Codex output timing consume the shared taxonomy
- exercise every canonical terminal event through the real WebSocket hook for timing disposal and prewarm usage suppression

## Scope

This is a structural Python refactor. It does not change event membership, parser limits, unknown-event fail-open behavior, feature state machines, public APIs, persisted state, or deployment protocols.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (6440 passed)

Closes #28476
