### PR TITLE
fix(platform): paginate personal usage records

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
@@ -176,7 +176,6 @@ export const loadMoreUsageRecord$ = command(
         return retryablePages;
       });
     });
-    signal.throwIfAborted();
     if (get(myUsageRecordGeneration$) !== generation) {
       return;
     }

--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
@@ -2,11 +2,12 @@ import { command, computed, state } from "ccstate";
 import {
   usageRecordContract,
   type UsageRecordRange,
-  type UsageRecordScope,
+  type UsageRecordResponse,
 } from "@okouai/api-contracts/contracts/usage-record";
 import { usageMembersContract } from "@okouai/api-contracts/contracts/usage";
 import { accept } from "../../../lib/accept.ts";
 import { zeroClient$ } from "../../api-client.ts";
+import { onRejection } from "../../utils.ts";
 
 export type CreditBalanceTab = "mine" | "team";
 
@@ -55,12 +56,27 @@ export const toggleUsagePackMemberAdditions$ = command(
   },
 );
 
-const PAGE_STEP = 20;
+const PAGE_SIZE = 20;
+
+type LoadUsageRecordPage = (
+  page: number,
+  signal?: AbortSignal,
+) => Promise<UsageRecordResponse>;
 
 const usageRecordReload$ = state(0);
-const myUsagePageSize$ = state(PAGE_STEP);
+const myUsageRecordPages$ = state<readonly UsageRecordResponse[]>([]);
+const myUsageRecordRequestedPages$ = state<ReadonlySet<number>>(new Set());
+const myUsageRecordGeneration$ = state(0);
 const myUsageRangeState$ = state<UsageRecordRange>("today");
 const teamUsageRangeState$ = state<UsageRecordRange>("billingPeriod");
