### PR TITLE
fix(nbd-cow): prevent stale disconnects after tid reuse

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2072,6 +2072,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test-support",
+ "uuid",
  "which",
 ]
 

--- a/crates/nbd-cow/Cargo.toml
+++ b/crates/nbd-cow/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 which = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/nbd-cow/src/device/connection.rs
+++ b/crates/nbd-cow/src/device/connection.rs
@@ -1,5 +1,7 @@
 use std::time::{Duration, Instant};
 
+use uuid::Uuid;
+
 use crate::error::{self, Result};
 use crate::{netlink, pool};
 
@@ -148,9 +150,11 @@ impl Drop for ConnectDeviceOutcome {
             return;
         };
 
-        let connect_tid = match result {
-            Ok(success) => success.connect_tid,
-            Err(netlink::ConnectDeviceError::AmbiguousAfterSend { connect_tid, .. }) => connect_tid,
+        let connection_id = match result {
+            Ok(success) => success.connection_id,
+            Err(netlink::ConnectDeviceError::AmbiguousAfterSend { connection_id, .. }) => {
+                connection_id
+            }
             Err(
                 netlink::ConnectDeviceError::NotSent { .. }
                 | netlink::ConnectDeviceError::DefiniteAfterSend { .. },
@@ -159,12 +163,11 @@ impl Drop for ConnectDeviceOutcome {
 
         tracing::warn!(
             device_index = self.device_index,
-            connect_tid,
             "NBD connect result dropped before observation; disconnecting owned device"
         );
         disconnect_connected_if_owned(ConnectedDevice {
             index: self.device_index,
-            connect_tid,
+            connection_id,
         });
     }
 }
@@ -213,67 +216,6 @@ pub(super) async fn connect_device_with_state_critical_section(
     ConnectDeviceCriticalSectionResult { timing, result }
 }
 
-pub(super) struct DisconnectOutcome {
-    device_index: u32,
-    lease: Option<DeferredLease>,
-    result: Option<Result<()>>,
-}
-
-impl DisconnectOutcome {
-    fn with_lease(device_index: u32, lease: DeferredLease, result: Result<()>) -> Self {
-        Self {
-            device_index,
-            lease: Some(lease),
-            result: Some(result),
-        }
-    }
-
-    pub(super) fn into_parts(mut self) -> Result<(pool::DeviceLease, Result<()>)> {
-        let result = match self.result.take() {
-            Some(result) => result,
-            None => Err(error::NbdCowError::Io(std::io::Error::other(
-                "disconnect outcome consumed twice",
-            )))?,
-        };
-        let lease = match self.lease.as_mut().and_then(DeferredLease::take) {
-            Some(lease) => lease,
-            None => {
-                return Err(error::NbdCowError::Io(std::io::Error::other(
-                    "disconnect outcome lease consumed twice",
-                )));
-            }
-        };
-        Ok((lease, result))
-    }
-}
-
-impl Drop for DisconnectOutcome {
-    fn drop(&mut self) {
-        if let Some(result) = self.result.as_ref() {
-            observe_detached_disconnect_result(
-                self.device_index,
-                DetachedDisconnectResult::Unconditional(result),
-            );
-        }
-    }
-}
-
-pub(super) async fn disconnect_device_with_lease_critical_section(
-    device_index: u32,
-    pool: pool::DevicePoolHandle,
-    lease: pool::DeviceLease,
-) -> Result<DisconnectOutcome> {
-    let deferred_lease = DeferredLease::new(pool, lease);
-    run_netlink_critical_section("NBD disconnect", move || {
-        DisconnectOutcome::with_lease(
-            device_index,
-            deferred_lease,
-            netlink::disconnect(device_index),
-        )
-    })
-    .await
-}
-
 pub(super) struct OwnedDisconnectResultOutcome {
     device_index: u32,
     lease: DeferredLease,
@@ -309,10 +251,7 @@ impl OwnedDisconnectResultOutcome {
 impl Drop for OwnedDisconnectResultOutcome {
     fn drop(&mut self) {
         if let Some(result) = self.result.as_ref() {
-            observe_detached_disconnect_result(
-                self.device_index,
-                DetachedDisconnectResult::Owned(result),
-            );
+            observe_detached_disconnect_result(self.device_index, result);
         }
     }
 }
@@ -346,12 +285,12 @@ pub(super) async fn disconnect_connected_if_owned_result_with_lease_critical_sec
     .await
 }
 
-/// Result of checking NBD device ownership via sysfs PID.
+/// Result of checking NBD device ownership via its sysfs backend identifier.
 pub(super) enum DeviceOwnership {
-    /// We own the device (sysfs PID matches our PID).
+    /// We own the device (the backend identifier matches our connection UUID).
     Ours,
-    /// Another process owns the device (with its PID).
-    Foreign(u32),
+    /// Another connection owns the device.
+    Foreign,
     /// Cannot determine ownership (sysfs read failed).
     Unknown(std::io::Error),
 }
@@ -359,66 +298,46 @@ pub(super) enum DeviceOwnership {
 #[derive(Clone, Copy)]
 pub(super) struct ConnectedDevice {
     pub(super) index: u32,
-    pub(super) connect_tid: u32,
+    pub(super) connection_id: Uuid,
 }
 
 pub(super) enum OwnedDisconnectState {
     Disconnected,
-    Foreign(u32),
+    Foreign,
 }
 
-enum DetachedDisconnectResult<'a> {
-    Unconditional(&'a Result<()>),
-    Owned(&'a Result<OwnedDisconnectState>),
-}
-
-fn observe_detached_disconnect_result(device_index: u32, result: DetachedDisconnectResult<'_>) {
+fn observe_detached_disconnect_result(device_index: u32, result: &Result<OwnedDisconnectState>) {
     match result {
-        DetachedDisconnectResult::Unconditional(Err(e))
-        | DetachedDisconnectResult::Owned(Err(e)) => {
+        Err(e) => {
             tracing::warn!(
                 device_index,
                 error = %e,
                 "detached NBD disconnect failed"
             );
         }
-        DetachedDisconnectResult::Owned(Ok(OwnedDisconnectState::Foreign(pid))) => {
+        Ok(OwnedDisconnectState::Foreign) => {
             tracing::warn!(
                 device_index,
-                foreign_pid = pid,
                 "detached owned NBD disconnect skipped: device recycled by another process"
             );
         }
-        DetachedDisconnectResult::Unconditional(Ok(()))
-        | DetachedDisconnectResult::Owned(Ok(OwnedDisconnectState::Disconnected)) => {}
+        Ok(OwnedDisconnectState::Disconnected) => {}
     }
 }
 
-pub(super) fn device_ownership(device_index: u32, connect_tid: u32) -> DeviceOwnership {
-    let pid_path = format!("/sys/block/nbd{device_index}/pid");
-    match std::fs::read_to_string(&pid_path) {
-        Ok(contents) => device_ownership_from_pid_contents(device_index, connect_tid, &contents),
+pub(super) fn device_ownership(device_index: u32, connection_id: Uuid) -> DeviceOwnership {
+    let backend_path = format!("/sys/block/nbd{device_index}/backend");
+    match std::fs::read_to_string(&backend_path) {
+        Ok(contents) => device_ownership_from_backend_contents(connection_id, &contents),
         Err(e) => DeviceOwnership::Unknown(e),
     }
 }
 
-fn device_ownership_from_pid_contents(
-    device_index: u32,
-    connect_tid: u32,
-    contents: &str,
-) -> DeviceOwnership {
-    let pid = contents.trim();
-    if pid == "-1" || pid == "0" || pid.is_empty() {
-        return DeviceOwnership::Foreign(0);
-    }
-
-    match pid.parse::<u32>() {
-        Ok(tid) if tid == connect_tid => DeviceOwnership::Ours,
-        Ok(tid) => DeviceOwnership::Foreign(tid),
-        Err(e) => DeviceOwnership::Unknown(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!("invalid NBD device pid for nbd{device_index}: {e}"),
-        )),
+fn device_ownership_from_backend_contents(connection_id: Uuid, contents: &str) -> DeviceOwnership {
+    if contents.trim() == connection_id.to_string() {
+        DeviceOwnership::Ours
+    } else {
+        DeviceOwnership::Foreign
     }
 }
 
@@ -428,15 +347,15 @@ pub(super) fn disconnect_connected_if_owned(connected: ConnectedDevice) -> bool 
 
 fn disconnect_connected_if_owned_result_with(
     connected: ConnectedDevice,
-    ownership: impl FnOnce(u32, u32) -> DeviceOwnership,
+    ownership: impl FnOnce(u32, Uuid) -> DeviceOwnership,
     disconnect: impl FnOnce(u32) -> Result<()>,
 ) -> Result<OwnedDisconnectState> {
-    match ownership(connected.index, connected.connect_tid) {
+    match ownership(connected.index, connected.connection_id) {
         DeviceOwnership::Ours => {
             disconnect(connected.index)?;
             Ok(OwnedDisconnectState::Disconnected)
         }
-        DeviceOwnership::Foreign(pid) => Ok(OwnedDisconnectState::Foreign(pid)),
+        DeviceOwnership::Foreign => Ok(OwnedDisconnectState::Foreign),
         DeviceOwnership::Unknown(err) => Err(error::NbdCowError::Io(std::io::Error::new(
             err.kind(),
             format!(
@@ -449,10 +368,10 @@ fn disconnect_connected_if_owned_result_with(
 
 fn disconnect_connected_if_owned_with(
     connected: ConnectedDevice,
-    ownership: impl FnOnce(u32, u32) -> DeviceOwnership,
+    ownership: impl FnOnce(u32, Uuid) -> DeviceOwnership,
     disconnect: impl FnOnce(u32) -> Result<()>,
 ) -> bool {
-    match ownership(connected.index, connected.connect_tid) {
+    match ownership(connected.index, connected.connection_id) {
         DeviceOwnership::Ours => {
             if let Err(e) = disconnect(connected.index) {
                 tracing::warn!(
@@ -465,10 +384,9 @@ fn disconnect_connected_if_owned_with(
                 true
             }
         }
-        DeviceOwnership::Foreign(pid) => {
+        DeviceOwnership::Foreign => {
             tracing::warn!(
                 device_index = connected.index,
-                foreign_pid = pid,
                 "skipping cancelled-create disconnect: device recycled by another process"
             );
             false
@@ -477,7 +395,7 @@ fn disconnect_connected_if_owned_with(
             tracing::warn!(
                 device_index = connected.index,
                 error = %err,
-                "skipping cancelled-create disconnect: cannot read device pid"
+                "skipping cancelled-create disconnect: cannot read device backend identity"
             );
             false
         }
@@ -503,6 +421,10 @@ mod tests {
     use tracing_test_support::{CapturedEvent, CapturedEvents};
 
     const TEST_DEVICE_INDEX: u32 = 0;
+
+    fn test_connection_id() -> Uuid {
+        Uuid::from_u128(42)
+    }
 
     async fn acquired_test_lease() -> (pool::DevicePoolHandle, pool::DeviceLease, tempfile::TempDir)
     {
@@ -559,32 +481,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn dropped_unconditional_disconnect_error_is_observed() {
-        let (pool, lease, _lock_dir) = acquired_test_lease().await;
-        let outcome = DisconnectOutcome::with_lease(
-            TEST_DEVICE_INDEX,
-            DeferredLease::new(pool.clone(), lease),
-            Err(error::NbdCowError::Io(std::io::Error::other(
-                "unconditional disconnect failed",
-            ))),
-        );
-
-        let ((), captured) = capture_events(|| drop(outcome));
-
-        let event = event_with_message(&captured, "detached NBD disconnect failed");
-        assert_eq!(event.level, Level::WARN);
-        assert_eq!(
-            event.fields.get("device_index").map(String::as_str),
-            Some("0")
-        );
-        assert_eq!(
-            event.fields.get("error").map(String::as_str),
-            Some("I/O error: unconditional disconnect failed")
-        );
-        assert_single_lease_returned(&pool).await;
-    }
-
-    #[tokio::test(flavor = "current_thread")]
     async fn dropped_owned_disconnect_error_is_observed() {
         let (pool, lease, _lock_dir) = acquired_test_lease().await;
         let outcome = OwnedDisconnectResultOutcome::new(
@@ -616,7 +512,7 @@ mod tests {
         let outcome = OwnedDisconnectResultOutcome::new(
             TEST_DEVICE_INDEX,
             DeferredLease::new(pool.clone(), lease),
-            Ok(OwnedDisconnectState::Foreign(41)),
+            Ok(OwnedDisconnectState::Foreign),
         );
 
         let ((), captured) = capture_events(|| drop(outcome));
@@ -630,72 +526,38 @@ mod tests {
             event.fields.get("device_index").map(String::as_str),
             Some("0")
         );
-        assert_eq!(
-            event.fields.get("foreign_pid").map(String::as_str),
-            Some("41")
-        );
+        assert!(!event.fields.contains_key("foreign_pid"));
         assert_single_lease_returned(&pool).await;
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn successful_and_consumed_disconnect_outcomes_are_not_observed() {
-        let (unconditional_pool, unconditional_lease, _unconditional_lock_dir) =
-            acquired_test_lease().await;
         let (owned_pool, owned_lease, _owned_lock_dir) = acquired_test_lease().await;
-        let (consumed_unconditional_pool, consumed_unconditional_lease, _consumed_lock_dir) =
-            acquired_test_lease().await;
         let (consumed_owned_pool, consumed_owned_lease, _consumed_owned_lock_dir) =
             acquired_test_lease().await;
 
         let (consumed, captured) = capture_events(|| {
-            drop(DisconnectOutcome::with_lease(
-                TEST_DEVICE_INDEX,
-                DeferredLease::new(unconditional_pool.clone(), unconditional_lease),
-                Ok(()),
-            ));
             drop(OwnedDisconnectResultOutcome::new(
                 TEST_DEVICE_INDEX,
                 DeferredLease::new(owned_pool.clone(), owned_lease),
                 Ok(OwnedDisconnectState::Disconnected),
             ));
 
-            let unconditional = DisconnectOutcome::with_lease(
-                TEST_DEVICE_INDEX,
-                DeferredLease::new(
-                    consumed_unconditional_pool.clone(),
-                    consumed_unconditional_lease,
-                ),
-                Err(error::NbdCowError::Io(std::io::Error::other(
-                    "consumed unconditional error",
-                ))),
-            )
-            .into_parts()
-            .unwrap();
-            let owned = OwnedDisconnectResultOutcome::new(
+            OwnedDisconnectResultOutcome::new(
                 TEST_DEVICE_INDEX,
                 DeferredLease::new(consumed_owned_pool.clone(), consumed_owned_lease),
-                Ok(OwnedDisconnectState::Foreign(42)),
+                Ok(OwnedDisconnectState::Foreign),
             )
             .into_parts()
-            .unwrap();
-            (unconditional, owned)
+            .unwrap()
         });
 
         assert_no_detached_disconnect_events(&captured);
-        let ((unconditional_lease, unconditional_result), (owned_lease, owned_result)) = consumed;
-        assert!(unconditional_result.is_err());
-        assert!(matches!(
-            owned_result,
-            Ok(OwnedDisconnectState::Foreign(42))
-        ));
-        consumed_unconditional_pool
-            .release_clean(unconditional_lease)
-            .await;
+        let (owned_lease, owned_result) = consumed;
+        assert!(matches!(owned_result, Ok(OwnedDisconnectState::Foreign)));
         consumed_owned_pool.release_clean(owned_lease).await;
 
-        assert_single_lease_returned(&unconditional_pool).await;
         assert_single_lease_returned(&owned_pool).await;
-        assert_single_lease_returned(&consumed_unconditional_pool).await;
         assert_single_lease_returned(&consumed_owned_pool).await;
     }
 
@@ -875,47 +737,37 @@ mod tests {
     }
 
     #[test]
-    fn device_ownership_parses_matching_pid_as_ours() {
-        let ownership = device_ownership_from_pid_contents(7, 42, "42\n");
+    fn device_ownership_matches_backend_identity() {
+        let connection_id = test_connection_id();
+        let ownership =
+            device_ownership_from_backend_contents(connection_id, &format!("{connection_id}\n"));
 
         assert!(matches!(ownership, DeviceOwnership::Ours));
     }
 
     #[test]
-    fn device_ownership_treats_empty_or_nonpositive_pid_as_released() {
-        for contents in ["", "0\n", "-1\n"] {
-            let ownership = device_ownership_from_pid_contents(7, 42, contents);
+    fn device_ownership_rejects_empty_or_different_backend_identity() {
+        for contents in ["", "different\n", "00000000-0000-0000-0000-000000000000\n"] {
+            let ownership = device_ownership_from_backend_contents(test_connection_id(), contents);
 
-            assert!(matches!(ownership, DeviceOwnership::Foreign(0)));
-        }
-    }
-
-    #[test]
-    fn device_ownership_reports_malformed_pid_as_unknown() {
-        let ownership = device_ownership_from_pid_contents(7, 42, "not-a-pid\n");
-
-        match ownership {
-            DeviceOwnership::Unknown(e) => {
-                assert_eq!(e.kind(), std::io::ErrorKind::InvalidData);
-                assert!(e.to_string().contains("invalid NBD device pid for nbd7"));
-            }
-            _ => panic!("malformed pid must not be treated as released or foreign"),
+            assert!(matches!(ownership, DeviceOwnership::Foreign));
         }
     }
 
     #[test]
     fn disconnect_connected_if_owned_disconnects_matching_owner() {
         let calls = std::cell::Cell::new(0);
+        let connection_id = test_connection_id();
         let connected = ConnectedDevice {
             index: 7,
-            connect_tid: 42,
+            connection_id,
         };
 
         let disconnected = disconnect_connected_if_owned_with(
             connected,
-            |index, tid| {
+            |index, observed_connection_id| {
                 assert_eq!(index, 7);
-                assert_eq!(tid, 42);
+                assert_eq!(observed_connection_id, connection_id);
                 DeviceOwnership::Ours
             },
             |index| {
@@ -932,16 +784,17 @@ mod tests {
     #[test]
     fn disconnect_connected_if_owned_result_disconnects_matching_owner() {
         let calls = std::cell::Cell::new(0);
+        let connection_id = test_connection_id();
         let connected = ConnectedDevice {
             index: 7,
-            connect_tid: 42,
+            connection_id,
         };
 
         let result = disconnect_connected_if_owned_result_with(
             connected,
-            |index, tid| {
+            |index, observed_connection_id| {
                 assert_eq!(index, 7);
-                assert_eq!(tid, 42);
+                assert_eq!(observed_connection_id, connection_id);
                 DeviceOwnership::Ours
             },
             |index| {
@@ -958,17 +811,18 @@ mod tests {
 
     #[test]
     fn disconnect_connected_if_owned_skips_foreign_owner() {
+        let connection_id = test_connection_id();
         let connected = ConnectedDevice {
             index: 7,
-            connect_tid: 42,
+            connection_id,
         };
 
         let disconnected = disconnect_connected_if_owned_with(
             connected,
-            |index, tid| {
+            |index, observed_connection_id| {
                 assert_eq!(index, 7);
-                assert_eq!(tid, 42);
-                DeviceOwnership::Foreign(100)
+                assert_eq!(observed_connection_id, connection_id);
+                DeviceOwnership::Foreign
             },
             |_| panic!("foreign device must not be disconnected"),
         );
@@ -978,37 +832,39 @@ mod tests {
 
     #[test]
     fn disconnect_connected_if_owned_result_skips_foreign_owner() {
+        let connection_id = test_connection_id();
         let connected = ConnectedDevice {
             index: 7,
-            connect_tid: 42,
+            connection_id,
         };
 
         let result = disconnect_connected_if_owned_result_with(
             connected,
-            |index, tid| {
+            |index, observed_connection_id| {
                 assert_eq!(index, 7);
-                assert_eq!(tid, 42);
-                DeviceOwnership::Foreign(100)
+                assert_eq!(observed_connection_id, connection_id);
+                DeviceOwnership::Foreign
             },
             |_| panic!("foreign device must not be disconnected"),
         )
         .expect("foreign owner should be reported");
 
-        assert!(matches!(result, OwnedDisconnectState::Foreign(100)));
+        assert!(matches!(result, OwnedDisconnectState::Foreign));
     }
 
     #[test]
     fn disconnect_connected_if_owned_skips_unknown_owner() {
+        let connection_id = test_connection_id();
         let connected = ConnectedDevice {
             index: 7,
-            connect_tid: 42,
+            connection_id,
         };
 
         let disconnected = disconnect_connected_if_owned_with(
             connected,
-            |index, tid| {
+            |index, observed_connection_id| {
                 assert_eq!(index, 7);
-                assert_eq!(tid, 42);
+                assert_eq!(observed_connection_id, connection_id);
                 DeviceOwnership::Unknown(std::io::Error::other("sysfs unavailable"))
             },
             |_| panic!("unknown ownership must not be disconnected"),
@@ -1019,16 +875,17 @@ mod tests {
 
     #[test]
     fn disconnect_connected_if_owned_result_errors_on_unknown_owner() {
+        let connection_id = test_connection_id();
         let connected = ConnectedDevice {
             index: 7,
-            connect_tid: 42,
+            connection_id,
         };
 
         let result = disconnect_connected_if_owned_result_with(
             connected,
-            |index, tid| {
+            |index, observed_connection_id| {
                 assert_eq!(index, 7);
-                assert_eq!(tid, 42);
+                assert_eq!(observed_connection_id, connection_id);
                 DeviceOwnership::Unknown(std::io::Error::other("sysfs unavailable"))
             },
             |_| panic!("unknown ownership must not be disconnected"),
@@ -1047,7 +904,7 @@ mod tests {
     fn disconnect_connected_if_owned_reports_disconnect_error() {
         let connected = ConnectedDevice {
             index: 7,
-            connect_tid: 42,
+            connection_id: test_connection_id(),
         };
 
         let disconnected = disconnect_connected_if_owned_with(

--- a/crates/nbd-cow/src/device/connection.rs
+++ b/crates/nbd-cow/src/device/connection.rs
@@ -318,7 +318,7 @@ fn observe_detached_disconnect_result(device_index: u32, result: &Result<OwnedDi
         Ok(OwnedDisconnectState::Foreign) => {
             tracing::warn!(
                 device_index,
-                "detached owned NBD disconnect skipped: device recycled by another process"
+                "detached owned NBD disconnect skipped: device belongs to a different connection"
             );
         }
         Ok(OwnedDisconnectState::Disconnected) => {}
@@ -387,7 +387,7 @@ fn disconnect_connected_if_owned_with(
         DeviceOwnership::Foreign => {
             tracing::warn!(
                 device_index = connected.index,
-                "skipping cancelled-create disconnect: device recycled by another process"
+                "skipping cancelled-create disconnect: device belongs to a different connection"
             );
             false
         }
@@ -519,7 +519,7 @@ mod tests {
 
         let event = event_with_message(
             &captured,
-            "detached owned NBD disconnect skipped: device recycled by another process",
+            "detached owned NBD disconnect skipped: device belongs to a different connection",
         );
         assert_eq!(event.level, Level::WARN);
         assert_eq!(

--- a/crates/nbd-cow/src/device/create.rs
+++ b/crates/nbd-cow/src/device/create.rs
@@ -576,13 +576,13 @@ fn log_owned_disconnect_foreign(mode: CreateDisconnectCleanupMode, connected: Co
         CreateDisconnectCleanupMode::AmbiguousConnect => {
             tracing::warn!(
                 device_index = connected.index,
-                "skipping create cleanup disconnect: device recycled by another process"
+                "skipping create cleanup disconnect: device belongs to a different connection"
             );
         }
         CreateDisconnectCleanupMode::SizeRetry => {
             tracing::warn!(
                 device_index = connected.index,
-                "skipping create retry cleanup disconnect: device recycled by another process"
+                "skipping create retry cleanup disconnect: device belongs to a different connection"
             );
         }
     }

--- a/crates/nbd-cow/src/device/create.rs
+++ b/crates/nbd-cow/src/device/create.rs
@@ -8,13 +8,13 @@ use crate::{
 };
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
 
 use super::NbdCowDevice;
 use super::connection::{
     ConnectedDevice, OwnedDisconnectState, connect_device_with_state_critical_section,
     disconnect_connected_if_owned, disconnect_connected_if_owned_result_critical_section,
     disconnect_connected_if_owned_result_with_lease_critical_section,
-    disconnect_device_with_lease_critical_section,
 };
 use super::create_timing::{
     NbdCowCreateObserver, NbdCowCreateStage, NbdCowCreateTiming, NbdNetlinkConnectTiming,
@@ -56,14 +56,7 @@ impl CreateDisconnectStatus {
             Ok(OwnedDisconnectState::Disconnected) => Self::Disconnected,
             // In create cleanup, a foreign owner means this attempt did not
             // prove its provisional device was disconnected.
-            Ok(OwnedDisconnectState::Foreign(_)) | Err(_) => Self::Uncertain,
-        }
-    }
-
-    fn from_unconditional_result(result: &Result<()>) -> Self {
-        match result {
-            Ok(()) => Self::Disconnected,
-            Err(_) => Self::Uncertain,
+            Ok(OwnedDisconnectState::Foreign) | Err(_) => Self::Uncertain,
         }
     }
 
@@ -191,7 +184,7 @@ impl<'a, 'observer> CreateContext<'a, 'observer> {
             let connect_result = connect_attempt.result;
             match connect_result {
                 Ok(connected) => {
-                    attempt.mark_connected(connected.connect_tid);
+                    attempt.mark_connected(connected.connection_id);
                     return Ok(attempt);
                 }
                 Err(netlink::ConnectDeviceError::DefiniteAfterSend {
@@ -226,14 +219,14 @@ impl<'a, 'observer> CreateContext<'a, 'observer> {
                     );
                 }
                 Err(netlink::ConnectDeviceError::AmbiguousAfterSend {
-                    connect_tid,
+                    connection_id,
                     source,
                 }) => {
                     // The kernel may have accepted NBD_CMD_CONNECT even
                     // though userspace failed while observing completion.
                     // Record a provisional candidate so cleanup can
                     // disconnect only if sysfs still proves we own it.
-                    attempt.mark_connected(connect_tid);
+                    attempt.mark_connected(connection_id);
                     attempt.disconnect_owned_and_release().await;
                     return Err(source);
                 }
@@ -335,10 +328,10 @@ impl CreateAttemptGuard {
         self.server_handles.push(handle);
     }
 
-    fn mark_connected(&mut self, connect_tid: u32) {
+    fn mark_connected(&mut self, connection_id: Uuid) {
         self.connected = Some(ConnectedDevice {
             index: self.device_index(),
-            connect_tid,
+            connection_id,
         });
     }
 
@@ -410,60 +403,7 @@ impl CreateAttemptGuard {
         mode: CreateDisconnectCleanupMode,
         connected: ConnectedDevice,
     ) -> CreateDisconnectStatus {
-        match mode {
-            CreateDisconnectCleanupMode::AmbiguousConnect => {
-                self.disconnect_owned_for_cleanup(mode, connected).await
-            }
-            CreateDisconnectCleanupMode::SizeRetry => {
-                self.disconnect_size_retry_for_cleanup(connected).await
-            }
-        }
-    }
-
-    async fn disconnect_size_retry_for_cleanup(
-        &mut self,
-        connected: ConnectedDevice,
-    ) -> CreateDisconnectStatus {
-        let Some(lease) = self.take_lease() else {
-            tracing::warn!(
-                device_index = connected.index,
-                "pool lease missing during create retry cleanup; using owned NBD disconnect fallback"
-            );
-            return self
-                .disconnect_owned_for_cleanup(CreateDisconnectCleanupMode::SizeRetry, connected)
-                .await;
-        };
-
-        match disconnect_device_with_lease_critical_section(
-            connected.index,
-            self.pool.clone(),
-            lease,
-        )
-        .await
-        {
-            Ok(outcome) => match outcome.into_parts() {
-                Ok((lease, disconnect_result)) => {
-                    self.restore_lease(lease);
-                    self.unconditional_disconnect_status(connected, disconnect_result)
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        device_index = connected.index,
-                        error = %e,
-                        "NBD disconnect result failed during create retry cleanup"
-                    );
-                    CreateDisconnectStatus::Uncertain
-                }
-            },
-            Err(e) => {
-                tracing::warn!(
-                    device_index = connected.index,
-                    error = %e,
-                    "NBD disconnect task failed during create retry cleanup"
-                );
-                CreateDisconnectStatus::Uncertain
-            }
-        }
+        self.disconnect_owned_for_cleanup(mode, connected).await
     }
 
     async fn disconnect_owned_for_cleanup(
@@ -517,28 +457,12 @@ impl CreateAttemptGuard {
         let status = CreateDisconnectStatus::from_owned_result(&disconnect_result);
         match disconnect_result {
             Ok(OwnedDisconnectState::Disconnected) => {}
-            Ok(OwnedDisconnectState::Foreign(pid)) => {
-                log_owned_disconnect_foreign(mode, connected, pid);
+            Ok(OwnedDisconnectState::Foreign) => {
+                log_owned_disconnect_foreign(mode, connected);
             }
             Err(e) => {
                 log_owned_disconnect_failed(mode, connected, &e);
             }
-        }
-        status
-    }
-
-    fn unconditional_disconnect_status(
-        &self,
-        connected: ConnectedDevice,
-        disconnect_result: Result<()>,
-    ) -> CreateDisconnectStatus {
-        let status = CreateDisconnectStatus::from_unconditional_result(&disconnect_result);
-        if let Err(e) = disconnect_result {
-            tracing::warn!(
-                device_index = connected.index,
-                error = %e,
-                "NBD disconnect failed during create retry cleanup"
-            );
         }
         status
     }
@@ -571,7 +495,7 @@ impl CreateAttemptGuard {
                 server_handles,
                 shutdown,
                 disconnected: false,
-                connect_tid: connected.connect_tid,
+                connection_id: connected.connection_id,
             },
             lease,
         ))
@@ -647,23 +571,17 @@ fn log_owned_disconnect_failed(
     }
 }
 
-fn log_owned_disconnect_foreign(
-    mode: CreateDisconnectCleanupMode,
-    connected: ConnectedDevice,
-    foreign_pid: u32,
-) {
+fn log_owned_disconnect_foreign(mode: CreateDisconnectCleanupMode, connected: ConnectedDevice) {
     match mode {
         CreateDisconnectCleanupMode::AmbiguousConnect => {
             tracing::warn!(
                 device_index = connected.index,
-                foreign_pid,
                 "skipping create cleanup disconnect: device recycled by another process"
             );
         }
         CreateDisconnectCleanupMode::SizeRetry => {
             tracing::warn!(
                 device_index = connected.index,
-                foreign_pid,
                 "skipping create retry cleanup disconnect: device recycled by another process"
             );
         }
@@ -761,7 +679,7 @@ mod tests {
         );
         assert!(CreateDisconnectStatus::from_owned_result(&disconnected).is_clean());
 
-        let foreign: Result<OwnedDisconnectState> = Ok(OwnedDisconnectState::Foreign(100));
+        let foreign: Result<OwnedDisconnectState> = Ok(OwnedDisconnectState::Foreign);
         assert_eq!(
             CreateDisconnectStatus::from_owned_result(&foreign),
             CreateDisconnectStatus::Uncertain
@@ -776,25 +694,6 @@ mod tests {
             CreateDisconnectStatus::Uncertain
         );
         assert!(!CreateDisconnectStatus::from_owned_result(&unknown).is_clean());
-    }
-
-    #[test]
-    fn create_disconnect_status_maps_unconditional_results() {
-        let disconnected: Result<()> = Ok(());
-        assert_eq!(
-            CreateDisconnectStatus::from_unconditional_result(&disconnected),
-            CreateDisconnectStatus::Disconnected
-        );
-        assert!(CreateDisconnectStatus::from_unconditional_result(&disconnected).is_clean());
-
-        let failed: Result<()> = Err(error::NbdCowError::Io(std::io::Error::other(
-            "disconnect failed",
-        )));
-        assert_eq!(
-            CreateDisconnectStatus::from_unconditional_result(&failed),
-            CreateDisconnectStatus::Uncertain
-        );
-        assert!(!CreateDisconnectStatus::from_unconditional_result(&failed).is_clean());
     }
 
     #[tokio::test]

--- a/crates/nbd-cow/src/device/mod.rs
+++ b/crates/nbd-cow/src/device/mod.rs
@@ -4,6 +4,7 @@ use crate::error::Result;
 use crate::{cow, cow_io, error, netlink};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
 
 mod connection;
 mod create;
@@ -43,11 +44,8 @@ pub struct NbdCowDevice {
     shutdown: CancellationToken,
     /// Set to true after shutdown_inner completes, so Drop doesn't double-disconnect.
     disconnected: bool,
-    /// TID of the thread that called netlink::connect_device(). The kernel
-    /// records this in `/sys/block/nbdN/pid`. We save it so we can still
-    /// identify the device as ours even after the connecting tokio worker
-    /// thread has exited (at which point `/proc/self/task/{tid}` disappears).
-    connect_tid: u32,
+    /// Unique identity recorded by the kernel in `/sys/block/nbdN/backend`.
+    connection_id: Uuid,
 }
 
 impl NbdCowDevice {
@@ -167,7 +165,7 @@ impl NbdCowDevice {
         if !self.disconnected {
             let connected = ConnectedDevice {
                 index: self.device_index,
-                connect_tid: self.connect_tid,
+                connection_id: self.connection_id,
             };
             let state = disconnect_connected_if_owned_result_critical_section(connected).await?;
             self.apply_owned_disconnect_state(state);
@@ -181,11 +179,10 @@ impl NbdCowDevice {
             OwnedDisconnectState::Disconnected => {
                 self.disconnected = true;
             }
-            OwnedDisconnectState::Foreign(pid) => {
+            OwnedDisconnectState::Foreign => {
                 self.disconnected = true;
                 tracing::warn!(
                     device_index = self.device_index,
-                    foreign_pid = pid,
                     "skipping disconnect: device recycled by another process"
                 );
             }
@@ -209,17 +206,10 @@ impl NbdCowDevice {
         }
     }
 
-    /// Check if we still own the NBD device by comparing the sysfs PID
-    /// against the TID we recorded at connect time.
-    ///
-    /// The kernel records the connecting thread's TID (via `task_pid_nr`) in
-    /// `/sys/block/nbdN/pid`. We compare it to `self.connect_tid` rather than
-    /// probing `/proc/self/task/` because the connecting tokio worker thread
-    /// may have exited by the time we clean up, which would make the old
-    /// `is_our_thread()` check return false and skip disconnect — leaking the
-    /// device.
+    /// Check if we still own the NBD device by comparing the sysfs backend
+    /// identifier against the UUID recorded at connect time.
     fn device_ownership(&self) -> DeviceOwnership {
-        device_ownership(self.device_index, self.connect_tid)
+        device_ownership(self.device_index, self.connection_id)
     }
 
     fn bitmap_path(&self) -> PathBuf {

--- a/crates/nbd-cow/src/device/mod.rs
+++ b/crates/nbd-cow/src/device/mod.rs
@@ -183,7 +183,7 @@ impl NbdCowDevice {
                 self.disconnected = true;
                 tracing::warn!(
                     device_index = self.device_index,
-                    "skipping disconnect: device recycled by another process"
+                    "skipping disconnect: device belongs to a different connection"
                 );
             }
         }

--- a/crates/nbd-cow/src/device/pooled.rs
+++ b/crates/nbd-cow/src/device/pooled.rs
@@ -434,7 +434,7 @@ impl PooledNbdCowDevice {
         if !device.disconnected {
             let connected = ConnectedDevice {
                 index: device.device_index,
-                connect_tid: device.connect_tid,
+                connection_id: device.connection_id,
             };
             let Some(device_lease) = lease.take() else {
                 return Err(error::NbdCowError::Io(std::io::Error::other(
@@ -563,7 +563,7 @@ mod tests {
                     server_handles: Vec::new(),
                     shutdown: CancellationToken::new(),
                     disconnected: true,
-                    connect_tid: 0,
+                    connection_id: uuid::Uuid::nil(),
                 },
                 lease: LeaseGuard::new(
                     pool::DeviceLease::new_for_test(TEST_DEVICE_INDEX, &lock_dir),

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -19,6 +19,7 @@ use std::path::Path;
 use std::time::Instant;
 
 use nix::sys::socket::{AddressFamily, SockFlag, SockType, socketpair};
+use uuid::Uuid;
 
 use crate::device::{NbdNetlinkConnectStage, NbdNetlinkConnectTiming};
 use crate::error::{NbdCowError, Result};
@@ -38,6 +39,7 @@ const NBD_ATTR_SERVER_FLAGS: u16 = 5;
 const NBD_ATTR_SOCKETS: u16 = 7;
 const NBD_ATTR_TIMEOUT: u16 = 4;
 const NBD_ATTR_DEAD_CONN_TIMEOUT: u16 = 8;
+const NBD_ATTR_BACKEND_IDENTIFIER: u16 = 10;
 
 // NBD socket item attribute types (nested inside NBD_ATTR_SOCKETS)
 const NBD_SOCK_ITEM: u16 = 1;
@@ -123,12 +125,8 @@ where
 /// Successful NBD connect metadata.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct ConnectDeviceSuccess {
-    /// TID of the thread that sent `NBD_CMD_CONNECT`.
-    ///
-    /// The kernel records this value in `/sys/block/nbdN/pid` after a
-    /// successful connect. Cleanup uses it to avoid disconnecting a device
-    /// recycled by another process.
-    pub(crate) connect_tid: u32,
+    /// Unique identity exposed by the kernel in `/sys/block/nbdN/backend`.
+    pub(crate) connection_id: Uuid,
 }
 
 /// Error state for `NBD_CMD_CONNECT`.
@@ -154,8 +152,8 @@ pub(crate) enum ConnectDeviceError {
     /// The connect command was sent, but userspace could not observe completion.
     #[error("NBD connect completion is ambiguous after sending command: {source}")]
     AmbiguousAfterSend {
-        /// TID of the thread that sent `NBD_CMD_CONNECT`.
-        connect_tid: u32,
+        /// Unique identity included in the connect command.
+        connection_id: Uuid,
         /// Underlying completion-observation error.
         source: NbdCowError,
     },
@@ -241,6 +239,8 @@ pub(crate) fn connect_device_with_state_timing(
 
     let command_started_at = Instant::now();
     let sockets_nla = build_sockets_nla(client_fds, sockets_payload_len);
+    let connection_id = Uuid::new_v4();
+    let backend_identifier = format!("{connection_id}\0");
     let flags =
         NBD_FLAG_HAS_FLAGS | NBD_FLAG_SEND_FLUSH | NBD_FLAG_SEND_TRIM | NBD_FLAG_CAN_MULTI_CONN;
 
@@ -266,13 +266,14 @@ pub(crate) fn connect_device_with_state_timing(
         NBD_ATTR_DEAD_CONN_TIMEOUT,
         &TIMEOUT_SECS.to_ne_bytes(),
     ));
+    attrs.extend_from_slice(&wire::build_nla(
+        NBD_ATTR_BACKEND_IDENTIFIER,
+        backend_identifier.as_bytes(),
+    ));
     attrs.extend_from_slice(&sockets_nla);
 
-    // The kernel records the sending task's TID in /sys/block/nbdN/pid on
-    // successful connect. Capture it before crossing the netlink send boundary.
-    let connect_tid = unsafe { libc::gettid() } as u32;
     let result = match send_nbd_genl_msg(&sock, family_id, NBD_CMD_CONNECT, &attrs) {
-        Ok(seq) => finish_connect_after_send(&sock, seq, connect_tid),
+        Ok(seq) => finish_connect_after_send(&sock, seq, connection_id),
         Err(source) => Err(ConnectDeviceError::NotSent { source }),
     };
     timing.record_stage(
@@ -373,22 +374,22 @@ fn recv_genl_completion(sock: &socket::GenlSocket, expected_seq: u32) -> Result<
 fn finish_connect_after_send(
     sock: &socket::GenlSocket,
     expected_seq: u32,
-    connect_tid: u32,
+    connection_id: Uuid,
 ) -> std::result::Result<ConnectDeviceSuccess, ConnectDeviceError> {
-    classify_connect_completion(connect_tid, recv_genl_completion(sock, expected_seq))
+    classify_connect_completion(connection_id, recv_genl_completion(sock, expected_seq))
 }
 
 fn classify_connect_completion(
-    connect_tid: u32,
+    connection_id: Uuid,
     completion: Result<()>,
 ) -> std::result::Result<ConnectDeviceSuccess, ConnectDeviceError> {
     match completion {
-        Ok(()) => Ok(ConnectDeviceSuccess { connect_tid }),
+        Ok(()) => Ok(ConnectDeviceSuccess { connection_id }),
         Err(source @ NbdCowError::NetlinkErrno { .. }) => {
             Err(ConnectDeviceError::DefiniteAfterSend { source })
         }
         Err(source) => Err(ConnectDeviceError::AmbiguousAfterSend {
-            connect_tid,
+            connection_id,
             source,
         }),
     }
@@ -456,6 +457,10 @@ mod tests {
     fn assert_close_on_exec(fd: &OwnedFd) {
         let flags = fcntl(fd, FcntlArg::F_GETFD).unwrap();
         assert!(FdFlag::from_bits_truncate(flags).contains(FdFlag::FD_CLOEXEC));
+    }
+
+    fn test_connection_id() -> Uuid {
+        Uuid::from_u128(1234)
     }
 
     #[test]
@@ -685,17 +690,15 @@ mod tests {
     }
 
     #[test]
-    fn finish_connect_after_send_success_returns_connect_tid() {
+    fn finish_connect_after_send_success_returns_connection_id() {
         let (sock, peer) = socket::test_genl_socket_pair();
         let reply = wire::build_genl_msg(0x19, NBD_CMD_CONNECT, NBD_GENL_VERSION, &[], 2, false);
         socket::send_test_nl(&peer, &reply);
 
-        let result = finish_connect_after_send(&sock, 2, 1234);
+        let connection_id = test_connection_id();
+        let result = finish_connect_after_send(&sock, 2, connection_id);
 
-        assert!(matches!(
-            result,
-            Ok(ConnectDeviceSuccess { connect_tid: 1234 })
-        ));
+        assert_eq!(result.unwrap().connection_id, connection_id);
     }
 
     #[test]
@@ -703,7 +706,7 @@ mod tests {
         let (sock, peer) = socket::test_genl_socket_pair();
         socket::send_test_nl(&peer, &wire::build_nlmsg_error_for_test(2, -libc::EBUSY));
 
-        let result = finish_connect_after_send(&sock, 2, 1234);
+        let result = finish_connect_after_send(&sock, 2, test_connection_id());
 
         assert!(matches!(
             result,
@@ -718,7 +721,7 @@ mod tests {
         let (sock, peer) = socket::test_genl_socket_pair();
         socket::send_test_nl(&peer, &wire::build_nlmsg_error_for_test(2, -libc::EINVAL));
 
-        let result = finish_connect_after_send(&sock, 2, 1234);
+        let result = finish_connect_after_send(&sock, 2, test_connection_id());
 
         assert!(matches!(
             result,
@@ -735,18 +738,16 @@ mod tests {
         socket::send_test_nl(&peer, &wire::build_nlmsg_error_for_test(1, -libc::EBUSY));
         socket::send_test_nl(&peer, &reply);
 
-        let result = finish_connect_after_send(&sock, 2, 1234);
+        let connection_id = test_connection_id();
+        let result = finish_connect_after_send(&sock, 2, connection_id);
 
-        assert!(matches!(
-            result,
-            Ok(ConnectDeviceSuccess { connect_tid: 1234 })
-        ));
+        assert_eq!(result.unwrap().connection_id, connection_id);
     }
 
     #[test]
     fn classify_connect_completion_io_error_is_ambiguous() {
         let result = classify_connect_completion(
-            1234,
+            test_connection_id(),
             Err(NbdCowError::Io(std::io::Error::new(
                 std::io::ErrorKind::TimedOut,
                 "completion timed out",
@@ -756,9 +757,9 @@ mod tests {
         assert!(matches!(
             result,
             Err(ConnectDeviceError::AmbiguousAfterSend {
-                connect_tid: 1234,
+                connection_id,
                 ..
-            })
+            }) if connection_id == test_connection_id()
         ));
     }
 
@@ -769,14 +770,14 @@ mod tests {
         wire::set_nlmsg_len_for_test(&mut malformed, 15);
         socket::send_test_nl(&peer, &malformed);
 
-        let result = finish_connect_after_send(&sock, 2, 1234);
+        let result = finish_connect_after_send(&sock, 2, test_connection_id());
 
         assert!(matches!(
             result,
             Err(ConnectDeviceError::AmbiguousAfterSend {
-                connect_tid: 1234,
+                connection_id,
                 ..
-            })
+            }) if connection_id == test_connection_id()
         ));
     }
 

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -144,6 +144,13 @@ fn nbd_pid(device_index: u32) -> Option<u32> {
         .and_then(|contents| contents.trim().parse().ok())
 }
 
+fn nbd_backend(device_index: u32) -> Option<String> {
+    let backend_path = format!("/sys/block/nbd{device_index}/backend");
+    std::fs::read_to_string(backend_path)
+        .ok()
+        .map(|contents| contents.trim().to_owned())
+}
+
 // ---------------------------------------------------------------------------
 // Full device lifecycle tests (require root + nbd module)
 // ---------------------------------------------------------------------------
@@ -956,4 +963,117 @@ async fn drop_without_destroy_disconnects() {
     }
 
     pool.cleanup().await;
+}
+
+/// A stale device object must not disconnect a replacement connection even
+/// when Tokio reuses the same blocking worker TID for both connects.
+#[test]
+#[ignore]
+fn stale_cleanup_rejects_recycled_tid_with_different_backend_identity() {
+    if !nbd_test_available() {
+        return;
+    }
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .max_blocking_threads(1)
+        .enable_all()
+        .build()
+        .expect("build single-blocking-thread runtime");
+
+    runtime.block_on(async {
+        let fixture = NbdTestFixture::new();
+        let original_cow = fixture.cow_path("original-cow.img");
+        let replacement_cow = fixture.cow_path("replacement-cow.img");
+        let pool = default_device_pool();
+        let original = pool
+            .create_cow_device(fixture.base(), &original_cow, fixture.size())
+            .await
+            .expect("create original device");
+        let device_index = original.device_index();
+        let original_tid = nbd_pid(device_index).expect("original sysfs pid");
+        let original_backend = nbd_backend(device_index).expect("original sysfs backend");
+
+        nbd_cow::netlink::disconnect(device_index).expect("externally disconnect original");
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while !nbd_cow::netlink::device_appears_free(device_index) {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("original device should be released");
+
+        let replacement_layer = nbd_cow::cow::CowLayer::new(
+            fixture.base(),
+            &replacement_cow,
+            fixture.size(),
+            nbd_cow::BLOCK_SIZE,
+            nbd_cow::DEFAULT_FLUSH_THRESHOLD,
+        )
+        .expect("replacement COW layer");
+        let replacement_io = nbd_cow::cow_io::CowIo::new(replacement_layer);
+        let replacement_shutdown = tokio_util::sync::CancellationToken::new();
+        let (client_fd, server_fd) =
+            nbd_cow::netlink::create_socketpair().expect("replacement socketpair");
+        let server_io = replacement_io.clone();
+        let server_shutdown = replacement_shutdown.clone();
+        let replacement_server = tokio::spawn(async move {
+            let _ = nbd_cow::server::dispatch(server_fd, server_io, server_shutdown).await;
+        });
+        let size = fixture.size();
+        let replacement_connect_tid = tokio::task::spawn_blocking(move || {
+            let tid = unsafe { libc::gettid() } as u32;
+            let result = nbd_cow::netlink::connect_device(
+                device_index,
+                &[client_fd],
+                size,
+                nbd_cow::BLOCK_SIZE as u64,
+            );
+            (tid, result)
+        })
+        .await
+        .expect("replacement connect task");
+        replacement_connect_tid
+            .1
+            .expect("connect replacement device");
+        let replacement_tid = nbd_pid(device_index).expect("replacement sysfs pid");
+        let replacement_backend = nbd_backend(device_index).expect("replacement sysfs backend");
+        let replacement_size_matches =
+            nbd_cow::netlink::verify_device_size(device_index, fixture.size()).await;
+
+        let stale_cleanup_result = original.destroy_with_retries(destroy_policy()).await;
+        let backend_after_stale_cleanup = nbd_backend(device_index);
+        let pid_after_stale_cleanup = nbd_pid(device_index);
+        let replacement_read = tokio::time::timeout(Duration::from_secs(5), async {
+            let mut device = tokio::fs::File::open(format!("/dev/nbd{device_index}")).await?;
+            let mut block = vec![1_u8; nbd_cow::BLOCK_SIZE];
+            device.read_exact(&mut block).await?;
+            Ok::<_, std::io::Error>(block)
+        })
+        .await;
+
+        let replacement_disconnect_result = nbd_cow::netlink::disconnect(device_index);
+        replacement_shutdown.cancel();
+        replacement_server.abort();
+        let _ = replacement_server.await;
+        pool.cleanup().await;
+
+        assert_eq!(original_tid, replacement_connect_tid.0);
+        assert_eq!(replacement_tid, replacement_connect_tid.0);
+        assert_ne!(original_backend, replacement_backend);
+        assert!(replacement_size_matches);
+        stale_cleanup_result.expect("stale device cleanup");
+        assert_eq!(
+            backend_after_stale_cleanup.as_deref(),
+            Some(replacement_backend.as_str())
+        );
+        assert_eq!(pid_after_stale_cleanup, Some(replacement_tid));
+        assert_eq!(
+            replacement_read
+                .expect("replacement read should not time out")
+                .expect("replacement read should succeed"),
+            vec![0_u8; nbd_cow::BLOCK_SIZE]
+        );
+        replacement_disconnect_result.expect("disconnect replacement device");
+    });
 }

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -1055,22 +1055,25 @@ fn stale_cleanup_rejects_recycled_tid_with_different_backend_identity() {
         let replacement_backend = nbd_backend(device_index).expect("replacement sysfs backend");
         let replacement_size_matches =
             nbd_cow::netlink::verify_device_size(device_index, fixture.size()).await;
-        let mut replacement_device = tokio::time::timeout(Duration::from_secs(5), async move {
-            tokio::fs::File::open(format!("/dev/nbd{device_index}")).await
-        })
-        .await
-        .expect("replacement open should not time out")
-        .expect("replacement open should succeed");
 
         let stale_cleanup_result = original.destroy_with_retries(destroy_policy()).await;
         let backend_after_stale_cleanup = nbd_backend(device_index);
         let pid_after_stale_cleanup = nbd_pid(device_index);
-        let replacement_read = tokio::time::timeout(Duration::from_secs(5), async move {
-            let mut block = vec![1_u8; nbd_cow::BLOCK_SIZE];
-            replacement_device.read_exact(&mut block).await?;
-            Ok::<_, std::io::Error>(block)
-        })
-        .await;
+        // Keep block-device I/O off the single Tokio blocking worker reserved
+        // above for deterministic connect TID reuse. NBD request handling also
+        // needs that worker, so using tokio::fs here would deadlock the test.
+        let (replacement_read_sender, replacement_read_receiver) = tokio::sync::oneshot::channel();
+        let replacement_read_thread = std::thread::spawn(move || {
+            let result = (|| {
+                let mut device = std::fs::File::open(format!("/dev/nbd{device_index}"))?;
+                let mut block = vec![1_u8; nbd_cow::BLOCK_SIZE];
+                std::io::Read::read_exact(&mut device, &mut block)?;
+                Ok::<_, std::io::Error>(block)
+            })();
+            let _ = replacement_read_sender.send(result);
+        });
+        let replacement_read =
+            tokio::time::timeout(Duration::from_secs(5), replacement_read_receiver).await;
 
         let replacement_disconnect_result = nbd_cow::netlink::disconnect(device_index);
         replacement_shutdown.cancel();
@@ -1079,6 +1082,9 @@ fn stale_cleanup_rejects_recycled_tid_with_different_backend_identity() {
             let _ = server.await;
         }
         pool.cleanup().await;
+        replacement_read_thread
+            .join()
+            .expect("replacement read thread");
 
         assert_eq!(original_tid, replacement_connect_tid.0);
         assert_eq!(replacement_tid, replacement_connect_tid.0);
@@ -1093,6 +1099,7 @@ fn stale_cleanup_rejects_recycled_tid_with_different_backend_identity() {
         assert_eq!(
             replacement_read
                 .expect("replacement read should not time out")
+                .expect("replacement read thread should report its result")
                 .expect("replacement read should succeed"),
             vec![0_u8; nbd_cow::BLOCK_SIZE]
         );

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -1013,22 +1013,37 @@ fn stale_cleanup_rejects_recycled_tid_with_different_backend_identity() {
         .expect("replacement COW layer");
         let replacement_io = nbd_cow::cow_io::CowIo::new(replacement_layer);
         let replacement_shutdown = tokio_util::sync::CancellationToken::new();
-        let (client_fd, server_fd) =
-            nbd_cow::netlink::create_socketpair().expect("replacement socketpair");
-        let server_io = replacement_io.clone();
-        let server_shutdown = replacement_shutdown.clone();
-        let replacement_server = tokio::spawn(async move {
-            let _ = nbd_cow::server::dispatch(server_fd, server_io, server_shutdown).await;
-        });
+        let mut client_fds = Vec::with_capacity(nbd_cow::NUM_CONNECTIONS);
+        let mut replacement_servers = Vec::with_capacity(nbd_cow::NUM_CONNECTIONS);
+        for _ in 0..nbd_cow::NUM_CONNECTIONS {
+            let (client_fd, server_fd) =
+                nbd_cow::netlink::create_socketpair().expect("replacement socketpair");
+            client_fds.push(client_fd);
+            let server_io = replacement_io.clone();
+            let server_shutdown = replacement_shutdown.clone();
+            replacement_servers.push(tokio::spawn(async move {
+                let _ = nbd_cow::server::dispatch(server_fd, server_io, server_shutdown).await;
+            }));
+        }
         let size = fixture.size();
         let replacement_connect_tid = tokio::task::spawn_blocking(move || {
             let tid = unsafe { libc::gettid() } as u32;
-            let result = nbd_cow::netlink::connect_device(
-                device_index,
-                &[client_fd],
-                size,
-                nbd_cow::BLOCK_SIZE as u64,
-            );
+            let deadline = std::time::Instant::now() + Duration::from_secs(5);
+            let result = loop {
+                match nbd_cow::netlink::connect_device(
+                    device_index,
+                    &client_fds,
+                    size,
+                    nbd_cow::BLOCK_SIZE as u64,
+                ) {
+                    Err(nbd_cow::error::NbdCowError::NetlinkErrno { errno, .. })
+                        if errno == libc::EBUSY && std::time::Instant::now() < deadline =>
+                    {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    result => break result,
+                }
+            };
             (tid, result)
         })
         .await
@@ -1040,22 +1055,29 @@ fn stale_cleanup_rejects_recycled_tid_with_different_backend_identity() {
         let replacement_backend = nbd_backend(device_index).expect("replacement sysfs backend");
         let replacement_size_matches =
             nbd_cow::netlink::verify_device_size(device_index, fixture.size()).await;
+        let mut replacement_device = tokio::time::timeout(Duration::from_secs(5), async move {
+            tokio::fs::File::open(format!("/dev/nbd{device_index}")).await
+        })
+        .await
+        .expect("replacement open should not time out")
+        .expect("replacement open should succeed");
 
         let stale_cleanup_result = original.destroy_with_retries(destroy_policy()).await;
         let backend_after_stale_cleanup = nbd_backend(device_index);
         let pid_after_stale_cleanup = nbd_pid(device_index);
-        let replacement_read = tokio::time::timeout(Duration::from_secs(5), async {
-            let mut device = tokio::fs::File::open(format!("/dev/nbd{device_index}")).await?;
+        let replacement_read = tokio::time::timeout(Duration::from_secs(5), async move {
             let mut block = vec![1_u8; nbd_cow::BLOCK_SIZE];
-            device.read_exact(&mut block).await?;
+            replacement_device.read_exact(&mut block).await?;
             Ok::<_, std::io::Error>(block)
         })
         .await;
 
         let replacement_disconnect_result = nbd_cow::netlink::disconnect(device_index);
         replacement_shutdown.cancel();
-        replacement_server.abort();
-        let _ = replacement_server.await;
+        for server in replacement_servers {
+            server.abort();
+            let _ = server.await;
+        }
         pool.cleanup().await;
 
         assert_eq!(original_tid, replacement_connect_tid.0);


### PR DESCRIPTION
## Summary

- attach a UUID v4 backend identifier to every NBD connect command
- require an exact `/sys/block/nbdN/backend` match before any live-object cleanup disconnects an index
- route size-retry cleanup through the same ownership check and remove the unconditional disconnect path
- add a root-only metal regression that reconnects the same index from the same blocking-worker TID and verifies stale cleanup leaves the replacement usable

## Scope and risks

- keep sysfs PID/TID handling only for orphan discovery and GC
- rely on `NBD_ATTR_BACKEND_IDENTIFIER`, available on the supported Ubuntu 22.04+ runner baseline; older kernels fail the connect instead of falling back to unsafe TID matching
- retain the kernel API's residual sysfs-read-to-index-disconnect race because NBD does not provide an atomic conditional disconnect operation

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p nbd-cow --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow`
- repository pre-commit Rust formatting, documentation, and Clippy hooks

The root-only NBD regression was compiled locally and is executed by the existing serial metal integration-test job; the local container has no loaded NBD module and is not root.

Closes #28523
