### PR TITLE
fix(guest-agent): ignore task notification results

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -1328,10 +1328,15 @@ async fn execute_cli_inner(
                                 ParsedEventAction::Forward => {}
                                 ParsedEventAction::Skip => continue,
                             }
-                            let is_result_event =
-                                event.get("type").and_then(serde_json::Value::as_str)
-                                    == Some("result");
-                            if post_result_cleanup_was_armed || is_result_event {
+                            let is_terminal_result_event = event
+                                .get("type")
+                                .and_then(serde_json::Value::as_str)
+                                == Some("result")
+                                && event
+                                    .pointer("/origin/kind")
+                                    .and_then(serde_json::Value::as_str)
+                                    != Some("task-notification");
+                            if post_result_cleanup_was_armed || is_terminal_result_event {
                                 match try_observe_cli_exit(
                                     &mut child,
                                     &mut cli_status,
@@ -1347,7 +1352,7 @@ async fn execute_cli_inner(
                                 }
                             }
                             // Print Claude Code final result to stdout if applicable.
-                            if is_result_event {
+                            if is_terminal_result_event {
                                 let result_summary = ClaudeResultSummary::from_event(&event);
                                 claude_result = Some(result_summary);
                                 if let Some(diagnostic) =

--- a/crates/guest-agent/tests/claude_task_notification_result.rs
+++ b/crates/guest-agent/tests/claude_task_notification_result.rs
@@ -1,0 +1,125 @@
+//! A Claude Code result for a startup task notification is observable but
+//! cannot terminate the actual user command or arm post-result cleanup.
+
+mod common;
+
+use guest_contracts::diagnostics::CliTerminationReason;
+use serde_json::json;
+use std::time::Duration;
+
+#[tokio::test]
+async fn task_notification_result_does_not_end_the_user_command()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let session_id = "mock-task-notification-result";
+    let continued_activity = "actual user command is still running";
+    let prompt = [
+        "@ECHO-HANG@".to_string(),
+        json!({
+            "type": "system",
+            "subtype": "task_notification",
+            "session_id": session_id,
+            "task_id": "background-workflow",
+            "status": "stopped",
+            "summary": "Previous background workflow had no completion record"
+        })
+        .to_string(),
+        json!({
+            "type": "command_lifecycle",
+            "session_id": session_id,
+            "command_uuid": "user-command",
+            "state": "queued"
+        })
+        .to_string(),
+        json!({
+            "type": "system",
+            "subtype": "init",
+            "session_id": session_id,
+            "cwd": "/home/user/workspace",
+            "tools": ["Bash"],
+            "model": "mock-claude"
+        })
+        .to_string(),
+        json!({
+            "type": "result",
+            "subtype": "success",
+            "session_id": session_id,
+            "is_error": false,
+            "num_turns": 0,
+            "result": "",
+            "origin": { "kind": "task-notification" }
+        })
+        .to_string(),
+        json!({
+            "type": "command_lifecycle",
+            "session_id": session_id,
+            "command_uuid": "user-command",
+            "state": "started"
+        })
+        .to_string(),
+        json!({
+            "type": "assistant",
+            "session_id": session_id,
+            "message": {
+                "role": "assistant",
+                "content": [{ "type": "text", "text": continued_activity }]
+            }
+        })
+        .to_string(),
+    ]
+    .join("\n");
+
+    unsafe {
+        common::setup_env(&mock, tmp.path(), &prompt, 1, 1)?;
+        std::env::set_var("VM0_POST_RESULT_TOTAL_CAP_SECS", "1");
+        std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "2");
+    }
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let checkpoint = common::VirtualTimeCheckpoint::new(
+        runtime.paths.agent_log_file(),
+        continued_activity,
+        runtime.config.post_result_total_cap,
+    );
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(8),
+        common::execute_with_virtual_time_checkpoints(
+            common::execute_cli_for_runtime(
+                &runtime,
+                &guest_agent::masker::SecretMasker::from_raw(""),
+                common::spawn_dummy_heartbeat(),
+            ),
+            &[checkpoint],
+        ),
+    )
+    .await
+    .expect("execution timeout did not terminate the hanging mock")??;
+
+    let error = result
+        .control_error
+        .as_ref()
+        .expect("the independent execution timeout should remain authoritative");
+    assert!(
+        error
+            .to_string()
+            .contains("Agent execution timed out after 2 seconds"),
+        "unexpected control error: {error}"
+    );
+    assert_eq!(
+        result
+            .cli_termination
+            .expect("execution timeout should attach termination diagnostics")
+            .reason,
+        CliTerminationReason::ExecutionTimeout
+    );
+    assert!(result.claude_result.is_none());
+    assert!(result.post_result_cleanup_result.is_none());
+
+    let agent_log = std::fs::read_to_string(runtime.paths.agent_log_file())?;
+    assert!(agent_log.contains(r#""kind":"task-notification""#));
+    assert!(agent_log.contains(continued_activity));
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- treat Claude Code `result` events from `origin.kind=task-notification` as auxiliary startup output instead of the terminal result for the user command
- keep those events in the agent log and delivery stream without recording a Claude result or arming post-result cleanup
- add an integration regression that reproduces a task notification followed by continued user-command activity

## Explicit exclusions

- no change to ordinary Claude Code result handling
- no change to the post-result quiet timeout or 120-second total cleanup cap
- no API, persistence, runner protocol, or deployment compatibility changes

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test claude_task_notification_result`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test post_result_reap --test post_result_reap_happy --test post_result_reap_total_cap --test post_result_reap_refresh --test post_result_reap_error_result --test execution_timeout`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`

Closes #28531
