### PR TITLE
fix(composer): reconcile live dom before submission

### DIFF
--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -67,6 +67,12 @@ export const imageModelSelectionEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.ImageModelSelection] ?? false;
 });
 
+export const composerSubmitDomReconcileEnabled$ = computed((get): boolean => {
+  return (
+    get(featureSwitch$)[FeatureSwitchKey.ComposerSubmitDomReconcile] ?? false
+  );
+});
+
 export const codexFastModeEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.CodexFastMode] ?? false;
 });

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -16,7 +16,12 @@ import {
   type EditorState,
   type Transaction,
 } from "@tiptap/pm/state";
-import { Decoration, DecorationSet, type NodeView } from "@tiptap/pm/view";
+import {
+  Decoration,
+  DecorationSet,
+  type EditorView,
+  type NodeView,
+} from "@tiptap/pm/view";
 import { StarterKit } from "@tiptap/starter-kit";
 import { createCompositionGate, type CompositionGate } from "@okouai/ui";
 import {
@@ -27,6 +32,9 @@ import {
 import type { WorkflowSummary } from "@okouai/api-contracts/contracts/workflows";
 import { agents$ } from "../agent.ts";
 import { currentChatAgentRecordId$ } from "../agent-chat.ts";
+import { composerSubmitDomReconcileEnabled$ } from "../external/feature-switch.ts";
+import { logger } from "../log.ts";
+import { sentryLogContext } from "../../lib/sentry-config.ts";
 import { onRef, resetSignal } from "../utils.ts";
 import type { DraftInputSyncTarget, DraftSignals } from "./chat-draft.ts";
 import {
@@ -263,6 +271,110 @@ function connectComposerFeedback(
   });
 }
 
+const L = logger("WorkflowComposer");
+
+const COMPOSER_RESYNC_ATTRIBUTE = "data-composer-resync";
+
+interface EditorViewWithDomObserver extends EditorView {
+  readonly domObserver: {
+    readonly flush: () => void;
+    readonly forceFlush: () => void;
+  };
+}
+
+/**
+ * An attribute record maps to its block's full range in the observer's
+ * registerMutation, so touching one attribute makes prosemirror-view re-read
+ * that whole block from the live DOM. The feedback item's node view ignores
+ * mutations outside its contentDOM, so its marker must land on the note
+ * element; the template chip carries no editable text.
+ */
+function blockResyncTargets(editor: Editor): HTMLElement[] {
+  const targets: HTMLElement[] = [];
+  const { doc } = editor.state;
+  let position = 0;
+  for (let index = 0; index < doc.childCount; index++) {
+    const node = doc.child(index);
+    const element = editor.view.nodeDOM(position);
+    position += node.nodeSize;
+    if (node.type.name === TEMPLATE_ATTACHMENT_NODE_NAME) {
+      continue;
+    }
+    if (!(element instanceof HTMLElement)) {
+      throw new Error("Composer block DOM not found");
+    }
+    if (node.type.name === FEEDBACK_ITEM_NODE_NAME) {
+      const note = element.querySelector("[data-feedback-note]");
+      if (!(note instanceof HTMLElement)) {
+        throw new Error("Composer feedback note DOM not found");
+      }
+      targets.push(note);
+      continue;
+    }
+    targets.push(element);
+  }
+  return targets;
+}
+
+/**
+ * A broken mobile composition can leave text visible in the contenteditable
+ * that never reached `editor.state.doc`. Once the browser's mutation records
+ * for it are consumed, nothing re-reads that DOM — the divergence is permanent
+ * and a submission serializes less than the user sees. Queue one synthetic
+ * whole-block mutation per block and flush the observer, so prosemirror-view
+ * re-reads every block through its normal parse path. Node views survive the
+ * re-read via their view desc parse rules; blocks whose DOM already matches
+ * the document parse to no change and dispatch nothing.
+ *
+ * This must only run outside an IME composition. The submission read sits
+ * behind the composition gate, and prosemirror-view clears `composing` in its
+ * own compositionend handler before the gate's settling frame.
+ *
+ * Every `EditorView` constructs `domObserver`, but prosemirror-view marks it
+ * internal and omits it from the published types, so it is reached through a
+ * cast. A future rename must fail loudly here rather than silently restore
+ * truncated submissions.
+ */
+function reconcileDomIntoDocument(editor: Editor): void {
+  const { domObserver } = editor.view as EditorViewWithDomObserver;
+  // flush() returns early while a deferred flush is scheduled — the state a
+  // just-ended composition leaves behind — so clear that timer first.
+  domObserver.forceFlush();
+  for (const element of blockResyncTargets(editor)) {
+    element.setAttribute(COMPOSER_RESYNC_ATTRIBUTE, "");
+    element.removeAttribute(COMPOSER_RESYNC_ATTRIBUTE);
+  }
+  domObserver.flush();
+}
+
+// Report every submission changed by the reconcile, with sizes only and never
+// content, so the switch can be evaluated against real mobile sends.
+function reconcileSubmissionDocument(
+  editor: Editor,
+  includeQuoteOnlyFeedback: boolean,
+): void {
+  const before = workflowComposerDocToString(editor, includeQuoteOnlyFeedback);
+  reconcileDomIntoDocument(editor);
+  const after = workflowComposerDocToString(editor, includeQuoteOnlyFeedback);
+  if (after === before) {
+    return;
+  }
+  L.error(
+    "composer submission document differed from the live DOM",
+    sentryLogContext({
+      tags: {
+        hasFeedbackItem: feedbackItemsFromWorkflowComposer(editor).length > 0,
+      },
+      contexts: {
+        composerSubmitDomReconcile: {
+          promptLengthBefore: before.length,
+          promptLengthAfter: after.length,
+        },
+      },
+    }),
+  );
+}
+
 function createReadInputForSubmissionCommand(
   editor: Editor,
   compositionGate: CompositionGate,
@@ -270,7 +382,11 @@ function createReadInputForSubmissionCommand(
 ) {
   return command(({ get }, signal: AbortSignal) => {
     const includeQuoteOnlyFeedback = get(quoteOnlyFeedbackEnabled$);
+    const reconcileEnabled = get(composerSubmitDomReconcileEnabled$);
     return compositionGate.runWhenSettled(() => {
+      if (reconcileEnabled) {
+        reconcileSubmissionDocument(editor, includeQuoteOnlyFeedback);
+      }
       return {
         prompt: workflowComposerDocToString(editor, includeQuoteOnlyFeedback),
         editorDocument: createEditorDocumentSnapshot(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { Editor } from "@tiptap/core";
+import type { EditorView } from "@tiptap/pm/view";
 import {
   chatThreadByIdContract,
   type UserMessageDocument,
@@ -286,6 +288,134 @@ async function findFeedbackNote(): Promise<HTMLElement> {
     throw new Error("Feedback note not found");
   }
   return note;
+}
+
+interface ComposerDomObserver {
+  readonly stop: () => void;
+  readonly start: () => void;
+}
+
+// Tiptap stores the editor on its contenteditable root, and prosemirror-view
+// keeps domObserver internal — reached the same way the submit-time dom
+// reconcile reaches it.
+function composerDomObserver(editorElement: HTMLElement): ComposerDomObserver {
+  const editor: unknown =
+    "editor" in editorElement ? editorElement.editor : null;
+  if (!(editor instanceof Editor)) {
+    throw new Error("Composer tiptap editor not found");
+  }
+  const view = editor.view as EditorView & {
+    readonly domObserver: ComposerDomObserver;
+  };
+  return view.domObserver;
+}
+
+// Extends the paragraph's existing text node in place, the shape a broken
+// mobile composition leaves behind: text visible in the DOM, absent from the
+// ProseMirror document, with no mutation record left to ever deliver it.
+function strandTextInParagraph(paragraph: Element, value: string): void {
+  const textNode = Array.from(paragraph.childNodes)
+    .reverse()
+    .find((child): child is Text => {
+      return child instanceof Text;
+    });
+  if (!textNode) {
+    throw new Error("Paragraph text node not found");
+  }
+  textNode.nodeValue = `${textNode.nodeValue ?? ""}${value}`;
+}
+
+function topLevelParagraph(editorElement: HTMLElement): Element {
+  const paragraph = editorElement.querySelector(":scope > p");
+  if (!paragraph) {
+    throw new Error("Top-level composer paragraph not found");
+  }
+  return paragraph;
+}
+
+function noteParagraph(note: HTMLElement): Element {
+  const paragraph = note.querySelector("p");
+  if (!paragraph) {
+    throw new Error("Feedback note paragraph not found");
+  }
+  return paragraph;
+}
+
+async function submitWithStrandedComposerText(
+  reconcileEnabled: boolean,
+  caseName: string,
+): Promise<{
+  readonly assistantReply: string;
+  readonly sentMessage: RunCreateCapture;
+}> {
+  const user = userEvent.setup({ delay: null });
+  const assistantReply = "The rollout dates are unclear in this summary.";
+  const sentMessages: RunCreateCapture[] = [];
+
+  mockChatLifecycle(context, {
+    threadId: FEEDBACK_THREAD_ID,
+    threadTitle: "Feedback review",
+    chatEvents: [
+      {
+        id: `msg-feedback-reconcile-${caseName}-user`,
+        role: "user",
+        content: "Review this launch summary",
+        runId: `run-feedback-reconcile-${caseName}`,
+        createdAt: "2026-06-09T10:00:00Z",
+      },
+      {
+        id: `msg-feedback-reconcile-${caseName}-assistant`,
+        role: "assistant",
+        content: assistantReply,
+        runId: `run-feedback-reconcile-${caseName}`,
+        createdAt: "2026-06-09T10:01:00Z",
+      },
+    ],
+    onRunCreate: (body) => {
+      sentMessages.push(body);
+    },
+  });
+
+  detachedSetupPage({
+    context,
+    path: `/chats/${FEEDBACK_THREAD_ID}`,
+    featureSwitches: {
+      [FeatureSwitchKey.ComposerSubmitDomReconcile]: reconcileEnabled,
+    },
+  });
+
+  const composerEditor = await findComposerEditor();
+  await user.click(composerEditor);
+  pastePlainText(composerEditor, "Mention the dates");
+  await waitForDeferredSelectionCapture();
+  selectTextForInlineFeedback(await screen.findByText(assistantReply));
+  await user.click(await screen.findByText("Quote"));
+
+  const feedbackComment = await findFeedbackNote();
+  await user.click(feedbackComment);
+  pastePlainText(feedbackComment, "Make the dates");
+  await waitFor(() => {
+    expect(feedbackComment).toHaveTextContent("Make the dates");
+  });
+
+  const domObserver = composerDomObserver(composerEditor);
+  domObserver.stop();
+  strandTextInParagraph(
+    topLevelParagraph(composerEditor),
+    " before the risk summary.",
+  );
+  strandTextInParagraph(noteParagraph(feedbackComment), " explicit.");
+  domObserver.start();
+
+  await user.click(screen.getByLabelText("Send"));
+  await waitFor(() => {
+    expect(sentMessages).toHaveLength(1);
+  });
+  const [sentMessage] = sentMessages;
+  if (!sentMessage) {
+    throw new Error("Submission was not captured");
+  }
+  return { assistantReply, sentMessage };
 }
 
 async function replaceFeedbackNote(
@@ -1503,6 +1633,63 @@ describe("chat inline feedback", () => {
       expect(sentPrompts).toHaveLength(1);
     });
     expect(sentPrompts[0]).toContain("补充具体日期");
+  });
+
+  it("recovers text stranded in the dom before reading a submission", async () => {
+    // The recovery reports itself through the error logger; the shared setup
+    // turns unexpected console.error calls into test failures, so capture it
+    // here and assert the report below.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const { assistantReply, sentMessage } =
+      await submitWithStrandedComposerText(true, "enabled");
+    const sentPrompt = sentMessage.prompt;
+    expect(sentPrompt).toContain("Mention the dates before the risk summary.");
+    expect(sentPrompt).toContain("Make the dates explicit.");
+    expect(sentMessage.userMessage).toStrictEqual({
+      version: 1,
+      parts: [
+        {
+          type: "text",
+          text: "Mention the dates before the risk summary.",
+        },
+        {
+          type: "feedback",
+          quote: assistantReply,
+          eventId: "msg-feedback-reconcile-enabled-assistant",
+          range: { start: 0, end: assistantReply.length },
+          note: [{ type: "text", text: "Make the dates explicit." }],
+        },
+      ],
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[E][WorkflowComposer]",
+      "composer submission document differed from the live DOM",
+      expect.anything(),
+    );
+  });
+
+  it("leaves stranded dom text out when the reconcile switch is disabled", async () => {
+    const { assistantReply, sentMessage } =
+      await submitWithStrandedComposerText(false, "disabled");
+    expect(sentMessage.userMessage).toStrictEqual({
+      version: 1,
+      parts: [
+        {
+          type: "text",
+          text: "Mention the dates",
+        },
+        {
+          type: "feedback",
+          quote: assistantReply,
+          eventId: "msg-feedback-reconcile-disabled-assistant",
+          range: { start: 0, end: assistantReply.length },
+          note: [{ type: "text", text: "Make the dates" }],
+        },
+      ],
+    });
   });
 
   it("waits until mouseup before showing the inline feedback toolbar", async () => {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -101,6 +101,9 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.SharedChatDatabase]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.ComposerSubmitDomReconcile]).toBe(
+      true,
+    );
     expect(staffOrgStates[FeatureSwitchKey.ChatForward]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatMarkUnread]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatQuoteOnlyFeedback]).toBe(true);
@@ -137,6 +140,9 @@ describe("getAllFeatureStates", () => {
     });
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ComposerSubmitDomReconcile]).toBe(
+      false,
+    );
     expect(otherOrgStates[FeatureSwitchKey.ChatForward]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatMarkUnread]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatQuoteOnlyFeedback]).toBe(false);

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -102,7 +102,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.SharedChatDatabase]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ComposerSubmitDomReconcile]).toBe(
-      true,
+      false,
     );
     expect(staffOrgStates[FeatureSwitchKey.ChatForward]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatMarkUnread]).toBe(true);
