### PR TITLE
fix(platform): narrow the model picker popover back to 260px

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -1158,16 +1158,17 @@ function ModelFirstModelPickerContentLayout({
   return (
     <SelectContent
       className={cn(
+        // The same width every model picker uses. The wider panel width was
+        // there for the media rows' variant segments, which sat beside the
+        // model name; now that a family contributes one row, the widest row is
+        // a name beside a badge again.
+        "min-w-[260px]",
         mediaModelPanel
-          ? // One width for every category, so switching tabs never resizes the
-            // popover: it is sized for the chat rows, which carry a provider
-            // label and a price tier badge beside the model name. The 294px
-            // bordered cap leaves a 292px scroll viewport: enough for the
-            // compact header and seven model rows, while an eighth adds one
-            // 32px row plus its 4px gap. The max-width only bites below a 348px
-            // viewport, where 332px would otherwise run past the screen edge.
-            "max-h-[294px] min-w-[332px] max-w-[calc(100vw-1rem)]"
-          : "max-h-[280px] min-w-[260px]",
+          ? // The 294px bordered cap leaves a 292px scroll viewport: enough for
+            // the compact header and seven model rows, while an eighth adds one
+            // 32px row plus its 4px gap.
+            "max-h-[294px]"
+          : "max-h-[280px]",
       )}
     >
       {/* A media-model panel replaces the model rows, so keep the selected run


### PR DESCRIPTION
## What

The media panel branch of the model picker popover kept a `min-w-[332px]` floor. Drop it to the `min-w-[260px]` every other model picker in this file uses, so the popover is the same width inside the category switch (image / video) and outside it.

## Why

The 332px floor was introduced with the media panel, sized for the longest row it had to render at the time: a model name beside a three-up variant segment (Seedance 2.0 Standard/Fast/Mini). #28510 gave each family a single row, so those segments are gone and the widest row is a model name beside a badge again -- the same row the plain pickers size for. The floor now only leaves empty space.

The `max-w-[calc(100vw-1rem)]` guard went with it: it existed because 332px runs past the screen edge below a 348px viewport. At 260px it would only bite below a 276px viewport, narrower than any phone.

`max-h` is untouched -- the media branch keeps its 294px cap (compact header plus seven rows without scrolling), which is independent of width.

## Widths measured

Rebuilt the popover rows at the component's real metrics (Noto Sans, `text-sm`, `pl-2 pr-8` rows, header `pl-3 pr-2` beside the three 28px segments) and measured natural content width with the floor removed:

| Category | Natural width | Headroom under 260px |
| --- | --- | --- |
| image | 199px | 61px |
| chat (name + price tier badge + 32px right gutter) | 229px | 31px |

Both stay under the floor, so every category renders at 260px and switching category does not resize the popover. A row can still outgrow the floor if its label is long enough -- a BYOK policy falling back to a raw model id, for instance -- which was equally true at 332px.

## Checks

- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx` -- 81 passed
- `pnpm -F @okouai/app exec tsc --noEmit` -- clean
- `pnpm -F @okouai/app run lint` -- no new findings
- `prettier --check` on the changed file -- clean