### PR TITLE
refactor(teams): move the teams routes off the brand namespace

### DIFF
--- a/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
+++ b/turbo/apps/api/src/__tests__/migrated-branded-paths.test.ts
@@ -18,6 +18,7 @@ import { slackChannelsRoutes } from "../signals/routes/slack-channels";
 import { slackConnectRoutes } from "../signals/routes/slack-connect";
 import { slackOauthRoutes } from "../signals/routes/slack-oauth";
 import { strapiIntegrationsRoutes } from "../signals/routes/strapi-integrations";
+import { teamsBotRoutes } from "../signals/routes/teams-bot";
 import { teamsBrowserConnectRoutes } from "../signals/routes/teams-browser-connect";
 import { teamsConnectRoutes } from "../signals/routes/teams-connect";
 import { teamsOauthRoutes } from "../signals/routes/teams-oauth";
@@ -1132,6 +1133,16 @@ const MIGRATED_ROUTE_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/workflows/:workflowId/run",
     "/api/zero/workflows/:workflowId/run",
   ],
+  // #28545: the Teams OAuth callback and the Teams bot ingress, moved off
+  // `FINAL_PROVIDER_CONSOLE_PATHS` now that both Microsoft consoles hold the
+  // final URL. `/api/zero/teams/oauth/callback` is still emitted on purpose by
+  // the VM0 brand, so it is a producer target rather than drain-window
+  // compatibility; `route-entry.ts` records why on the row.
+  "/api/integrations/teams/oauth/callback": [
+    "/api/okou/teams/oauth/callback",
+    "/api/zero/teams/oauth/callback",
+  ],
+  "/api/webhooks/teams/bot": ["/api/okou/teams/bot", "/api/zero/teams/bot"],
 };
 
 function missingBrandedPaths(
@@ -1691,6 +1702,59 @@ describe("branded paths for migrated neutral routes", () => {
 
       expect({ suffix, neutral, okou, zero }).toStrictEqual({
         suffix,
+        neutral,
+        okou: neutral,
+        zero: neutral,
+      });
+      expect(neutral).not.toBe(404);
+    }
+  });
+
+  // The #28545 twin, and the one slice where the branded forms are held by a
+  // provider console rather than by a released client: the Microsoft app
+  // registration still lists both callback URLs and Azure Bot can still be
+  // pointed at either bot URL, so a dropped row 404s Microsoft itself with no
+  // drain window to wait out. Requests carry no credentials, so the status is
+  // whatever the handler returns before it has any — the point is that the
+  // neutral path and both branded forms reach the same handler.
+  it("serves the migrated Teams console paths through the production app factory", async () => {
+    context.mocks.clerk.authenticateRequest.mockResolvedValue({
+      isAuthenticated: false,
+    });
+
+    const families = [
+      {
+        routes: teamsOauthRoutes,
+        method: "GET",
+        neutralSuffix: "integrations/teams/oauth/callback",
+        brandedSuffix: "teams/oauth/callback",
+      },
+      {
+        routes: teamsBotRoutes,
+        method: "POST",
+        neutralSuffix: "webhooks/teams/bot",
+        brandedSuffix: "teams/bot",
+      },
+    ] as const;
+
+    for (const { routes, method, neutralSuffix, brandedSuffix } of families) {
+      const app = createAppWithRoutes({ signal: context.signal, routes });
+
+      async function statusFor(path: string): Promise<number> {
+        const response = await app.request(`${REQUEST_ORIGIN}${path}`, {
+          method,
+          headers: { "content-type": "application/json" },
+          ...(method === "POST" ? { body: "{}" } : {}),
+        });
+        return response.status;
+      }
+
+      const neutral = await statusFor(`/api/${neutralSuffix}`);
+      const okou = await statusFor(`/api/okou/${brandedSuffix}`);
+      const zero = await statusFor(`/api/zero/${brandedSuffix}`);
+
+      expect({ neutralSuffix, neutral, okou, zero }).toStrictEqual({
+        neutralSuffix,
         neutral,
         okou: neutral,
         zero: neutral,

--- a/turbo/apps/api/src/__tests__/provider-console-paths.test.ts
+++ b/turbo/apps/api/src/__tests__/provider-console-paths.test.ts
@@ -14,19 +14,21 @@ interface FinalConsoleRoute {
   readonly finalPath: string;
 }
 
-// The eight URLs the Feishu, Slack, and Microsoft consoles hold after #28278
-// Stage 0. Restated here so the registration is asserted against the issue
-// table rather than against the map the production code reads.
+// The URLs the Feishu and Slack consoles hold after #28278 Stage 0 and whose
+// contracts still declare the branded path. Restated here so the registration
+// is asserted against the issue table rather than against the map the
+// production code reads.
+//
+// The two Microsoft rows are gone: #28545 moved those contracts onto their
+// final console paths, so `MIGRATED_BRANDED_PATHS` owes their branded forms
+// now and `migrated-branded-paths.test.ts` is what covers them. A row that
+// migrates has to leave this list, because the last assertion below pins that
+// this table adds exactly these registrations and nothing else.
 const FINAL_CONSOLE_ROUTES: readonly FinalConsoleRoute[] = [
   {
     method: "GET",
     brandedPath: "/api/okou/slack/oauth/callback",
     finalPath: "/api/integrations/slack/oauth/callback",
-  },
-  {
-    method: "GET",
-    brandedPath: "/api/okou/teams/oauth/callback",
-    finalPath: "/api/integrations/teams/oauth/callback",
   },
   {
     method: "GET",
@@ -47,11 +49,6 @@ const FINAL_CONSOLE_ROUTES: readonly FinalConsoleRoute[] = [
     method: "POST",
     brandedPath: "/api/okou/slack/interactive",
     finalPath: "/api/webhooks/slack/interactive",
-  },
-  {
-    method: "POST",
-    brandedPath: "/api/okou/teams/bot",
-    finalPath: "/api/webhooks/teams/bot",
   },
   {
     method: "POST",
@@ -93,9 +90,9 @@ function requireRegistration(
 
 // Per-endpoint behaviour is covered through the endpoints themselves in
 // routes/__tests__/provider-console-paths.test.ts. This file asserts the one
-// property no endpoint can express: over the whole route table, exactly these
-// eight registrations are added and none of the other product routes gains a
-// second path.
+// property no endpoint can express: over the whole route table, exactly the
+// registrations listed above are added and none of the other product routes
+// gains a second path.
 describe("final provider console paths", () => {
   const registeredRoutes = withApiNamespaceAliases(
     withFinalProviderConsolePaths(ROUTES),
@@ -130,7 +127,7 @@ describe("final provider console paths", () => {
     }
   });
 
-  it("adds only these eight paths and keeps every registration unique", () => {
+  it("adds only these listed paths and keeps every registration unique", () => {
     const brandedOnlyKeys = new Set(
       withApiNamespaceAliases(ROUTES).map(routeKey),
     );

--- a/turbo/apps/api/src/signals/route-entry.ts
+++ b/turbo/apps/api/src/signals/route-entry.ts
@@ -47,10 +47,10 @@ function routeEntryWithPath(entry: RouteEntry, path: string): RouteEntry {
 }
 
 /**
- * Final paths that the Feishu, Slack, and Microsoft consoles hold after #28278
- * Stage 0, keyed by the branded path that serves them today. OAuth callbacks
- * join `/api/integrations/**` beside the IM connect routes, and inbound
- * webhooks join `/api/webhooks/**` beside the other providers.
+ * Final paths that the Feishu and Slack consoles hold after #28278 Stage 0,
+ * keyed by the branded path that serves them today. OAuth callbacks join
+ * `/api/integrations/**` beside the IM connect routes, and inbound webhooks
+ * join `/api/webhooks/**` beside the other providers.
  *
  * Step 1 only makes these paths routable: each one adds a second way to reach
  * the handler that already serves its branded path. Producers switch one at a
@@ -58,26 +58,31 @@ function routeEntryWithPath(entry: RouteEntry, path: string): RouteEntry {
  * Teams OAuth callback switched in #28300 and the Feishu events URL we display
  * to operators in #28338. Every branded path here stays registered: removal is
  * gated on #26701.
+ *
+ * A row leaves this table when #28278 moves its contract onto the final path,
+ * because from then on the contract declares that path and this table has
+ * nothing left to add. The two Microsoft rows left in #28545, and
+ * `MIGRATED_BRANDED_PATHS` below owes their branded forms instead. That
+ * deletion is not optional: a row kept alongside a migrated contract makes both
+ * tables produce the same registration, which `assertUniqueRouteRegistrations`
+ * throws on at startup.
  */
 const FINAL_PROVIDER_CONSOLE_PATHS: Readonly<Record<string, string>> = {
   "GET /api/okou/slack/oauth/callback":
     "/api/integrations/slack/oauth/callback",
-  "GET /api/okou/teams/oauth/callback":
-    "/api/integrations/teams/oauth/callback",
   "GET /api/okou/feishu/oauth/callback":
     "/api/integrations/feishu/oauth/callback",
   "POST /api/okou/slack/events": "/api/webhooks/slack/events",
   "POST /api/okou/slack/commands": "/api/webhooks/slack/commands",
   "POST /api/okou/slack/interactive": "/api/webhooks/slack/interactive",
-  "POST /api/okou/teams/bot": "/api/webhooks/teams/bot",
   "POST /api/okou/feishu/events/:installationId":
     "/api/webhooks/feishu/events/:installationId",
 };
 
 /**
- * Adds the eight final provider console paths. Unlike the namespace aliases
- * below, this expands an explicit list and never derives a path, so no other
- * route gains a second registration.
+ * Adds the six final provider console paths still served from a branded
+ * contract. Unlike the namespace aliases below, this expands an explicit list
+ * and never derives a path, so no other route gains a second registration.
  */
 export function withFinalProviderConsolePaths(
   routes: readonly RouteEntry[],
@@ -156,9 +161,12 @@ const LEGACY_ZERO_PATHS: Readonly<Record<string, string>> = {
   "/api/okou/mail/drafts/:mailDraftId": "/api/zero/mail/drafts/:mailDraftId",
 
   // Held by a provider console, so measured traffic cannot retire them. Every
-  // branded path in `FINAL_PROVIDER_CONSOLE_PATHS` is listed, including the
-  // Teams OAuth callback that the Microsoft app registration still points at
-  // after #28300 — see the ordering constraint recorded on #26701.
+  // branded path in `FINAL_PROVIDER_CONSOLE_PATHS` is listed, plus the Teams
+  // OAuth callback below and the `/api/okou/teams/bot` row above: #28545 moved
+  // both contracts onto their final console paths, so those two rows are served
+  // by `MIGRATED_BRANDED_PATHS` rather than by the expansion. They stay listed,
+  // because a row records that a path is owed rather than which table serves it
+  // — see the ordering constraint recorded on #26701.
   "/api/okou/teams/oauth/callback": "/api/zero/teams/oauth/callback",
   "/api/okou/slack/oauth/callback": "/api/zero/slack/oauth/callback",
   "/api/okou/feishu/oauth/callback": "/api/zero/feishu/oauth/callback",
@@ -1462,6 +1470,30 @@ const MIGRATED_BRANDED_PATHS: Readonly<Record<string, readonly string[]>> = {
     "/api/okou/workflows/:workflowId/run",
     "/api/zero/workflows/:workflowId/run",
   ],
+  // #28545: the two Microsoft console routes, which arrive here from
+  // `FINAL_PROVIDER_CONSOLE_PATHS` rather than from the branded namespace like
+  // the rows above. The Azure Bot messaging endpoint and the Microsoft identity
+  // platform redirect URIs now hold the final paths, so the contracts declare
+  // them and that table's rows were deleted in the same commit — keeping them
+  // would have made both tables produce the same registration.
+  //
+  // What holds the branded forms open is not a released client but the two
+  // Microsoft consoles themselves, which have no drain window: they keep
+  // sending to whatever URL is registered until an operator changes it.
+  // Removal follows #26701's evidence rules, and for the `zero` callback the
+  // ordering constraint recorded there.
+  "/api/integrations/teams/oauth/callback": [
+    "/api/okou/teams/oauth/callback",
+    // Not drain-window compatibility. `callbackRedirectUri` in
+    // `routes/teams-oauth.ts` is brand-conditional and still emits this exact
+    // path for the VM0 brand on purpose: it is registered in the Microsoft app
+    // registration, and #26701 records that it retires together with the
+    // `api.vm0.ai` brand host. So this row is an active producer target, not a
+    // leftover — do not prune it merely for being an `/api/zero/` path, or
+    // live VM0-brand connects lose the callback they were sent to.
+    "/api/zero/teams/oauth/callback",
+  ],
+  "/api/webhooks/teams/bot": ["/api/okou/teams/bot", "/api/zero/teams/bot"],
 };
 
 /**

--- a/turbo/apps/api/src/signals/routes/__tests__/provider-console-paths.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/provider-console-paths.test.ts
@@ -164,6 +164,12 @@ describe("final provider console paths", () => {
     });
   });
 
+  // Kept here after #28545 moved the contract onto the final path: what this
+  // block asserts is that all three forms answer identically, which is the
+  // property the move has to preserve. The table behind them changed —
+  // `MIGRATED_BRANDED_PATHS` now owes the two branded forms rather than
+  // `FINAL_PROVIDER_CONSOLE_PATHS` owing the final one — and that swap is what
+  // this replay would catch if a row had been dropped on either side.
   describe("GET /api/integrations/teams/oauth/callback", () => {
     const paths = namespacePaths(
       "/teams/oauth/callback",

--- a/turbo/packages/api-contracts/src/contracts/teams-bot.ts
+++ b/turbo/packages/api-contracts/src/contracts/teams-bot.ts
@@ -122,7 +122,7 @@ export const teamsBotIngressResponseSchema = z.object({
 export const teamsBotContract = c.router({
   post: {
     method: "POST",
-    path: "/api/okou/teams/bot",
+    path: "/api/webhooks/teams/bot",
     body: z.unknown(),
     responses: {
       200: teamsBotIngressResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/teams-oauth.ts
+++ b/turbo/packages/api-contracts/src/contracts/teams-oauth.ts
@@ -33,7 +33,7 @@ export const teamsOauthContract = c.router({
   },
   callback: {
     method: "GET",
-    path: "/api/okou/teams/oauth/callback",
+    path: "/api/integrations/teams/oauth/callback",
     query: teamsOauthCallbackQuerySchema,
     responses: {
       307: c.noBody(),


### PR DESCRIPTION
Closes #28545. Part of #28278.

Both Teams provider consoles now hold the final URLs — the Azure Bot messaging endpoint points at `/api/webhooks/teams/bot`, and the Microsoft identity platform redirect URIs cover `/api/integrations/teams/oauth/callback` — so the contracts can follow the other product routes off the brand namespace.

## Change

**1. Contract paths**

| Contract | From | To |
|---|---|---|
| `contracts/teams-oauth.ts` | `/api/okou/teams/oauth/callback` | `/api/integrations/teams/oauth/callback` |
| `contracts/teams-bot.ts` | `/api/okou/teams/bot` | `/api/webhooks/teams/bot` |

**2. Both rows move between tables in `apps/api/src/signals/route-entry.ts`**

Deleted from `FINAL_PROVIDER_CONSOLE_PATHS`, added to `MIGRATED_BRANDED_PATHS`. Deleting the old rows is mandatory: a row kept alongside a migrated contract makes both tables produce the same registration, and `assertUniqueRouteRegistrations` throws at startup.

The registered set is unchanged — three paths per route, before and after.

## `/api/zero/teams/oauth/callback` is an active producer target

`callbackRedirectUri()` in `routes/teams-oauth.ts` is brand-conditional and still emits that exact path for the VM0 brand on purpose. It is registered in the Microsoft app registration, and the decision recorded on #26701 is that it retires together with the `api.vm0.ai` brand host. Its row carries a comment saying so, so that a later prune of `MIGRATED_BRANDED_PATHS` does not treat it as stale merely for being an `/api/zero/` path.

`callbackRedirectUri()`, its brand-conditional behaviour, and the #28300 OAuth state handling (including the fallback for state written without a redirect URI) are untouched. The four remaining Slack entries and the two Feishu entries in `FINAL_PROVIDER_CONSOLE_PATHS` are untouched — #28544 owns the Feishu ones.

## Fallbacks

- `turbo/apps/api/src/signals/route-entry.ts:MIGRATED_BRANDED_PATHS` — two new rows (four branded registrations) keeping `/api/okou/teams/oauth/callback`, `/api/zero/teams/oauth/callback`, `/api/okou/teams/bot`, and `/api/zero/teams/bot` resolving after the contracts declare `/api/integrations/teams/oauth/callback` and `/api/webhooks/teams/bot`. `apiNamespaceAliasPaths()` returns a neutral path unchanged, so without these rows both branded forms would 404 the moment the contracts moved. Surface: **the two Microsoft provider consoles — no drain window**. Unlike the client-bounded windows in `docs/fallback.md` §7 (old web/app client ~2 days, existing runner or sandbox up to 2h), a provider console keeps sending to whatever URL is registered until an operator changes it, so no clock bounds these rows. `/api/zero/teams/oauth/callback` is further an **active producer target** rather than drain-window compatibility: `callbackRedirectUri()` still emits it for the VM0 brand on purpose, and its row carries an inline comment saying so. Removal condition: #26701's request-log evidence rules, and for the `zero` callback the constraint recorded there that it retires together with the `api.vm0.ai` brand host. Follow-up: #26701.

## Tests

- `src/__tests__/provider-console-paths.test.ts` — the two Microsoft rows drop out of the restated console list; the "adds only these listed paths" assertion is what would fail if a migrated row were left behind in either table.
- `src/__tests__/migrated-branded-paths.test.ts` — both rows added to the restated `MIGRATED_ROUTE_PATHS` list, plus a new request-level case driving all three forms of each route through the production app factory.
- `signals/routes/__tests__/provider-console-paths.test.ts` — the Teams callback replay stays and still asserts all three forms answer identically; only the table behind them changed.
- `api-namespace-compatibility.test.ts` is unchanged and still passes: both branded Teams paths stay owed, now served by `MIGRATED_BRANDED_PATHS` instead of by the namespace expansion.
- `teams-oauth.test.ts` and `teams-bot.test.ts` are unchanged and still exercise the branded request paths, the brand-conditional redirect URI, the state replay, and the missing-field fallback.

### Verified locally

`pnpm -F api check-types`, `pnpm -F api lint`, `pnpm -F @okouai/api-contracts check-types`, `pnpm -F @okouai/api-contracts lint`, `pnpm knip`, `prettier --check`, `pnpm -F @okouai/api-contracts exec vitest run` (595 passed), and `pnpm -F api exec vitest run src/__tests__/` (106 passed) all pass. The Teams route suites pass except for six `teams-bot.test.ts` cases that fail identically on unmodified `main` in this sandbox (runner job-claim returns "Job not found in queue" — a local queue-env gap, not a regression from this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
