### PR TITLE
perf(nbd-cow): share scans across acquire waiters

### DIFF
--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -20,7 +20,7 @@ pub use state::{DevicePool, DevicePoolConfig};
 
 pub(crate) use lease::DeviceAcquireSource;
 
-/// Maximum blocking NBD scans running concurrently.
+/// Maximum blocking workers sharing one active demand scan.
 const MAX_PENDING: usize = 4;
 
 /// Default cooldown period (milliseconds) after disconnecting a device.

--- a/crates/nbd-cow/src/pool/actor.rs
+++ b/crates/nbd-cow/src/pool/actor.rs
@@ -8,7 +8,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinSet;
 
 use super::lease::{DeviceAcquisition, DeviceLease};
-use super::scan::ScannedDeviceClaim;
+use super::scan::{ScanRequest, ScannedDeviceClaim};
 #[cfg(test)]
 use super::state::DevicePoolSnapshot;
 use super::state::{DevicePool, DevicePoolConfig};
@@ -105,6 +105,9 @@ struct DevicePoolActor {
     pool: DevicePool,
     commands: mpsc::UnboundedReceiver<DevicePoolCommand>,
     pending: JoinSet<Result<ScannedDeviceClaim>>,
+    active_scan: Option<ScanRequest>,
+    scan_exhausted: bool,
+    scan_faulted: bool,
 }
 
 impl DevicePoolHandle {
@@ -160,6 +163,9 @@ impl DevicePoolHandle {
                 pool,
                 commands: command_rx,
                 pending,
+                active_scan: None,
+                scan_exhausted: false,
+                scan_faulted: false,
             }
             .run(),
         );
