### PR TITLE
test(runner): bound workspace cache readiness probe

### DIFF
--- a/.github/scripts/runner-behavior-workspace-cache-promotion.sh
+++ b/.github/scripts/runner-behavior-workspace-cache-promotion.sh
@@ -166,10 +166,9 @@ cat /tmp/vm0-workspace-cache-release >/dev/null' &
     'writer_attempt=0
 while [ "$writer_attempt" -lt 50 ]; do
   writer_size=$(stat -c %s /home/user/workspace/live-writer 2>/dev/null || printf 0)
-  case "$writer_size" in
-    ""|*[!0-9]*) ;;
-    *) [ "$writer_size" -gt 13 ] && exit 0 ;;
-  esac
+  if [ "$writer_size" -gt 13 ]; then
+    exit 0
+  fi
   writer_attempt=$((writer_attempt + 1))
   sleep 0.1
 done

--- a/.github/scripts/runner-behavior-workspace-cache-promotion.sh
+++ b/.github/scripts/runner-behavior-workspace-cache-promotion.sh
@@ -154,28 +154,75 @@ cat /tmp/vm0-workspace-cache-release >/dev/null' &
     'cd /home/user/workspace && exec 3>>live-writer && printf "writer-start\n" >&3 && while :; do printf x >&3; sleep 0.05; done' &
   WRITER_EXEC_PID=$!
 
-  WRITER_READY=false
-  for _ in $(seq 1 30); do
-    if ! kill -0 "$WRITER_EXEC_PID" 2>/dev/null; then
+  set +e
+  WRITER_PROBE_OUTPUT=$(sudo timeout 17 "$BIN_DIR/runner" exec --timeout 10 \
+    --sandbox "$SANDBOX_ID" -- sh -c \
+    'writer_attempt=0
+while [ "$writer_attempt" -lt 50 ]; do
+  writer_size=$(stat -c %s /home/user/workspace/live-writer 2>/dev/null || printf 0)
+  case "$writer_size" in
+    ''|*[!0-9]*) ;;
+    *) [ "$writer_size" -gt 13 ] && exit 0 ;;
+  esac
+  writer_attempt=$((writer_attempt + 1))
+  sleep 0.1
+done
+printf "Independent workspace writer did not become active within 5 seconds\n" >&2
+exit 42' 2>&1)
+  WRITER_PROBE_STATUS=$?
+  set -e
+
+  if [ "$WRITER_PROBE_STATUS" -ne 0 ]; then
+    printf '%s\n' "$WRITER_PROBE_OUTPUT"
+
+    CONTROL_DEADLINE=false
+    if grep -F 'failed to connect to sandbox: connect timed out' \
+      <<<"$WRITER_PROBE_OUTPUT" >/dev/null \
+      || grep -F 'failed to connect to sandbox: request timed out' \
+        <<<"$WRITER_PROBE_OUTPUT" >/dev/null \
+      || grep -F 'exec failed: exec start timeout' \
+        <<<"$WRITER_PROBE_OUTPUT" >/dev/null; then
+      CONTROL_DEADLINE=true
+    elif [ "$WRITER_PROBE_STATUS" -eq 124 ] \
+      && ! grep -Fx 'Timeout' <<<"$WRITER_PROBE_OUTPUT" >/dev/null; then
+      CONTROL_DEADLINE=true
+    fi
+
+    if [ "$CONTROL_DEADLINE" = true ]; then
+      echo "--- Control exec diagnostics for invocation ${TURN1_INVOCATION_ID} ---"
+      CONTROL_LINES=$(sudo journalctl --no-pager \
+        "_SYSTEMD_INVOCATION_ID=$TURN1_INVOCATION_ID" 2>&1 \
+        | grep -E 'control socket|exec operation|runner-exec' || true)
+      if [ -n "$CONTROL_LINES" ]; then
+        printf '%s\n' "$CONTROL_LINES"
+      else
+        echo "No control exec diagnostics found"
+      fi
+
+      if [ "$ATTEMPT" -eq "$MAX_ATTEMPTS" ]; then
+        fail "Concurrent control exec remained unavailable after ${MAX_ATTEMPTS} attempts"
+      fi
+
+      echo "RETRY: concurrent control exec missed its deadline on attempt ${ATTEMPT}"
+      sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+      wait_for_unit_inactive
+      kill "$WRITER_EXEC_PID" 2>/dev/null || true
       wait "$WRITER_EXEC_PID" 2>/dev/null || true
       WRITER_EXEC_PID=""