@@ -172,6 +172,23 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.UsagePackPlans]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.SavedBillingCreditPurchase]).toBe(
       true,
+    );
+  });
+
+  it("should enable composer submit DOM reconciliation only for Bingjie", () => {
+    const bingjieStates = getAllFeatureStates({
+      email: "bingjie@vm0.ai",
+    });
+    expect(bingjieStates[FeatureSwitchKey.ComposerSubmitDomReconcile]).toBe(
+      true,
+    );
+
+    const otherStaffStates = getAllFeatureStates({
+      email: "ethan@vm0.ai",
+      orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+    });
+    expect(otherStaffStates[FeatureSwitchKey.ComposerSubmitDomReconcile]).toBe(
+      false,
     );
   });
 

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -86,4 +86,5 @@ export enum FeatureSwitchKey {
   LatestWebsiteTemplates = "latestWebsiteTemplates",
   ChatConversationLocator = "chatConversationLocator",
   SharedChatDatabase = "sharedChatDatabase",
+  ComposerSubmitDomReconcile = "composerSubmitDomReconcile",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -383,7 +383,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Re-read every composer block from the live contenteditable before serializing a submission, recovering text a broken mobile composition left only in the DOM, and report each recovery.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
   },
   [FeatureSwitchKey.ChatForward]: {
     maintainer: "ethan@vm0.ai",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -378,6 +378,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Share canonical ChatEvent and ChatThreadEvent synchronization across same-revision browser tabs.",
     enabled: false,
   },
+  [FeatureSwitchKey.ComposerSubmitDomReconcile]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Re-read every composer block from the live contenteditable before serializing a submission, recovering text a broken mobile composition left only in the DOM, and report each recovery.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ChatForward]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add the Bingjie-only `composerSubmitDomReconcile` feature switch
- before serializing a settled composer submission, create fresh whole-block DOM mutations and synchronously flush ProseMirror so text stranded only in the live contenteditable is parsed back into `editor.state.doc`
- target the feedback note `contentDOM` directly so the custom node view does not ignore the reconciliation marker
- report only before/after prompt lengths and feedback presence when reconciliation changes a submission; no composer text is included in telemetry
- cover both the enabled recovery path and the disabled-switch behavior through the rendered chat page

This does not depend on an old mutation record still being pending. It creates a new record at submission time, which makes the recovery work after the original record has already been consumed or lost.

Related to #27787.

## Rollout

- default: disabled
- `bingjie@vm0.ai`: enabled

## Verification

- `pnpm exec prettier --check <changed files>`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/chat-inline-feedback.test.tsx` (32 passed)
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (25 passed)
- negative control: with the fresh reconciliation mutations temporarily removed, the new page test failed and submitted only the document prefix while the full text remained visible in the DOM
