### PR TITLE
fix(platform): bold the selected pinned agent label

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -395,8 +395,8 @@ function PinnedAgentGridCard({
       </span>
       <span
         className={`w-full truncate text-center text-[11px] leading-tight ${
-          isDragging ? "opacity-0" : ""
-        }`}
+          isPrimarySelected ? "font-medium" : ""
+        } ${isDragging ? "opacity-0" : ""}`}
       >
         {agent.displayName ?? agent.id}
       </span>


### PR DESCRIPTION
## Summary

In the chat sidebar's **Pinned agents** grid, the selected tile only got a background tint — its label stayed at regular weight. The vertical pinned list already switches the selected row's label to `font-medium`, so the two selection treatments disagreed.

The selected tile's label now renders at medium weight.

| | Before | After |
| --- | --- | --- |
| Selected tile label | `text-[11px]` regular | `text-[11px] font-medium` |

## Test plan

- Visual: open the chat sidebar, select a pinned agent, and confirm the active tile's name is medium weight while the others stay regular.
- Drag a pinned tile: the label still fades with the rest of the card (`opacity-0`) while dragging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)