### PR TITLE
docs(rust): specify vsock frame buffer state on encode errors

### DIFF
--- a/crates/vsock-proto/src/payloads/exec_operation/control.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/control.rs
@@ -389,6 +389,17 @@ pub fn validate_exec_control(
 /// The resulting frame uses the same bytes as
 /// `encode(MSG_EXEC_CONTROL, seq, &encode_exec_control(...))` without allocating
 /// a separate exec-control payload vector.
+///
+/// # Errors
+///
+/// Returns [`ProtocolError`] if `target_seq` is zero, `message_id` is empty or
+/// too long, `payload` exceeds [`EXEC_CONTROL_MAX_PAYLOAD_BYTES`], or the
+/// encoded payload exceeds the maximum message size.
+///
+/// `frame` is cleared before request validation. Consequently, a validation
+/// error leaves the destination empty. After validation succeeds, the shared
+/// frame encoder also clears `frame` before checking the frame size and writing
+/// the encoded bytes.
 pub fn encode_exec_control_frame_into(
     frame: &mut Vec<u8>,
     seq: u32,

--- a/crates/vsock-proto/src/payloads/exec_operation/output.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/output.rs
@@ -56,6 +56,16 @@ pub fn encode_exec_output(
 /// The resulting frame uses the same bytes as
 /// `encode(MSG_EXEC_OUTPUT, seq, &encode_exec_output(...))` without allocating
 /// separate payload and frame vectors.
+///
+/// # Errors
+///
+/// Returns [`ProtocolError`] if `chunk` cannot fit its wire length field or the
+/// encoded payload exceeds the maximum message size.
+///
+/// `frame` is cleared before payload validation. Consequently, a validation
+/// error leaves the destination empty. After validation succeeds, the shared
+/// frame encoder also clears `frame` before checking the frame size and writing
+/// the encoded bytes.
 pub fn encode_exec_output_frame_into(
     frame: &mut Vec<u8>,
     seq: u32,

--- a/crates/vsock-proto/src/payloads/exec_operation/result.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/result.rs
@@ -184,6 +184,17 @@ pub fn encode_exec_result(
 /// The resulting frame uses the same bytes as
 /// `encode(MSG_EXEC_RESULT, seq, &encode_exec_result(...))` without allocating
 /// separate payload and frame vectors.
+///
+/// # Errors
+///
+/// Returns [`ProtocolError`] if `diagnostic` or captured stdout/stderr cannot
+/// fit its wire length field, or the encoded payload exceeds the maximum
+/// message size.
+///
+/// `frame` is cleared before payload validation. Consequently, a validation
+/// error leaves the destination empty. After validation succeeds, the shared
+/// frame encoder also clears `frame` before checking the frame size and writing
+/// the encoded bytes.
 pub fn encode_exec_result_frame_into(
     frame: &mut Vec<u8>,
     seq: u32,

--- a/crates/vsock-proto/src/payloads/guest_dns_readiness.rs
+++ b/crates/vsock-proto/src/payloads/guest_dns_readiness.rs
@@ -73,6 +73,16 @@ pub fn encode_guest_dns_readiness_request(
 }
 
 /// Encode a full guest DNS readiness request frame into `frame`.
+///
+/// # Errors
+///
+/// Returns [`ProtocolError`] if `timeout_ms` is zero, `hostname` is empty,
+/// exceeds the configured hostname limit, contains a NUL byte, or cannot fit
+/// the hostname wire-length field.
+///
+/// Request validation runs before the shared frame encoder clears `frame`, so
+/// validation errors leave the destination unchanged. After validation
+/// succeeds, frame construction follows the shared clear-and-write behavior.
 pub fn encode_guest_dns_readiness_request_frame_into(
     frame: &mut Vec<u8>,
     seq: u32,

--- a/crates/vsock-proto/src/payloads/write_file.rs
+++ b/crates/vsock-proto/src/payloads/write_file.rs
@@ -69,6 +69,16 @@ pub fn validate_write_file(
 /// The resulting frame uses the same bytes as
 /// `encode(MSG_WRITE_FILE, seq, &encode_write_file(...))` without allocating
 /// separate payload and frame vectors.
+///
+/// # Errors
+///
+/// Returns [`ProtocolError`] if `path` or `content` cannot fit its wire length
+/// field, or the encoded payload exceeds the maximum message size.
+///
+/// `frame` is cleared before payload validation. Consequently, a validation
+/// error leaves the destination empty. After validation succeeds, the shared
+/// frame encoder also clears `frame` before checking the frame size and writing
+/// the encoded bytes.
 pub fn encode_write_file_frame_into(
     frame: &mut Vec<u8>,
     seq: u32,
@@ -103,6 +113,16 @@ pub fn validate_private_write_file(
 /// The resulting frame uses the same bytes as
 /// `encode(MSG_WRITE_FILE, seq, &encode_private_write_file(...))` without
 /// allocating separate payload and frame vectors.
+///
+/// # Errors
+///
+/// Returns [`ProtocolError`] if `path` or `content` cannot fit its wire length
+/// field, or the encoded payload exceeds the maximum message size.
+///
+/// `frame` is cleared before payload validation. Consequently, a validation
+/// error leaves the destination empty. After validation succeeds, the shared
+/// frame encoder also clears `frame` before checking the frame size and writing
+/// the encoded bytes.
 pub fn encode_private_write_file_frame_into(
     frame: &mut Vec<u8>,
     seq: u32,
@@ -145,6 +165,17 @@ pub fn validate_write_files(files: &[WriteFileBatchEntry<'_>]) -> Result<(), Pro
 /// separate payload and frame vectors.
 ///
 /// This applies the same input constraints documented by [`encode_write_files`].
+///
+/// # Errors
+///
+/// Returns [`ProtocolError`] if `files` is empty, the file count exceeds its
+/// wire length field, a path or content length exceeds its wire length field,
+/// or the encoded payload exceeds the maximum message size.
+///
+/// `frame` is cleared before payload validation. Consequently, a validation
+/// error leaves the destination empty. After validation succeeds, the shared
+/// frame encoder also clears `frame` before checking the frame size and writing
+/// the encoded bytes.
 pub fn encode_write_files_frame_into(
     frame: &mut Vec<u8>,
     seq: u32,

--- a/crates/vsock-proto/tests/guest_dns_readiness_frames.rs
+++ b/crates/vsock-proto/tests/guest_dns_readiness_frames.rs
@@ -1,0 +1,26 @@
+use vsock_proto::{ProtocolError, encode_guest_dns_readiness_request_frame_into};
+
+#[test]
+fn validation_errors_preserve_existing_frame() {
+    for (timeout_ms, hostname, expected_error) in [
+        (
+            0,
+            "example.invalid",
+            "guest_dns_readiness timeout_ms must be positive",
+        ),
+        (1, "", "guest_dns_readiness hostname must not be empty"),
+        (1, "bad\0name", "guest_dns_readiness hostname contains NUL"),
+    ] {
+        let mut frame = b"stale frame bytes".to_vec();
+
+        let error =
+            encode_guest_dns_readiness_request_frame_into(&mut frame, 42, timeout_ms, hostname)
+                .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ProtocolError::InvalidPayload(message) if message == expected_error
+        ));
+        assert_eq!(frame, b"stale frame bytes");
+    }
+}


### PR DESCRIPTION
## Summary

- Document the validation errors and destination-buffer postconditions of all seven public `vsock-proto` `*_frame_into` encoders.
- Add a public-API integration test covering guest DNS validation errors preserving an existing frame buffer.

## Scope

This PR changes rustdoc and test coverage only. It does not change encoder order, wire output, runtime behavior, or the exported API surface.

Closes #28521

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-proto --all-features --no-deps`