-      fail "Independent workspace writer exited before promotion"
+      kill "$SUBMIT_PID" 2>/dev/null || true
+      wait "$SUBMIT_PID" 2>/dev/null || true
+      SUBMIT_PID=""
+      continue
     fi
-    WRITER_SIZE=$(sudo "$BIN_DIR/runner" exec --timeout 2 \
-      --sandbox "$SANDBOX_ID" -- stat -c %s /home/user/workspace/live-writer \
-      2>/dev/null || true)
-    case "$WRITER_SIZE" in
-      ''|*[!0-9]*) ;;
-      *)
-        if [ "$WRITER_SIZE" -gt 13 ]; then
-          WRITER_READY=true
-          break
-        fi
-        ;;
-    esac
-    sleep 1
-  done
-  [ "$WRITER_READY" = true ] || fail "Independent workspace writer did not become active"
+
+    if [ "$WRITER_PROBE_STATUS" -eq 42 ]; then
+      fail "Independent workspace writer did not become active"
+    fi
+    if [ "$WRITER_PROBE_STATUS" -eq 124 ]; then
+      fail "Independent workspace writer readiness command timed out in the guest"
+    fi
+    fail "Independent workspace writer readiness probe failed with status ${WRITER_PROBE_STATUS}"
+  fi
 
   # Enter draining while both the supervised turn and independent writer are
   # live. Releasing the turn then drives freeze, stop, and promotion without

--- a/.github/scripts/runner-behavior-workspace-cache-promotion.sh
+++ b/.github/scripts/runner-behavior-workspace-cache-promotion.sh
@@ -66,18 +66,24 @@ wait_for_unit_inactive() {
   fail "$UNIT is still active after stop"
 }
 
-cleanup() {
-  echo "--- Cleanup ---"
+stop_active_attempt() {
   sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
   wait_for_unit_inactive
   if [ -n "$WRITER_EXEC_PID" ]; then
     kill "$WRITER_EXEC_PID" 2>/dev/null || true
     wait "$WRITER_EXEC_PID" 2>/dev/null || true
+    WRITER_EXEC_PID=""
   fi
   if [ -n "$SUBMIT_PID" ]; then
     kill "$SUBMIT_PID" 2>/dev/null || true
     wait "$SUBMIT_PID" 2>/dev/null || true
+    SUBMIT_PID=""
   fi
+}
+
+cleanup() {
+  echo "--- Cleanup ---"
+  stop_active_attempt
   sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
 }
 trap cleanup EXIT
@@ -204,14 +210,7 @@ exit 42' 2>&1)
       fi
 
       echo "RETRY: concurrent control exec missed its deadline on attempt ${ATTEMPT}"
-      sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
-      wait_for_unit_inactive
-      kill "$WRITER_EXEC_PID" 2>/dev/null || true
-      wait "$WRITER_EXEC_PID" 2>/dev/null || true
-      WRITER_EXEC_PID=""
-      kill "$SUBMIT_PID" 2>/dev/null || true
-      wait "$SUBMIT_PID" 2>/dev/null || true
-      SUBMIT_PID=""
+      stop_active_attempt
       continue
     fi
 

--- a/.github/scripts/runner-behavior-workspace-cache-promotion.sh
+++ b/.github/scripts/runner-behavior-workspace-cache-promotion.sh
@@ -167,7 +167,7 @@ cat /tmp/vm0-workspace-cache-release >/dev/null' &
 while [ "$writer_attempt" -lt 50 ]; do
   writer_size=$(stat -c %s /home/user/workspace/live-writer 2>/dev/null || printf 0)
   case "$writer_size" in
-    ''|*[!0-9]*) ;;
+    ""|*[!0-9]*) ;;
     *) [ "$writer_size" -gt 13 ] && exit 0 ;;
   esac
   writer_attempt=$((writer_attempt + 1))

--- a/crates/sandbox-fc/src/control/server/tests.rs
+++ b/crates/sandbox-fc/src/control/server/tests.rs
@@ -956,6 +956,64 @@ async fn control_server_shutdown_cancels_in_flight_vsock_exec() {
 }
 
 #[tokio::test]
