### PR TITLE
fix(rebranding): neutralize built-in model copy

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -21,6 +21,7 @@ import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
+import { withBuiltInModelRuntimeRouteUnavailableForTest } from "../../../test-fixtures/built-in-model-runtime-route";
 import { readGoalQueueStateFixture } from "../../../test-fixtures/goal-queue";
 import {
   holdCheckpointReadsFixture,
@@ -4098,6 +4099,94 @@ describe("CHAT-02: drain-time admission failure", () => {
     },
     90_000,
   );
+
+  it("terminalizes a queued Web message with neutral built-in model copy when the key is unavailable", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const anchor = await startChatRun(actor, {
+      agentId,
+      prompt: "finish before queued built-in model admission",
+    });
+    const anchorHeaders = await claimChatRun(runnerGroup, anchor.runId);
+    const queuedPrompt = "reject this queued message without a built-in key";
+    const queuedEventId = await queueChatEvent(actor, {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: queuedPrompt,
+    });
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-sonnet-5",
+        isDefault: true,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
+      },
+    ]);
+    await chat.updateThreadModelSelection(
+      actor,
+      anchor.threadId,
+      "claude-sonnet-5",
+    );
+    chatCallbacks.mockChatOutputEvents([]);
+
+    await withBuiltInModelRuntimeRouteUnavailableForTest(
+      "claude-sonnet-5",
+      async () => {
+        await completeChatRunOk(anchor.runId, anchorHeaders);
+        await flushWaitUntilForTest();
+      },
+    );
+
+    const terminal = await waitForThreadMessages(
+      actor,
+      anchor.threadId,
+      (events) => {
+        return (
+          userMessages(events).some((event) => {
+            return (
+              event.eventType === "input.rejected" &&
+              event.revokesEventId === queuedEventId &&
+              event.error === "provider_unavailable"
+            );
+          }) &&
+          assistantMessages(events).some((event) => {
+            return (
+              event.eventType === "output.error" &&
+              event.error === "provider_unavailable"
+            );
+          })
+        );
+      },
+    );
+    const rejected = userMessages(terminal.events).find((event) => {
+      return (
+        event.eventType === "input.rejected" &&
+        event.revokesEventId === queuedEventId
+      );
+    });
+    if (rejected?.eventType !== "input.rejected") {
+      throw new Error("Expected the queued Web message to be rejected");
+    }
+    expect(rejected.error).toBe("provider_unavailable");
+    const errors = assistantMessages(terminal.events).filter((event) => {
+      return (
+        event.eventType === "output.error" &&
+        event.error === "provider_unavailable"
+      );
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.content).toBe(
+      "No model provider configured: no built-in model key is configured",
+    );
+    expect(errors[0]?.content).not.toContain("VM0");
+    expect(
+      (await api.listAgentRuns(actor, { limit: 20 })).runs.filter((run) => {
+        return run.prompt === queuedPrompt;
+      }),
+    ).toHaveLength(0);
+  }, 90_000);
 });
 
 describe("CHAT-02: failed chat callbacks", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1163,6 +1163,10 @@ describe("CHAT-02: completed chat callback", () => {
         'The "prompt" values are shown as plain text, not rendered as Markdown',
       ),
     ]);
