### PR TITLE
test(platform): stabilize webhook upgrade timezone

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -3542,6 +3542,7 @@ describe("workflow detail page", () => {
       name: "Test Org",
       role: "admin",
     });
+    context.mocks.data.userPreferences({ timezone: "UTC" });
     const workflow = {
       ...salesResearch(),
       automations: [


### PR DESCRIPTION
## Summary

- pin the webhook Team-upgrade integration story to an explicit UTC user preference
- preserve the exact schedule switch accessible-name query and loading-state isolation assertions
- make the story deterministic when Vitest runs in UTC or Asia/Shanghai

## Scope

- test setup only
- no production timezone fallback, global test timezone, API, data, migration, or deployment changes

## Validation

- `TZ=UTC pnpm -F @okouai/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx -t 'opens the Team upgrade dialog when webhook enable returns TEAM_REQUIRED'` (1 passed)
- `TZ=Asia/Shanghai pnpm -F @okouai/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx -t 'opens the Team upgrade dialog when webhook enable returns TEAM_REQUIRED'` (1 passed)
- `TZ=Asia/Shanghai pnpm -F @okouai/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx --silent=passed-only` (63 passed)
- `pnpm exec prettier --check apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- pre-commit hooks, including repository Knip and all Turbo type-check tasks

Closes #28555