+async fn control_exec_completes_second_request_while_first_is_in_flight() {
+    let (first_exec_seen_tx, first_exec_seen_rx) = oneshot::channel();
+    let fixture = VsockExecFixture::connect(|vsock_base| {
+        mock_guest_holds_first_exec_and_completes_second(vsock_base, first_exec_seen_tx)
+    })
+    .await;
+    let mut handle = fixture.spawn_server();
+    let first_client = tokio::spawn({
+        let sock_path = fixture.sock_path.clone();
+        async move {
+            send_exec(
+                &sock_path,
+                &exec_request("hold-first"),
+                Duration::from_secs(30),
+            )
+            .await
+        }
+    });
+
+    tokio::time::timeout(Duration::from_secs(1), first_exec_seen_rx)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(!first_client.is_finished());
+
+    let second_response = tokio::time::timeout(
+        Duration::from_secs(1),
+        send_exec(
+            &fixture.sock_path,
+            &exec_request("complete-second"),
+            Duration::from_secs(5),
+        ),
+    )
+    .await
+    .expect("second control exec should remain responsive")
+    .unwrap();
+    let (termination, stdout, stderr, stdout_truncated, stderr_truncated, diagnostic) =
+        expect_exec_success(second_response);
+    assert_eq!(termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(stdout, b"second");
+    assert!(stderr.is_empty());
+    assert!(!stdout_truncated);
+    assert!(!stderr_truncated);
+    assert!(diagnostic.is_empty());
+    assert!(!first_client.is_finished());
+
+    handle.shutdown().await;
+    let first_result = tokio::time::timeout(Duration::from_secs(1), first_client)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(first_result.is_err());
+
+    fixture.guest_task.abort();
+    let _ = fixture.guest_task.await;
+}
+
+#[tokio::test]
 async fn control_exec_rejects_when_policy_gate_is_closing() {
     let (exec_seen_tx, mut exec_seen_rx) = oneshot::channel();
     let fixture =
@@ -1218,6 +1276,50 @@ async fn read_vsock_message(stream: &mut UnixStream, decoder: &mut Decoder) -> R
 
 async fn mock_guest_holds_exec(vsock_base: PathBuf, exec_seen: oneshot::Sender<()>) {
     mock_guest_until_exec(vsock_base, exec_seen, true).await;
+}
+
+async fn mock_guest_holds_first_exec_and_completes_second(
+    vsock_base: PathBuf,
+    first_exec_seen: oneshot::Sender<()>,
+) {
+    let listener_path = PathBuf::from(format!(
+        "{}_{}",
+        vsock_base.display(),
+        vsock_proto::VSOCK_PORT
+    ));
+    wait_for_socket_exists(&listener_path).await;
+
+    let mut stream = UnixStream::connect(&listener_path).await.unwrap();
+    let mut decoder = Decoder::new();
+    mock_vsock_handshake(&mut stream, &mut decoder).await;
+
+    let first = read_vsock_message(&mut stream, &mut decoder).await;
+    assert_eq!(first.msg_type, MSG_EXEC_START);
+    first_exec_seen.send(()).unwrap();
+
+    let second = read_vsock_message(&mut stream, &mut decoder).await;
+    assert_eq!(second.msg_type, MSG_EXEC_START);
+    assert_ne!(second.seq, first.seq);
+    let mut frame = Vec::new();
+    vsock_proto::encode_exec_result_frame_into(
+        &mut frame,
+        second.seq,
+        vsock_proto::ExecTermination::Exited { exit_code: 0 },
+        10,
+        ExecCapturedOutput::Captured {
+            bytes: b"second",
+            truncated: false,
+        },
+        ExecCapturedOutput::Captured {
+            bytes: &[],
+            truncated: false,
+        },
+        "",
+    )
+    .unwrap();
+    stream.write_all(&frame).await.unwrap();
+
+    std::future::pending::<()>().await;
 }
 
 async fn mock_guest_records_exec(vsock_base: PathBuf, exec_seen: oneshot::Sender<()>) {


### PR DESCRIPTION
## Summary

- replace the workspace cache writer's 30 silent readiness calls with one bounded, diagnostic control exec
- retry only classified control deadlines after stopping the runner and reaping both host clients
- cover the full Unix control client/server path with a second exec completing while the first remains in flight

## Why

The failed behavior job discarded every readiness error and could spend the writer's complete 240-second lifetime on repeated control deadlines before reporting only that the writer exited. The new full-path regression passes on the current concurrent control implementation, so this PR does not add a speculative server watchdog, queue, or cancellation change.

The readiness command now has a distinct writer-not-ready exit, a 10-second guest deadline, and a 17-second host watchdog. Only connect, request, or exec-start deadlines—and the host watchdog—recreate the isolated scenario within its existing three-attempt budget. Guest command failures, workspace assertions, and unclassified failures still fail immediately.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p sandbox-fc --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `bash -n .github/scripts/runner-behavior-workspace-cache-promotion.sh`
- `shellcheck .github/scripts/runner-behavior-workspace-cache-promotion.sh`
- repository pre-commit hooks

Closes #28550