+    expect(followupSystemPrompts[0]).toContain(
+      "Supported built-in generation tasks:",
+    );
+    expect(followupSystemPrompts[0]).not.toContain("VM0");
 
     await waitForThreadTitle(actor, first.threadId, "Debugging Node Apps");
     expect(titlePrompts).toHaveLength(titlePromptCountBeforeComplete);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -4353,8 +4353,8 @@ describe("CHAT-02: model-first provider policies", () => {
     expect([201, 503]).toContain(vm0Send.status);
     if (vm0Send.status === 503) {
       expectApiError(vm0Send.body);
-      expect(vm0Send.body.error.message).toContain(
-        "No model provider configured",
+      expect(vm0Send.body.error.message).toBe(
+        "No model provider configured: no built-in model key is configured",
       );
     } else {
       const vm0Body = vm0Send.body as { readonly runId: string | null };

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
@@ -13,6 +13,7 @@ import { createApp } from "../../../app-factory";
 import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { mockNow, now, withNowScopeForTest } from "../../../lib/time";
+import { withBuiltInModelRuntimeRouteUnavailableForTest } from "../../../test-fixtures/built-in-model-runtime-route";
 import {
   createActiveGoalQueueEventFixture,
   drainChatThreadQueueFixture,
@@ -70,6 +71,8 @@ const webhooksApi = createWebhookCallbackApi(context);
 const chatCallbacks = createChatCallbacksApi(context);
 
 const WORKFLOW_NAME = "workflow-queue-workflow";
+const NO_BUILT_IN_MODEL_KEY_MESSAGE =
+  "No model provider configured: no built-in model key is configured";
 
 function it(name: string, test: () => Promise<void>, timeout?: number): void {
   vitestTest(
@@ -509,6 +512,93 @@ async function expectSweepLeftQueueUntouched(
 }
 
 describe("workflow queue", () => {
+  it("rejects a goal continuation with neutral built-in model copy when the key is unavailable", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    await chatCallbacks.updateOrgModelPolicies(scenario.actor, [
+      {
+        model: "claude-sonnet-5",
+        isDefault: true,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
+      },
+    ]);
+    const goal = await createActiveGoalQueueEventFixture({
+      threadId: automation.threadId,
+      orgId: scenario.orgId,
+      userId: scenario.userId,
+      agentId: scenario.agentId,
+      objective: "continue without a built-in model key",
+      objectiveBrief: "Continue without a built-in model key",
+    });
+
+    await withBuiltInModelRuntimeRouteUnavailableForTest(
+      "claude-sonnet-5",
+      async () => {
+        await drainChatThreadQueueFixture({
+          threadId: automation.threadId,
+          signal: context.signal,
+        });
+      },
+    );
+
+    const events = await wf.readThreadEvents(automation.threadId);
+    const rejected = events.find((event) => {
+      return (
+        event.eventType === "input.rejected" &&
+        event.revokesEventId === goal.eventId
+      );
+    });
+    if (rejected?.eventType !== "input.rejected") {
+      throw new Error("Expected the goal continuation to be rejected");
+    }
+    expect(rejected.error).toBe(NO_BUILT_IN_MODEL_KEY_MESSAGE);
+    expect(rejected.error).not.toContain("VM0");
+    await expect(
+      readGoalQueueStateFixture(automation.threadId),
+    ).resolves.toMatchObject({ runIds: [] });
+  });
+
+  it("rejects a workflow automation with neutral built-in model copy when the key is unavailable", async () => {
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    await chatCallbacks.updateOrgModelPolicies(scenario.actor, [
+      {
+        model: "claude-sonnet-5",
+        isDefault: true,
+        defaultProviderType: "vm0",
+        credentialScope: "org",
+        modelProviderId: null,
+      },
+    ]);
+
+    const response = await withBuiltInModelRuntimeRouteUnavailableForTest(
+      "claude-sonnet-5",
+      async () => {
+        return await postWorkflowWebhook(
+          automation,
+          "launch without a built-in model key",
+        );
+      },
+    );
+    expect(response).toStrictEqual({
+      status: 500,
+      body: { error: "Failed to start webhook workflow run" },
+    });
+
+    const events = await wf.readThreadEvents(automation.threadId);
+    const rejected = events.find((event) => {
+      return event.eventType === "input.rejected";
+    });
+    if (rejected?.eventType !== "input.rejected") {
+      throw new Error("Expected the workflow automation to be rejected");
+    }
+    expect(rejected.error).toBe(NO_BUILT_IN_MODEL_KEY_MESSAGE);
+    expect(rejected.error).not.toContain("VM0");
+    await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(0);
+  });
+
   it("keeps a user prompt ahead of a pending goal continuation", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);

--- a/turbo/apps/api/src/signals/services/built-in-model-runtime-route.service.ts
+++ b/turbo/apps/api/src/signals/services/built-in-model-runtime-route.service.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import {
   getVm0ManagedRouteCandidates,
   type Vm0ManagedRouteProviderType,
@@ -7,6 +9,7 @@ import { builtInModelKeys } from "@okouai/db/schema/built-in-model-key";
 import { managedModelCandidateCooldown } from "@okouai/db/schema/managed-model-cooldown";
 import { and, eq, gt, sql } from "drizzle-orm";
 
+import { singleton } from "../../lib/singleton";
 import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
 
@@ -27,6 +30,36 @@ interface ManagedModelCandidateIdentity {
   readonly selectedModel: string;
   readonly providerType: string;
   readonly upstreamModel: string;
+}
+
+const unavailableRuntimeRouteModelsForTest = singleton(() => {
+  return new AsyncLocalStorage<ReadonlySet<string>>();
+});
+
+/**
+ * Operator-managed model keys are global rows, so a missing-key API test cannot
+ * safely delete them while other test workers are running. Keep that impossible
+ * external state scoped to the calling async chain instead of mutating shared
+ * database state.
+ */
+export async function withBuiltInModelRuntimeRouteUnavailableForTest<T>(
+  selectedModel: string,
+  work: () => Promise<T>,
+): Promise<T> {
+  const inherited = unavailableRuntimeRouteModelsForTest.peek()?.getStore();
+  return await unavailableRuntimeRouteModelsForTest().run(
+    new Set([...(inherited ?? []), selectedModel]),
+    work,
+  );
+}
+
+function runtimeRouteUnavailableForTest(selectedModel: string): boolean {
+  return (
+    unavailableRuntimeRouteModelsForTest
+      .peek()
+      ?.getStore()
+      ?.has(selectedModel) === true
+  );
 }
 
 function routeFromTarget(
@@ -69,6 +102,9 @@ export async function resolveBuiltInModelRuntimeRoute(
   selectedModel: string,
   fallbackEnabled = false,
 ): Promise<BuiltInModelRuntimeRoute | null> {
+  if (runtimeRouteUnavailableForTest(selectedModel)) {
+    return null;
+  }
   if (!fallbackEnabled) {
     return await resolvePrimaryRoute(db, selectedModel);
   }

--- a/turbo/apps/api/src/signals/services/chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/chat-events.command.ts
@@ -927,7 +927,7 @@ async function withBuiltInModelRuntimeRoute(
   const selectedModel = configuration.modelPin.selectedModel;
   if (!selectedModel) {
     return providerUnavailable(
-      "No model provider configured: no VM0 managed model is selected",
+      "No model provider configured: no built-in model is selected",
     );
   }
   const builtInModelRuntimeRoute = await resolveBuiltInModelRuntimeRoute(
@@ -942,7 +942,7 @@ async function withBuiltInModelRuntimeRoute(
           "Every managed route for this model is temporarily unavailable",
         )
       : providerUnavailable(
-          "No model provider configured: no VM0 managed model key is configured",
+          "No model provider configured: no built-in model key is configured",
         );
 }
 

--- a/turbo/apps/api/src/signals/services/chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-title.service.ts
@@ -54,7 +54,7 @@ const TITLE_PRIOR_MESSAGE_CAP = 10;
 const FOLLOWUP_CONTEXT_CHAR_CAP = 700;
 const FOLLOWUP_CONTEXT_MESSAGE_CAP = 8;
 const BUILT_IN_GENERATION_FOLLOWUP_CONTEXT = [
-  "Supported VM0 built-in generation tasks:",
+  "Supported built-in generation tasks:",
   "- image: create or edit images and visual assets.",
   "- video: create short generated videos.",
   "- presentation: create slide decks or presentation documents.",
@@ -478,7 +478,7 @@ async function generateRecommendedFollowups(
           `Generate up to ${RECOMMENDED_FOLLOWUP_LIMIT.toString()} concise follow-up prompts the user may ask next in this chat.`,
           "Make each prompt specific to the latest assistant reply, actionable, and useful. Match the user's language.",
           'The "prompt" values are shown as plain text, not rendered as Markdown, so formatting characters will appear literally. Do not use Markdown or presentation-only syntax inside prompt values, including backticks around technical names, bold or italic markers, links, or bullet markers.',
-          'Classify each item as kind "talk" for normal discussion, planning, analysis, or refinement, or kind "generate" when the prompt asks VM0 to create one of the supported built-in generation outputs.',
+          'Classify each item as kind "talk" for normal discussion, planning, analysis, or refinement, or kind "generate" when the prompt asks for one of the supported built-in generation outputs.',
           BUILT_IN_GENERATION_FOLLOWUP_CONTEXT,
           "For generate items, include generationType as one of: image, video, presentation, website.",
           'Return only a JSON array of objects like {"prompt":"...","kind":"talk"} or {"prompt":"...","kind":"generate","generationType":"website"}. No markdown or extra text.',

--- a/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
@@ -295,7 +295,7 @@ async function resolveModelContext(
                 : "PROVIDER_UNAVAILABLE",
               message: fallbackEnabled
                 ? "Every managed route for this model is temporarily unavailable"
-                : "No model provider configured: no VM0 managed model key is configured",
+                : "No model provider configured: no built-in model key is configured",
             },
           },
         },

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2638,7 +2638,7 @@ async function resolveQueuedMessageModelRoute(args: {
           : "PROVIDER_UNAVAILABLE",
         message: args.fallbackEnabled
           ? "Every managed route for this model is temporarily unavailable"
-          : "No model provider configured: no VM0 managed model key is configured",
+          : "No model provider configured: no built-in model key is configured",
       },
     };
   }

--- a/turbo/apps/api/src/signals/services/workflow-automation-launch.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-launch.service.ts
@@ -337,7 +337,7 @@ async function resolveModelContext(
                 : "PROVIDER_UNAVAILABLE",
               message: fallbackEnabled
                 ? "Every managed route for this model is temporarily unavailable"
-                : "No model provider configured: no VM0 managed model key is configured",
+                : "No model provider configured: no built-in model key is configured",
             },
           },
         },

--- a/turbo/apps/api/src/test-fixtures/built-in-model-runtime-route.ts
+++ b/turbo/apps/api/src/test-fixtures/built-in-model-runtime-route.ts
@@ -1,0 +1,13 @@
+/**
+ * Missing operator-managed keys are global infrastructure state and cannot be
+ * isolated through a user-facing API. This fixture scopes that state to one
+ * async request chain so route tests never delete or restore shared key rows.
+ */
+import { withBuiltInModelRuntimeRouteUnavailableForTest as withRuntimeRouteUnavailable } from "../signals/services/built-in-model-runtime-route.service";
+
+export function withBuiltInModelRuntimeRouteUnavailableForTest<T>(
+  selectedModel: string,
+  work: () => Promise<T>,
+): Promise<T> {
+  return withRuntimeRouteUnavailable(selectedModel, work);
+}


### PR DESCRIPTION
## Summary

- replace VM0-managed model wording in direct chat, goal queue, queued callback, and workflow automation provider-unavailable responses with neutral `built-in model` terminology
- remove VM0 branding from the recommended follow-up classifier prompt while preserving the internal `vm0` provider identifier and configuration labels
- cover the user-facing error response and outbound follow-up prompt through existing API route integration tests

Part of #27750.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts -t "persists assistant output, reorders threads, titles the thread, recommends follow-ups, notifies, and auto-sends the queued template message"` (1 passed)
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t "routes model policy providers into the runner claim"` (1 passed)