@@ -303,7 +309,7 @@ impl DevicePoolActor {
                     self.handle_command(command).await;
                 }
                 scan = self.pending.join_next(), if has_pending => {
-                    self.pool.handle_scan_join(scan);
+                    self.handle_scan_join(scan);
                     self.ensure_waiting_progress();
                 }
                 () = sleep_until_deadline(deadline), if deadline.is_some() => {
@@ -354,11 +360,25 @@ impl DevicePoolActor {
     }
 
     fn ensure_waiting_progress(&mut self) {
-        self.pool.ensure_waiting_progress(self.pending.len());
+        let pending_scans = self.pending.len();
+        if pending_scans == 0 {
+            if self.scan_faulted {
+                self.reset_scan_cohort();
+            } else if self.scan_exhausted {
+                self.pool.defer_scan_exhaustion();
+                self.reset_scan_cohort();
+            } else if self.pool.waiting_acquires.is_empty() {
+                self.active_scan = None;
+            }
+        }
+        self.pool.ensure_waiting_progress(pending_scans);
         self.spawn_waiting_scans();
     }
 
     fn spawn_waiting_scans(&mut self) {
+        if self.scan_exhausted || self.scan_faulted {
+            return;
+        }
         let scans_to_spawn = self.pool.scans_to_spawn(self.pending.len());
         for _ in 0..scans_to_spawn {
             self.spawn_scan();
@@ -366,13 +386,47 @@ impl DevicePoolActor {
     }
 
     fn spawn_scan(&mut self) {
-        let request = self.pool.scan_request();
+        let request = self
+            .active_scan
+            .get_or_insert_with(|| self.pool.scan_request())
+            .clone();
         self.pending.spawn_blocking(move || request.run());
+    }
+
+    fn handle_scan_join(
+        &mut self,
+        scan: Option<std::result::Result<Result<ScannedDeviceClaim>, tokio::task::JoinError>>,
+    ) {
+        match scan {
+            Some(Ok(Ok(scanned))) => self.pool.handle_scan_claim(scanned),
+            Some(Ok(Err(NbdCowError::NoFreeDevice))) if !self.scan_faulted => {
+                self.scan_exhausted = true;
+            }
+            Some(Ok(Err(NbdCowError::NoFreeDevice))) => {}
+            Some(Ok(Err(error))) => self.handle_scan_fault(error),
+            Some(Err(error)) => self.handle_scan_fault(NbdCowError::Io(std::io::Error::other(
+                format!("device scan task failed: {error}"),
+            ))),
+            None => {}
+        }
+    }
+
+    fn handle_scan_fault(&mut self, error: NbdCowError) {
+        self.scan_faulted = true;
+        self.scan_exhausted = false;
+        self.pool.defer_acquire_error(error);
+    }
+
+    fn reset_scan_cohort(&mut self) {
+        self.active_scan = None;
+        self.scan_exhausted = false;
+        self.scan_faulted = false;
     }
 
     async fn abort_pending(&mut self) {
         self.pending.abort_all();
         while self.pending.join_next().await.is_some() {}
+        self.reset_scan_cohort();
     }
 }
 

--- a/crates/nbd-cow/src/pool/actor.rs
+++ b/crates/nbd-cow/src/pool/actor.rs
@@ -362,6 +362,9 @@ impl DevicePoolActor {
     fn ensure_waiting_progress(&mut self) {
         let pending_scans = self.pending.len();
         if pending_scans == 0 {
+            // One worker can reach the end of the shared cursor while peers are
+            // still checking offsets they already reserved. Exhaustion becomes
+            // authoritative only after every worker in the cohort has joined.
             if self.scan_faulted {
                 self.reset_scan_cohort();
             } else if self.scan_exhausted {
@@ -412,6 +415,8 @@ impl DevicePoolActor {
     }
 
     fn handle_scan_fault(&mut self, error: NbdCowError) {
+        // A failed worker may have reserved an offset without completing its
+        // checks, so this cohort can no longer prove clean exhaustion.
         self.scan_faulted = true;
         self.scan_exhausted = false;
         self.pool.defer_acquire_error(error);

--- a/crates/nbd-cow/src/pool/scan.rs
+++ b/crates/nbd-cow/src/pool/scan.rs
@@ -1,5 +1,9 @@
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Duration, Instant};
 
 use crate::device_lock::{self, NbdDeviceClaim};
@@ -8,11 +12,22 @@ use crate::netlink;
 
 use super::DeviceFreeCheck;
 
+/// One process-local demand scan shared by concurrent blocking workers.
+///
+/// The shared cursor issues every logical offset at most once. Host-global
+/// ownership still comes from the per-index lock and post-lock sysfs recheck.
+#[derive(Clone)]
 pub(super) struct ScanRequest {
-    pub(super) max_devices: u32,
-    pub(super) exclude: HashSet<u32>,
-    pub(super) lock_dir: PathBuf,
-    pub(super) device_appears_free: DeviceFreeCheck,
+    shared: Arc<SharedScan>,
+}
+
+struct SharedScan {
+    max_devices: u32,
+    start: u32,
+    next_offset: AtomicU32,
+    exclude: HashSet<u32>,
+    lock_dir: PathBuf,
+    device_appears_free: DeviceFreeCheck,
 }
 
 pub(super) struct ScannedDeviceClaim {
@@ -31,15 +46,69 @@ impl ScannedDeviceClaim {
 }
 
 impl ScanRequest {
+    pub(super) fn new(
+        max_devices: u32,
+        exclude: HashSet<u32>,
+        lock_dir: PathBuf,
+        device_appears_free: DeviceFreeCheck,
+    ) -> Self {
+        Self {
+            shared: Arc::new(SharedScan {
+                max_devices,
+                start: netlink::random_offset(max_devices),
+                next_offset: AtomicU32::new(0),
+                exclude,
+                lock_dir,
+                device_appears_free,
+            }),
+        }
+    }
+
     pub(super) fn run(self) -> Result<ScannedDeviceClaim> {
         let started_at = Instant::now();
-        let claim = scan_and_claim_with(
-            self.max_devices,
-            &self.exclude,
-            &self.lock_dir,
-            self.device_appears_free,
-        )?;
+        let claim = self.scan_and_claim()?;
         Ok(ScannedDeviceClaim::new(claim, started_at.elapsed()))
+    }
+
+    fn scan_and_claim(&self) -> Result<NbdDeviceClaim> {
+        while let Some(index) = self.next_index() {
+            if self.shared.exclude.contains(&index) {
+                continue;
+            }
+            if !(self.shared.device_appears_free)(index) {
+                continue;
+            }
+            match device_lock::try_acquire_device_claim_in(index, &self.shared.lock_dir) {
+                Ok(Some(claim)) => {
+                    if (self.shared.device_appears_free)(index) {
+                        return Ok(claim);
+                    }
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        device_index = index,
+                        error = %e,
+                        "cannot acquire NBD device lock, skipping index"
+                    );
+                }
+            }
+        }
+
+        Err(NbdCowError::NoFreeDevice)
+    }
+
+    fn next_index(&self) -> Option<u32> {
+        let offset = self
+            .shared
+            .next_offset
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |offset| {
+                (offset < self.shared.max_devices).then(|| offset + 1)
+            })
+            .ok()?;
+        let index =
+            (u64::from(self.shared.start) + u64::from(offset)) % u64::from(self.shared.max_devices);
+        Some(index as u32)
     }
 }
 
@@ -48,45 +117,18 @@ impl ScanRequest {
 /// Starts from a random offset to distribute usage across runners. The first
 /// sysfs check is a cheap precheck; the post-lock sysfs check is the correctness
 /// gate that prevents stale observations from becoming leases.
-pub(super) fn scan_and_claim_with<F>(
+#[cfg(test)]
+pub(super) fn scan_and_claim_with(
     max_devices: u32,
     exclude: &HashSet<u32>,
     lock_dir: &Path,
-    device_appears_free: F,
-) -> Result<NbdDeviceClaim>
-where
-    F: Fn(u32) -> bool,
-{
-    if max_devices == 0 {
-        return Err(NbdCowError::NoFreeDevice);
-    }
-
-    let start = netlink::random_offset(max_devices);
-
-    for n in 0..max_devices {
-        let i = (start + n) % max_devices;
-        if exclude.contains(&i) {
-            continue;
-        }
-        if !device_appears_free(i) {
-            continue;
-        }
-        match device_lock::try_acquire_device_claim_in(i, lock_dir) {
-            Ok(Some(claim)) => {
-                if device_appears_free(i) {
-                    return Ok(claim);
-                }
-            }
-            Ok(None) => {}
-            Err(e) => {
-                tracing::warn!(
-                    device_index = i,
-                    error = %e,
-                    "cannot acquire NBD device lock, skipping index"
-                );
-            }
-        }
-    }
-
-    Err(NbdCowError::NoFreeDevice)
+    device_appears_free: DeviceFreeCheck,
+) -> Result<NbdDeviceClaim> {
+    let request = ScanRequest::new(
+        max_devices,
+        exclude.clone(),
+        lock_dir.to_path_buf(),
+        device_appears_free,
+    );
+    request.scan_and_claim()
 }

--- a/crates/nbd-cow/src/pool/state.rs
+++ b/crates/nbd-cow/src/pool/state.rs
@@ -92,6 +92,8 @@ pub struct DevicePool {
     pub(super) lease_return: Option<mpsc::WeakUnboundedSender<DevicePoolCommand>>,
     /// Acquire errors that raced with still-pending scans.
     pub(super) deferred_acquire_errors: VecDeque<NbdCowError>,
+    /// A complete shared scan that found no claim, deferred behind cooldown.
+    pub(super) deferred_scan_exhaustion: bool,
     /// Acquire requests waiting for a scan or an expired cooldown claim.
     pub(super) waiting_acquires: VecDeque<oneshot::Sender<Result<DeviceAcquisition>>>,
     /// Total number of NBD devices (from sysfs nbds_max).
@@ -131,6 +133,7 @@ impl DevicePool {
             cooldown: VecDeque::new(),
             lease_return: None,
             deferred_acquire_errors: VecDeque::new(),
+            deferred_scan_exhaustion: false,
             waiting_acquires: VecDeque::new(),
             max_devices,
             config,
@@ -182,23 +185,27 @@ impl DevicePool {
 
         if self.waiting_acquires.is_empty() {
             self.deferred_acquire_errors.clear();
+            self.deferred_scan_exhaustion = false;
             return;
         }
 
-        if pending_scans == 0
-            && !self.deferred_acquire_errors.is_empty()
-            && !self.cooldown_timer_pending()
-        {
-            self.fail_deferred_acquire_errors();
+        if pending_scans == 0 && !self.cooldown_timer_pending() {
+            if !self.deferred_acquire_errors.is_empty() {
+                self.fail_deferred_acquire_errors();
+            } else if self.deferred_scan_exhaustion {
+                self.fail_all_waiters();
+            }
         }
 
         if self.waiting_acquires.is_empty() {
             self.deferred_acquire_errors.clear();
+            self.deferred_scan_exhaustion = false;
         }
     }
 
     pub(super) fn scans_to_spawn(&self, pending_scans: usize) -> usize {
-        if !self.active || !self.deferred_acquire_errors.is_empty() {
+        if !self.active || !self.deferred_acquire_errors.is_empty() || self.deferred_scan_exhaustion
+        {
             return 0;
         }
         let remaining_capacity = MAX_PENDING.saturating_sub(pending_scans);
@@ -207,43 +214,27 @@ impl DevicePool {
     }
 
     pub(super) fn scan_request(&self) -> ScanRequest {
-        ScanRequest {
-            max_devices: self.max_devices,
-            exclude: self.tracked_indices(),
-            lock_dir: self.lock_dir.clone(),
-            device_appears_free: self.device_appears_free,
-        }
+        ScanRequest::new(
+            self.max_devices,
+            self.tracked_indices(),
+            self.lock_dir.clone(),
+            self.device_appears_free,
+        )
     }
 
-    pub(super) fn handle_scan_join(
-        &mut self,
-        scan: Option<std::result::Result<Result<ScannedDeviceClaim>, tokio::task::JoinError>>,
-    ) {
-        match scan {
-            Some(Ok(Ok(scanned))) => {
-                let (claim, scan_duration) = scanned.into_parts();
-                if self.is_tracked(claim.index()) {
-                    tracing::warn!(
-                        device_index = claim.index(),
-                        "dropping scan result because index is already tracked"
-                    );
-                } else {
-                    self.assign_claim_to_waiter(
-                        claim,
-                        DeviceAcquireSource::DemandScan,
-                        Some(scan_duration),
-                    );
-                }
-            }
-            Some(Ok(Err(e))) => {
-                self.defer_acquire_error(e);
-            }
-            Some(Err(e)) if !self.waiting_acquires.is_empty() => {
-                self.defer_acquire_error(NbdCowError::Io(std::io::Error::other(format!(
-                    "device scan task failed: {e}"
-                ))));
-            }
-            Some(Err(_)) | None => {}
+    pub(super) fn handle_scan_claim(&mut self, scanned: ScannedDeviceClaim) {
+        let (claim, scan_duration) = scanned.into_parts();
+        if self.is_tracked(claim.index()) {
+            tracing::warn!(
+                device_index = claim.index(),
+                "dropping scan result because index is already tracked"
+            );
+        } else {
+            self.assign_claim_to_waiter(
+                claim,
+                DeviceAcquireSource::DemandScan,
+                Some(scan_duration),
+            );
         }
     }
 
@@ -287,11 +278,17 @@ impl DevicePool {
         false
     }
 
-    fn defer_acquire_error(&mut self, error: NbdCowError) {
+    pub(super) fn defer_acquire_error(&mut self, error: NbdCowError) {
         if self.waiting_acquires.is_empty() {
             return;
         }
         self.deferred_acquire_errors.push_back(error);
+    }
+
+    pub(super) fn defer_scan_exhaustion(&mut self) {
+        if !self.waiting_acquires.is_empty() {
+            self.deferred_scan_exhaustion = true;
+        }
     }
 
     fn fail_deferred_acquire_errors(&mut self) {
@@ -390,6 +387,7 @@ impl DevicePool {
         }
         self.fail_all_waiters();
         self.deferred_acquire_errors.clear();
+        self.deferred_scan_exhaustion = false;
     }
 
     pub(super) fn finish_cleanup(&mut self) {

--- a/crates/nbd-cow/src/pool/tests.rs
+++ b/crates/nbd-cow/src/pool/tests.rs
@@ -1,7 +1,8 @@
 use super::*;
 use std::collections::HashSet;
 use std::path::Path;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Condvar, Mutex};
 use std::time::Duration;
 
 use crate::device_lock::{self, NbdDeviceClaim};
@@ -18,6 +19,68 @@ fn always_free(_: u32) -> bool {
 
 fn never_free(_: u32) -> bool {
     false
+}
+
+struct ScanWorkerGate {
+    checks: AtomicUsize,
+    released: AtomicBool,
+    lock: Mutex<()>,
+    changed: Condvar,
+}
+
+impl ScanWorkerGate {
+    const fn new() -> Self {
+        Self {
+            checks: AtomicUsize::new(0),
+            released: AtomicBool::new(false),
+            lock: Mutex::new(()),
+            changed: Condvar::new(),
+        }
+    }
+
+    fn check(&self, result: bool) -> bool {
+        self.checks.fetch_add(1, Ordering::SeqCst);
+        let guard = self.lock.lock().expect("scan gate lock");
+        let _guard = self
+            .changed
+            .wait_while(guard, |_| !self.released.load(Ordering::SeqCst))
+            .expect("scan gate wait");
+        result
+    }
+
+    fn release(&self) {
+        let _guard = self.lock.lock().expect("scan gate lock");
+        self.released.store(true, Ordering::SeqCst);
+        self.changed.notify_all();
+    }
+
+    fn checks(&self) -> usize {
+        self.checks.load(Ordering::SeqCst)
+    }
+}
+
+static BUSY_SCAN_GATE: ScanWorkerGate = ScanWorkerGate::new();
+static FREE_SCAN_GATE: ScanWorkerGate = ScanWorkerGate::new();
+
+fn gated_never_free(_: u32) -> bool {
+    BUSY_SCAN_GATE.check(false)
+}
+
+fn gated_always_free(_: u32) -> bool {
+    FREE_SCAN_GATE.check(true)
+}
+
+async fn wait_for_scan_workers(gate: &ScanWorkerGate) {
+    let workers_ready = tokio::time::timeout(Duration::from_secs(1), async {
+        while gate.checks() < MAX_PENDING {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+    if workers_ready.is_err() {
+        gate.release();
+        panic!("demand scan did not start {MAX_PENDING} concurrent workers");
+    }
 }
 
 fn test_pool(

--- a/crates/nbd-cow/src/pool/tests/cooldown.rs
+++ b/crates/nbd-cow/src/pool/tests/cooldown.rs
@@ -79,9 +79,9 @@ async fn expired_cooldown_with_failed_recheck_drops_claim_and_scans() {
     pool.release_claim(claim(3, dir.path()));
     let (respond_to, mut response) = oneshot::channel();
     pool.waiting_acquires.push_back(respond_to);
-    pool.handle_scan_join(Some(Ok(Err(NbdCowError::NoFreeDevice))));
+    pool.defer_scan_exhaustion();
     assert_eq!(pool.waiting_acquires.len(), 1);
-    assert_eq!(pool.deferred_acquire_errors.len(), 1);
+    assert!(pool.deferred_scan_exhaustion);
     pool.ensure_waiting_progress(0);
     assert!(matches!(
         response.try_recv(),

--- a/crates/nbd-cow/src/pool/tests/waiting.rs
+++ b/crates/nbd-cow/src/pool/tests/waiting.rs
@@ -35,6 +35,90 @@ async fn waiting_acquires_spawn_demand_scans_up_to_limit() {
 }
 
 #[tokio::test]
+async fn all_busy_waiter_burst_shares_one_candidate_traversal() {
+    const MAX_TEST_DEVICES: u32 = 64;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let handle = DevicePoolHandle::from_pool(test_pool(
+        MAX_TEST_DEVICES,
+        DevicePoolConfig::default().cooldown,
+        dir.path(),
+        gated_never_free,
+    ));
+    let acquire_tasks = (0..MAX_PENDING)
+        .map(|_| {
+            let handle = handle.clone();
+            tokio::spawn(async move { handle.acquire().await })
+        })
+        .collect::<Vec<_>>();
+
+    wait_for_scan_workers(&BUSY_SCAN_GATE).await;
+    BUSY_SCAN_GATE.release();
+
+    let results = tokio::time::timeout(Duration::from_secs(1), async {
+        let mut results = Vec::with_capacity(MAX_PENDING);
+        for task in acquire_tasks {
+            results.push(task.await.expect("acquire task panicked"));
+        }
+        results
+    })
+    .await
+    .expect("all-busy acquire burst did not finish");
+
+    assert!(
+        results
+            .into_iter()
+            .all(|result| matches!(result, Err(NbdCowError::NoFreeDevice)))
+    );
+    assert_eq!(BUSY_SCAN_GATE.checks(), MAX_TEST_DEVICES as usize);
+    handle.cleanup().await;
+}
+
+#[tokio::test]
+async fn healthy_waiter_burst_keeps_concurrent_workers_and_distinct_claims() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let handle = DevicePoolHandle::from_pool(test_pool(
+        MAX_PENDING as u32,
+        DevicePoolConfig::default().cooldown,
+        dir.path(),
+        gated_always_free,
+    ));
+    let acquire_tasks = (0..MAX_PENDING)
+        .map(|_| {
+            let handle = handle.clone();
+            tokio::spawn(async move { handle.acquire().await })
+        })
+        .collect::<Vec<_>>();
+
+    wait_for_scan_workers(&FREE_SCAN_GATE).await;
+    FREE_SCAN_GATE.release();
+
+    let acquisitions = tokio::time::timeout(Duration::from_secs(1), async {
+        let mut acquisitions = Vec::with_capacity(MAX_PENDING);
+        for task in acquire_tasks {
+            acquisitions.push(
+                task.await
+                    .expect("acquire task panicked")
+                    .expect("acquire failed"),
+            );
+        }
+        acquisitions
+    })
+    .await
+    .expect("healthy acquire burst did not finish");
+
+    let indices = acquisitions
+        .iter()
+        .map(|acquisition| acquisition.index())
+        .collect::<HashSet<_>>();
+    assert_eq!(indices.len(), MAX_PENDING);
+    for acquisition in acquisitions {
+        handle.discard(acquisition.into_lease()).await;
+    }
+    handle.cleanup().await;
+}
+
+#[tokio::test]
 async fn single_waiting_acquire_spawns_single_demand_scan() {
     let dir = tempfile::tempdir().expect("tempdir");
     let mut pool = test_pool_for_pending_scan(dir.path());
@@ -113,7 +197,7 @@ async fn separate_pools_do_not_claim_same_locked_index() {
 }
 
 #[tokio::test]
-async fn demand_error_waits_for_pending_success_before_failing_waiter() {
+async fn scan_exhaustion_waits_for_pending_success_before_failing_waiter() {
     let dir = tempfile::tempdir().expect("tempdir");
     let mut pool = test_pool_for_pending_scan(dir.path());
     let (mut pending, complete_scan) = pending_controlled_scan();
@@ -122,7 +206,7 @@ async fn demand_error_waits_for_pending_success_before_failing_waiter() {
     pool.waiting_acquires.push_back(first_tx);
     pool.waiting_acquires.push_back(second_tx);
 
-    pool.handle_scan_join(Some(Ok(Err(NbdCowError::NoFreeDevice))));
+    pool.defer_scan_exhaustion();
     pool.ensure_waiting_progress(pending.len());
 
     assert!(matches!(
@@ -131,8 +215,8 @@ async fn demand_error_waits_for_pending_success_before_failing_waiter() {
     ));
 
     complete_scan.send(Ok(claim(4, dir.path()))).unwrap();
-    let scan = pending.join_next().await.unwrap();
-    pool.handle_scan_join(Some(scan));
+    let scanned = pending.join_next().await.unwrap().unwrap().unwrap();
+    pool.handle_scan_claim(scanned);
     pool.ensure_waiting_progress(pending.len());
 
     let first_lease = first_rx.await.unwrap().unwrap();
@@ -146,7 +230,7 @@ async fn demand_error_waits_for_pending_success_before_failing_waiter() {
 }
 
 #[tokio::test]
-async fn deferred_error_starts_new_demand_scan_for_remaining_waiter() {
+async fn deferred_task_error_starts_new_demand_scan_for_remaining_waiter() {
     let dir = tempfile::tempdir().expect("tempdir");
     let mut pool = test_pool_for_pending_scan(dir.path());
     let (first_tx, first_rx) = oneshot::channel();
@@ -154,13 +238,12 @@ async fn deferred_error_starts_new_demand_scan_for_remaining_waiter() {
     pool.waiting_acquires.push_back(first_tx);
     pool.waiting_acquires.push_back(second_tx);
 
-    pool.handle_scan_join(Some(Ok(Err(NbdCowError::NoFreeDevice))));
+    pool.defer_acquire_error(NbdCowError::Io(std::io::Error::other(
+        "injected scan task failure",
+    )));
     pool.ensure_waiting_progress(0);
 
-    assert!(matches!(
-        first_rx.await.unwrap(),
-        Err(NbdCowError::NoFreeDevice)
-    ));
+    assert!(matches!(first_rx.await.unwrap(), Err(NbdCowError::Io(_))));
     assert!(matches!(
         second_rx.try_recv(),
         Err(oneshot::error::TryRecvError::Empty)
@@ -180,7 +263,7 @@ fn scan_success_skips_cancelled_waiter_without_leaking_lock() {
     pool.waiting_acquires.push_back(cancelled_tx);
     pool.waiting_acquires.push_back(active_tx);
 
-    pool.handle_scan_join(Some(Ok(Ok(scanned(claim(4, dir.path()))))));
+    pool.handle_scan_claim(scanned(claim(4, dir.path())));
 
     let lease = active_rx.try_recv().unwrap().unwrap();
     assert_eq!(lease.index(), 4);
@@ -198,7 +281,7 @@ fn cancelled_waiter_after_scan_completion_drops_claim() {
     drop(cancelled_rx);
     pool.waiting_acquires.push_back(cancelled_tx);
 
-    pool.handle_scan_join(Some(Ok(Ok(scanned(claim(4, dir.path()))))));
+    pool.handle_scan_claim(scanned(claim(4, dir.path())));
 
     assert!(pool.waiting_acquires.is_empty());
     assert!(pool.in_flight.is_empty());
@@ -219,13 +302,12 @@ async fn deferred_error_skips_cancelled_waiter() {
     pool.waiting_acquires.push_back(cancelled_tx);
     pool.waiting_acquires.push_back(active_tx);
 
-    pool.handle_scan_join(Some(Ok(Err(NbdCowError::NoFreeDevice))));
+    pool.defer_acquire_error(NbdCowError::Io(std::io::Error::other(
+        "injected scan task failure",
+    )));
     pool.ensure_waiting_progress(0);
 
-    assert!(matches!(
-        active_rx.await.unwrap(),
-        Err(NbdCowError::NoFreeDevice)
-    ));
+    assert!(matches!(active_rx.await.unwrap(), Err(NbdCowError::Io(_))));
     assert!(pool.waiting_acquires.is_empty());
     assert!(pool.deferred_acquire_errors.is_empty());
 }


### PR DESCRIPTION
## Summary

- share one randomized NBD scan cohort across concurrent acquire workers
- defer clean cohort exhaustion until every issued check completes, while recovering from worker faults with a fresh cohort
- add deterministic actor-entry coverage for one traversal under exhaustion and concurrent distinct healthy claims

## Compatibility

- no public API, runner protocol, persisted state, or lock ownership changes
- old and new runners continue to coordinate through the existing host-global per-device locks

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p nbd-cow --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc -p nbd-cow --all-features --no-deps`
- [x] `cargo test -p nbd-cow`

Closes #28522