+
+const resetMyUsageRecordPages$ = command(({ set }) => {
+  set(myUsageRecordPages$, []);
+  set(myUsageRecordRequestedPages$, new Set());
+  set(myUsageRecordGeneration$, (generation) => {
+    return generation + 1;
+  });
+});
 
 export const myUsageRange$ = computed((get) => {
   return get(myUsageRangeState$);
@@ -72,7 +88,7 @@ export const teamUsageRange$ = computed((get) => {
 
 export const setMyUsageRange$ = command(({ set }, range: UsageRecordRange) => {
   set(myUsageRangeState$, range);
-  set(myUsagePageSize$, PAGE_STEP);
+  set(resetMyUsageRecordPages$);
 });
 
 export const setTeamUsageRange$ = command(
@@ -81,41 +97,100 @@ export const setTeamUsageRange$ = command(
   },
 );
 
-export const loadMoreUsageRecord$ = command(
-  ({ get, set }, _scope: UsageRecordScope) => {
-    set(myUsagePageSize$, get(myUsagePageSize$) + PAGE_STEP);
-  },
-);
-
-export const reloadUsageRecords$ = command(({ set }) => {
-  set(usageRecordReload$, (value) => {
-    return value + 1;
-  });
+const loadMyUsageRecordPage$ = computed((get): LoadUsageRecordPage => {
+  const range = get(myUsageRangeState$);
+  const client = get(zeroClient$)(usageRecordContract);
+  return async (page, signal) => {
+    const result = await accept(
+      client.get({
+        query: {
+          page,
+          pageSize: PAGE_SIZE,
+          scope: "mine",
+          range,
+          tz: currentTimeZone(),
+        },
+        ...(signal ? { fetchOptions: { signal } } : {}),
+      }),
+      [200],
+      signal,
+    );
+    return result.body;
+  };
 });
 
 function currentTimeZone(): string {
   return new Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
 }
 
+const firstMyUsageRecordPage$ = computed(
+  (get): Promise<UsageRecordResponse> => {
+    get(usageRecordReload$);
+    return get(loadMyUsageRecordPage$)(1);
+  },
+);
+
 export const myUsageRecordAsync$ = computed(async (get) => {
-  get(usageRecordReload$);
-  const pageSize = get(myUsagePageSize$);
-  const range = get(myUsageRangeState$);
-  const createClient = get(zeroClient$);
-  const client = createClient(usageRecordContract);
-  const result = await accept(
-    client.get({
-      query: {
-        page: 1,
-        pageSize,
-        scope: "mine",
-        range,
-        tz: currentTimeZone(),
-      },
-    }),
-    [200],
-  );
-  return result.body;
+  const firstPage = await get(firstMyUsageRecordPage$);
+  const appendedPages = get(myUsageRecordPages$);
+  const latestPage = appendedPages.at(-1) ?? firstPage;
+  return {
+    ...latestPage,
+    rows: [
+      ...firstPage.rows,
+      ...appendedPages.flatMap((page) => {
+        return page.rows;
+      }),
+    ],
+  };
+});
+
+export const loadMoreUsageRecord$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const generation = get(myUsageRecordGeneration$);
+    const loaded = await get(myUsageRecordAsync$);
+    signal.throwIfAborted();
+    if (
+      get(myUsageRecordGeneration$) !== generation ||
+      loaded.rows.length >= loaded.pagination.total
+    ) {
+      return;
+    }
+
+    const nextPage = get(myUsageRecordPages$).length + 2;
+    if (get(myUsageRecordRequestedPages$).has(nextPage)) {
+      return;
+    }
+    set(myUsageRecordRequestedPages$, (pages) => {
+      return new Set([...pages, nextPage]);
+    });
+
+    const loadPage = get(loadMyUsageRecordPage$);
+    const next = await onRejection(loadPage(nextPage, signal), () => {
+      if (get(myUsageRecordGeneration$) !== generation) {
+        return;
+      }
+      set(myUsageRecordRequestedPages$, (pages) => {
+        const retryablePages = new Set(pages);
+        retryablePages.delete(nextPage);
+        return retryablePages;
+      });
+    });
+    signal.throwIfAborted();
+    if (get(myUsageRecordGeneration$) !== generation) {
+      return;
+    }
+    set(myUsageRecordPages$, (pages) => {
+      return [...pages, next];
+    });
+  },
+);
+
+export const reloadUsageRecords$ = command(({ set }) => {
+  set(resetMyUsageRecordPages$);
+  set(usageRecordReload$, (value) => {
+    return value + 1;
+  });
 });
 
 export const teamMemberUsageAsync$ = computed(async (get) => {

--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
@@ -78,6 +78,19 @@ const resetMyUsageRecordPages$ = command(({ set }) => {
   });
 });
 
+const releaseMyUsageRecordPageRequest$ = command(
+  ({ get, set }, page: number, generation: number) => {
+    if (get(myUsageRecordGeneration$) !== generation) {
+      return;
+    }
+    set(myUsageRecordRequestedPages$, (pages) => {
+      const retryablePages = new Set(pages);
+      retryablePages.delete(page);
+      return retryablePages;
+    });
+  },
+);
+
 export const myUsageRange$ = computed((get) => {
   return get(myUsageRangeState$);
 });
@@ -167,15 +180,12 @@ export const loadMoreUsageRecord$ = command(
 
     const loadPage = get(loadMyUsageRecordPage$);
     const next = await onRejection(loadPage(nextPage, signal), () => {
-      if (get(myUsageRecordGeneration$) !== generation) {
-        return;
-      }
-      set(myUsageRecordRequestedPages$, (pages) => {
-        const retryablePages = new Set(pages);
-        retryablePages.delete(nextPage);
-        return retryablePages;
-      });
+      set(releaseMyUsageRecordPageRequest$, nextPage, generation);
     });
+    if (signal.aborted) {
+      set(releaseMyUsageRecordPageRequest$, nextPage, generation);
+      return;
+    }
     if (get(myUsageRecordGeneration$) !== generation) {
       return;
     }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -6,6 +6,7 @@ import {
 import {
   usageRecordContract,
   type UsageRecordRange,
+  type UsageRecordResponse,
   type UsageRecordRow,
 } from "@okouai/api-contracts/contracts/usage-record";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
@@ -211,6 +212,29 @@ interface UsageRecordRequestLog {
   readonly ranges: UsageRecordRange[];
 }
 
+function personalUsagePage(
+  rows: UsageRecordRow[],
+  page: number,
+  pageSize: number,
+): UsageRecordResponse {
+  const offset = (page - 1) * pageSize;
+  return {
+    period: {
+      start: "2026-03-01T00:00:00.000Z",
+      end: "2026-04-01T00:00:00.000Z",
+    },
+    rows: rows.slice(offset, offset + pageSize),
+    totalCredits: rows.reduce((sum, row) => {
+      return sum + row.credits;
+    }, 0),
+    pagination: {
+      page,
+      pageSize,
+      total: rows.length,
+    },
+  };
+}
+
 function mockPersonalUsageStory(
   rows: UsageRecordRow[] = usageRows(),
   tier: "limited-free-1" | "pro" = "pro",
@@ -233,23 +257,7 @@ function mockPersonalUsageStory(
     requests.pages.push(query.page);
     requests.pageSizes.push(query.pageSize);
     requests.ranges.push(query.range);
-    const offset = (query.page - 1) * query.pageSize;
-
-    return respond(200, {
-      period: {
-        start: "2026-03-01T00:00:00.000Z",
-        end: "2026-04-01T00:00:00.000Z",
-      },
-      rows: rows.slice(offset, offset + query.pageSize),
-      totalCredits: rows.reduce((sum, row) => {
-        return sum + row.credits;
-      }, 0),
-      pagination: {
-        page: query.page,
-        pageSize: query.pageSize,
-        total: rows.length,
-      },
-    });
+    return respond(200, personalUsagePage(rows, query.page, query.pageSize));
   });
   if (mockUsagePackCredits) {
     mockEmptyUsagePackCredits();
@@ -778,6 +786,42 @@ describe("personal usage settings", () => {
     expect(screen.queryByText("Load more")).not.toBeInTheDocument();
     expect(requests.pages).toStrictEqual([1, 2, 3, 4, 5, 6]);
     expect(requests.pageSizes).toStrictEqual([20, 20, 20, 20, 20, 20]);
+  });
+
+  it("retries a personal usage page after a failed request", async () => {
+    const user = userEvent.setup();
+    const rows = usageRows();
+    let secondPageAttempts = 0;
+    mockPersonalUsageStory(rows);
+    context.mocks.api(usageRecordContract.get, ({ query, respond }) => {
+      if (query.page === 2) {
+        secondPageAttempts += 1;
+        if (secondPageAttempts === 1) {
+          return respond(500, {
+            error: {
+              code: "INTERNAL_SERVER_ERROR",
+              message: "Usage page temporarily unavailable",
+            },
+          });
+        }
+      }
+      return respond(200, personalUsagePage(rows, query.page, query.pageSize));
+    });
+
+    await openUsageSettings(true, "usage-records");
+    expect(screen.queryByText("Extended agent audit")).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("Load more"));
+    await expect(
+      screen.findByText("Usage page temporarily unavailable"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.queryByText("Extended agent audit")).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("Load more"));
+    await expect(
+      screen.findByText("Extended agent audit"),
+    ).resolves.toBeInTheDocument();
+    expect(secondPageAttempts).toBe(2);
   });
 
   it("shows model names for limited-free-1 usage", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -5,6 +5,7 @@ import {
 } from "@okouai/api-contracts/contracts/billing";
 import {
   usageRecordContract,
+  type UsageRecordRange,
   type UsageRecordRow,
 } from "@okouai/api-contracts/contracts/usage-record";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
@@ -204,13 +205,23 @@ function mockEmptyUsagePackCredits(): void {
   });
 }
 
+interface UsageRecordRequestLog {
+  readonly pages: number[];
+  readonly pageSizes: number[];
+  readonly ranges: UsageRecordRange[];
+}
+
 function mockPersonalUsageStory(
   rows: UsageRecordRow[] = usageRows(),
   tier: "limited-free-1" | "pro" = "pro",
   mockUsagePackCredits = true,
   role: "admin" | "member" = "admin",
-): string[] {
-  const requestedRanges: string[] = [];
+): UsageRecordRequestLog {
+  const requests: UsageRecordRequestLog = {
+    pages: [],
+    pageSizes: [],
+    ranges: [],
+  };
 
   context.mocks.data.org({
     id: "org_1",
@@ -219,7 +230,9 @@ function mockPersonalUsageStory(
   });
   mockBillingStatus(tier);
   context.mocks.api(usageRecordContract.get, ({ query, respond }) => {
-    requestedRanges.push(query.range);
+    requests.pages.push(query.page);
+    requests.pageSizes.push(query.pageSize);
+    requests.ranges.push(query.range);
     const offset = (query.page - 1) * query.pageSize;
 
     return respond(200, {
@@ -241,7 +254,7 @@ function mockPersonalUsageStory(
   if (mockUsagePackCredits) {
     mockEmptyUsagePackCredits();
   }
-  return requestedRanges;
+  return requests;
 }
 
 async function openUsageSettings(
@@ -664,7 +677,7 @@ describe("personal usage settings", () => {
 
   it("shows personal usage, loads more, and changes the usage range", async () => {
     const user = userEvent.setup();
-    const requestedRanges = mockPersonalUsageStory();
+    const requests = mockPersonalUsageStory();
     await openUsageSettings(true, "usage-records");
 
     await waitFor(() => {
@@ -674,7 +687,7 @@ describe("personal usage settings", () => {
     expect(screen.getByText("1.1K")).toBeInTheDocument();
     expect(screen.queryByText("Extended agent audit")).not.toBeInTheDocument();
     expect(screen.queryByText("All sources")).not.toBeInTheDocument();
-    expect(requestedRanges).toContain("today");
+    expect(requests.ranges).toContain("today");
 
     await user.hover(screen.getByTestId("usage-kind-segment-other"));
 
@@ -723,14 +736,48 @@ describe("personal usage settings", () => {
     await waitFor(() => {
       expect(screen.getByText("Extended agent audit")).toBeInTheDocument();
     });
+    expect(requests.pages).toStrictEqual([1, 2]);
+    expect(requests.pageSizes).toStrictEqual([20, 20]);
 
     click(screen.getByText("Today"));
     click(await screen.findByText("Last 7 days"));
 
     await waitFor(() => {
       expect(screen.getByText("Last 7 days")).toBeInTheDocument();
-      expect(requestedRanges).toContain("7d");
+      expect(requests.ranges).toContain("7d");
+      expect(requests.pages.at(-1)).toBe(1);
     });
+  });
+
+  it("loads personal usage beyond 100 rows with bounded pages", async () => {
+    const user = userEvent.setup();
+    const rows = Array.from({ length: 101 }, (_, index) => {
+      const rowNumber = index + 1;
+      return usageRow({
+        title: `Usage record ${rowNumber}`,
+        credits: rowNumber,
+        runId: `run-usage-${rowNumber}`,
+      });
+    });
+    const requests = mockPersonalUsageStory(rows);
+
+    await openUsageSettings(true, "usage-records");
+
+    await expect(
+      screen.findByText("Usage record 20"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.queryByText("Usage record 21")).not.toBeInTheDocument();
+
+    for (const rowNumber of [21, 41, 61, 81, 101]) {
+      await user.click(screen.getByText("Load more"));
+      await expect(
+        screen.findByText(`Usage record ${rowNumber}`),
+      ).resolves.toBeInTheDocument();
+    }
+
+    expect(screen.queryByText("Load more")).not.toBeInTheDocument();
+    expect(requests.pages).toStrictEqual([1, 2, 3, 4, 5, 6]);
+    expect(requests.pageSizes).toStrictEqual([20, 20, 20, 20, 20, 20]);
   });
 
   it("shows model names for limited-free-1 usage", async () => {
@@ -821,31 +868,42 @@ describe("personal usage settings", () => {
       role: "admin",
     });
     mockBillingStatus();
-    let usageRequests = 0;
+    const initialRows = [
+      usageRow({
+        title: "Initial usage row",
+        credits: 100,
+        runId: "run-initial",
+      }),
+      ...Array.from({ length: 19 }, (_, index) => {
+        return usageRow({
+          title: `Initial usage filler ${index + 1}`,
+          credits: 10,
+          runId: `run-initial-filler-${index + 1}`,
+        });
+      }),
+      usageRow({
+        title: "Initial usage second page",
+        credits: 200,
+        runId: "run-initial-page-two",
+      }),
+    ];
+    const refreshedRows = [
+      usageRow({
+        title: "Realtime refreshed usage",
+        credits: 450,
+        runId: "run-refreshed",
+      }),
+    ];
+    let refreshed = false;
     context.mocks.api(usageRecordContract.get, ({ query, respond }) => {
-      usageRequests += 1;
-      const rows =
-        usageRequests === 1
-          ? [
-              usageRow({
-                title: "Initial usage row",
-                credits: 100,
-                runId: "run-initial",
-              }),
-            ]
-          : [
-              usageRow({
-                title: "Realtime refreshed usage",
-                credits: 450,
-                runId: "run-refreshed",
-              }),
-            ];
+      const rows = refreshed ? refreshedRows : initialRows;
+      const offset = (query.page - 1) * query.pageSize;
       return respond(200, {
         period: {
           start: "2026-03-01T00:00:00.000Z",
           end: "2026-04-01T00:00:00.000Z",
         },
-        rows,
+        rows: rows.slice(offset, offset + query.pageSize),
         totalCredits: rows.reduce((sum, row) => {
           return sum + row.credits;
         }, 0),
@@ -867,11 +925,20 @@ describe("personal usage settings", () => {
       ).toBeTruthy();
     });
 
+    click(screen.getByText("Load more"));
+    await expect(
+      screen.findByText("Initial usage second page"),
+    ).resolves.toBeInTheDocument();
+
+    refreshed = true;
     context.mocks.ably.trigger("billing:changed");
 
     await waitFor(() => {
       expect(screen.getByText("Realtime refreshed usage")).toBeInTheDocument();
       expect(screen.queryByText("Initial usage row")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Initial usage second page"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent } from "react";
-import { useLastLoadable, useLoadable, useSet } from "ccstate-react";
+import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import {
   ChevronDown,
   Clock,
@@ -14,7 +14,6 @@ import type {
   UsageRecordRange,
   UsageRecordResponse,
   UsageRecordRow,
-  UsageRecordScope,
   UsageRecordSource,
 } from "@okouai/api-contracts/contracts/usage-record";
 import type { UsageMembersResponse } from "@okouai/api-contracts/contracts/usage";
@@ -39,6 +38,8 @@ import {
   myUsageRecordAsync$,
   teamMemberUsageAsync$,
 } from "../../../../signals/zero-page/settings/personal-usage-record.ts";
+import { pageSignal$ } from "../../../../signals/page-signal.ts";
+import { detach, Reason } from "../../../../signals/utils.ts";
 import { orgMembers$ } from "../../../../signals/external/org-members.ts";
 import { closeSettingsModal$ } from "../../../../signals/zero-page/settings/settings-dialog.ts";
 import { nowDate } from "../../../../lib/time.ts";
@@ -578,15 +579,10 @@ function UsageRecordSummary({
   );
 }
 
-function UsageRecordList({
-  data,
-  scope,
-}: {
-  data: UsageRecordResponse;
-  scope: UsageRecordScope;
-}) {
+function UsageRecordList({ data }: { data: UsageRecordResponse }) {
   const { t } = useTranslation();
   const loadMore = useSet(loadMoreUsageRecord$);
+  const pageSignal = useGet(pageSignal$);
   const maxCredits = Math.max(
     1,
     ...data.rows.map((row) => {
@@ -620,7 +616,11 @@ function UsageRecordList({
             size="sm"
             className="h-9 rounded-lg text-muted-foreground hover:bg-state-hover hover:text-foreground"
             onClick={() => {
-              loadMore(scope);
+              detach(
+                loadMore(pageSignal),
+                Reason.DomCallback,
+                "personal usage record paging",
+              );
             }}
           >
             {t(($) => {
@@ -636,11 +636,9 @@ function UsageRecordList({
 function UsageRecordContent({
   loadable,
   range,
-  scope,
 }: {
   loadable: UsageRecordLoadable;
   range: UsageRecordRange;
-  scope: UsageRecordScope;
 }) {
   const { t } = useTranslation();
   return (
@@ -662,7 +660,7 @@ function UsageRecordContent({
             })}
           />
         ) : (
-          <UsageRecordList data={loadable.data} scope={scope} />
+          <UsageRecordList data={loadable.data} />
         ))}
     </section>
   );
@@ -724,7 +722,7 @@ function TeamMemberUsageContent({
 
 export function PersonalUsageRecord({ range }: { range: UsageRecordRange }) {
   const loadable = useLastLoadable(myUsageRecordAsync$);
-  return <UsageRecordContent loadable={loadable} range={range} scope="mine" />;
+  return <UsageRecordContent loadable={loadable} range={range} />;
 }
 
 export function TeamUsageRecord({ range }: { range: UsageRecordRange }) {


### PR DESCRIPTION
## Summary

- replace the personal usage list's growing `pageSize` with fixed 20-row page requests
- accumulate successful pages while guarding duplicate and stale requests across range and realtime resets
- release failed or cancelled page requests so the same page remains retryable
- cover loading 101 rows through page 6, failed-page retry, range reset, and realtime refresh at the rendered settings-page boundary

## Scope

- no API contract, service, database, migration, or persisted-state changes
- cursor pagination and the existing API page-size limit remain unchanged
- the unrelated non-UTC workflow test defect discovered during full-suite validation is tracked separately in #28555

## Validation

- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/personal-usage-tab.test.tsx --maxWorkers=4 --silent=passed-only` (14 passed)
- `pnpm exec prettier --write apps/platform/src/signals/zero-page/settings/personal-usage-record.ts apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- pre-commit hooks, including repository Knip and all Turbo type-check tasks

Closes #28546
