### PR TITLE
refactor(runner): centralize procfs process generation

### DIFF
--- a/crates/runner/src/cmd/kill/orphan.rs
+++ b/crates/runner/src/cmd/kill/orphan.rs
@@ -192,7 +192,7 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
             return OrphanTargetValidation::Changed;
         }
     };
-    if !process_stat_matches_identity(identity, &stat) {
+    if identity.procfs_generation() != stat.procfs_generation() {
         tracing::warn!(
             pid = target.pid,
             expected_pgid = identity.pgid,
@@ -264,7 +264,7 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
             return OrphanTargetValidation::Changed;
         }
     };
-    if !process_stat_matches_identity(identity, &final_stat) {
+    if identity.procfs_generation() != final_stat.procfs_generation() {
         tracing::warn!(
             pid = target.pid,
             expected_pgid = identity.pgid,
@@ -295,12 +295,14 @@ async fn classify_orphan_validation_after_unreadable_pid_fact(
 ) -> OrphanTargetValidation {
     match process::read_process_stat_checked(pid).await {
         ProcessStatRead::Found(stat)
-            if process_stat_matches_identity(identity, &stat)
+            if identity.procfs_generation() == stat.procfs_generation()
                 && !process::process_stat_is_live(&stat) =>
         {
             OrphanTargetValidation::AlreadyGone
         }
-        ProcessStatRead::Found(stat) if process_stat_matches_identity(identity, &stat) => {
+        ProcessStatRead::Found(stat)
+            if identity.procfs_generation() == stat.procfs_generation() =>
+        {
             OrphanTargetValidation::Changed
         }
         ProcessStatRead::Found(_) => OrphanTargetValidation::Changed,
@@ -376,7 +378,9 @@ fn classify_orphan_exit_observation(
     read: ProcessStatRead,
 ) -> OrphanExitObservation {
     match read {
-        ProcessStatRead::Found(stat) if !process_stat_matches_identity(identity, &stat) => {
+        ProcessStatRead::Found(stat)
+            if identity.procfs_generation() != stat.procfs_generation() =>
+        {
             OrphanExitObservation::IdentityChanged {
                 expected_pgid: identity.pgid,
                 observed_pgid: stat.pgid,
@@ -451,20 +455,13 @@ where
     }
 }
 
-fn process_stat_matches_identity(
-    identity: &FirecrackerProcessIdentity,
-    stat: &ProcessStat,
-) -> bool {
-    stat.pgid == identity.pgid && stat.starttime == identity.starttime
-}
-
 fn orphan_identity_matches_facts(
     identity: &FirecrackerProcessIdentity,
     stat: &ProcessStat,
     is_firecracker_cmdline: bool,
     cwd_info: Option<&(String, PathBuf)>,
 ) -> bool {
-    process_stat_matches_identity(identity, stat)
+    identity.procfs_generation() == stat.procfs_generation()
         && is_firecracker_cmdline
         && workspace_identity_matches(identity, cwd_info)
 }
@@ -725,7 +722,7 @@ mod tests {
     }
 
     #[test]
-    fn process_stat_identity_match_requires_stable_pgid_and_starttime() {
+    fn firecracker_identity_projects_to_procfs_generation() {
         let target = make_target(200, "sbox-123");
         let identity = target.identity.as_ref().unwrap();
         let matching = process_stat(identity);
@@ -748,10 +745,19 @@ mod tests {
             starttime: identity.starttime,
         };
 
-        assert!(process_stat_matches_identity(identity, &matching));
-        assert!(process_stat_matches_identity(identity, &changed_ppid));
-        assert!(!process_stat_matches_identity(identity, &changed_starttime));
-        assert!(!process_stat_matches_identity(identity, &changed_pgid));
+        assert_eq!(identity.procfs_generation(), matching.procfs_generation());
+        assert_eq!(
+            identity.procfs_generation(),
+            changed_ppid.procfs_generation()
+        );
+        assert_ne!(
+            identity.procfs_generation(),
+            changed_starttime.procfs_generation()
+        );
+        assert_ne!(
+            identity.procfs_generation(),
+            changed_pgid.procfs_generation()
+        );
     }
 
     #[test]
@@ -806,7 +812,7 @@ mod tests {
             starttime: identity.starttime,
         };
 
-        assert!(process_stat_matches_identity(identity, &zombie));
+        assert_eq!(identity.procfs_generation(), zombie.procfs_generation());
         assert!(!process::process_stat_is_live(&zombie));
     }
 
@@ -821,7 +827,7 @@ mod tests {
             starttime: identity.starttime,
         };
 
-        assert!(process_stat_matches_identity(identity, &dead));
+        assert_eq!(identity.procfs_generation(), dead.procfs_generation());
         assert!(!process::process_stat_is_live(&dead));
     }
 

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -147,10 +147,6 @@ async fn read_stable_firecracker_stat(pid: u32) -> Option<ProcessStat> {
     stable_live_firecracker_stat(&before, &argv, after)
 }
 
-fn process_stat_identity_matches(left: &ProcessStat, right: &ProcessStat) -> bool {
-    left.pgid == right.pgid && left.starttime == right.starttime
-}
-
 fn stable_live_firecracker_stat(
     before: &ProcessStat,
     argv: &[String],
@@ -158,7 +154,7 @@ fn stable_live_firecracker_stat(
 ) -> Option<ProcessStat> {
     if process_stat_is_live(before)
         && process_stat_is_live(&after)
-        && process_stat_identity_matches(before, &after)
+        && before.procfs_generation() == after.procfs_generation()
         && is_firecracker_cmdline(argv)
     {
         Some(after)
@@ -214,7 +210,7 @@ fn stable_firecracker_resolution(
     if !process_stat_is_live(&initial_stat) || !process_stat_is_live(&process_stat) {
         return FirecrackerCandidateResolution::NotPresent;
     }
-    if !process_stat_identity_matches(&initial_stat, &process_stat) {
+    if initial_stat.procfs_generation() != process_stat.procfs_generation() {
         let ppid = Some(process_stat.ppid);
         return FirecrackerCandidateResolution::UnidentifiedLive { pid, ppid };
     }
@@ -508,17 +504,26 @@ mod tests {
     }
 
     #[test]
-    fn process_stat_identity_ignores_state_changes() {
+    fn procfs_generation_uses_pgid_and_starttime() {
         let sleeping = stat('S', 1100, 123456);
         let running = stat('R', 1100, 123456);
         let different_group = stat('S', 2200, 123456);
         let different_start = stat('S', 1100, 654321);
         let different_parent = stat_with_ppid('S', 9, 1100, 123456);
 
-        assert!(process_stat_identity_matches(&sleeping, &running));
-        assert!(process_stat_identity_matches(&sleeping, &different_parent));
-        assert!(!process_stat_identity_matches(&sleeping, &different_group));
-        assert!(!process_stat_identity_matches(&sleeping, &different_start));
+        assert_eq!(sleeping.procfs_generation(), running.procfs_generation());
+        assert_eq!(
+            sleeping.procfs_generation(),
+            different_parent.procfs_generation()
+        );
+        assert_ne!(
+            sleeping.procfs_generation(),
+            different_group.procfs_generation()
+        );
+        assert_ne!(
+            sleeping.procfs_generation(),
+            different_start.procfs_generation()
+        );
     }
 
     #[test]

--- a/crates/runner/src/process/types.rs
+++ b/crates/runner/src/process/types.rs
@@ -12,6 +12,22 @@ pub struct ProcessStat {
     pub starttime: u64,
 }
 
+/// Stable generation of a process observed through procfs.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct ProcfsProcessGeneration {
+    pgid: u32,
+    starttime: u64,
+}
+
+impl ProcessStat {
+    pub(crate) fn procfs_generation(&self) -> ProcfsProcessGeneration {
+        ProcfsProcessGeneration {
+            pgid: self.pgid,
+            starttime: self.starttime,
+        }
+    }
+}
+
 /// Return true when the process stat state still represents a live process.
 ///
 /// `/proc/<pid>/stat` can briefly expose terminal states before the proc entry
@@ -29,6 +45,15 @@ pub struct FirecrackerProcessIdentity {
     pub starttime: u64,
     pub sandbox_id: String,
     pub base_dir: Option<PathBuf>,
+}
+
+impl FirecrackerProcessIdentity {
+    pub(crate) fn procfs_generation(&self) -> ProcfsProcessGeneration {
+        ProcfsProcessGeneration {
+            pgid: self.pgid,
+            starttime: self.starttime,
+        }
+    }
 }
 
 /// Info extracted from a firecracker process cmdline.

--- a/crates/runner/src/proxy/runtime.rs
+++ b/crates/runner/src/proxy/runtime.rs
@@ -317,7 +317,9 @@ fn scan_marked_processes(root: &Path, exact_path: Option<&Path>) -> RunnerResult
                 )));
             }
         };
-        if !same_process(&before, &after) || !seen.insert((pid, after.starttime)) {
+        if before.procfs_generation() != after.procfs_generation()
+            || !seen.insert((pid, after.starttime))
+        {
             continue;
         }
         let command = read_process_comm(pid);
@@ -379,10 +381,6 @@ fn runtime_marker(environ: &[u8]) -> Option<&[u8]> {
     environ
         .split(|byte| *byte == 0)
         .find_map(|entry| entry.strip_prefix(RUNTIME_MARKER_PREFIX))
-}
-
-fn same_process(before: &ProcessStat, after: &ProcessStat) -> bool {
-    before.pgid == after.pgid && before.starttime == after.starttime
 }
 
 fn is_launch_path(root: &Path, path: &Path) -> bool {


### PR DESCRIPTION
## Summary

- add a crate-private `ProcfsProcessGeneration` projection for `ProcessStat` and `FirecrackerProcessIdentity`
- use the canonical PGID/start-time value in Firecracker discovery, mitmdump marker scanning, and orphan validation/exit observation
- retain caller-owned liveness, diagnostics, workspace/cmdline checks, signal targeting, and proxy's later `(pid, starttime)` ownership rule

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner process::discovery`
- `cargo test -p runner cmd::kill::orphan`
- `cargo test -p runner`
- pre-commit Rust formatting, workspace Clippy, workspace documentation, and file-size checks

Closes #28566
