### PR TITLE
fix(billing): harden usage pack reconciliation

### DIFF
--- a/turbo/apps/api/src/signals/external/stripe-client.ts
+++ b/turbo/apps/api/src/signals/external/stripe-client.ts
@@ -236,6 +236,7 @@ export interface StripePaymentIntent {
 export interface StripeRefund {
   readonly id: string;
   readonly status: string | null;
+  readonly failure_reason?: string | null;
 }
 
 export interface StripeCreditNote {
@@ -261,6 +262,10 @@ export interface StripeCreditNoteParams {
   readonly amount?: number;
   readonly lines?: StripeCreditNoteLineParam[];
   readonly refund_amount?: number;
+  readonly refunds?: {
+    readonly refund: string;
+    readonly amount_refunded?: number;
+  }[];
   readonly email_type?: "credit_note" | "none";
   readonly metadata?: StripeMetadataParam;
   readonly reason?:
@@ -426,6 +431,13 @@ export type StripeSubscriptionListStatus =
   | "trialing"
   | "unpaid";
 
+export interface StripeSubscriptionListParams {
+  readonly customer?: string;
+  readonly status?: StripeSubscriptionListStatus;
+  readonly price?: string;
+  readonly expand?: string[];
+}
+
 export interface StripeSubscriptionsApi {
   create(
     params: StripeSubscriptionCreateParams,
@@ -440,14 +452,12 @@ export interface StripeSubscriptionsApi {
     params: StripeSubscriptionUpdateParams,
     options?: StripeRequestOptions,
   ): Promise<StripeSubscription>;
-  list(params: {
-    customer?: string;
-    status?: StripeSubscriptionListStatus;
-    price?: string;
-    limit?: number;
-    starting_after?: string;
-    expand?: string[];
-  }): Promise<StripeList<StripeSubscription>>;
+  list(
+    params: StripeSubscriptionListParams & {
+      readonly limit?: number;
+      readonly starting_after?: string;
+    },
+  ): Promise<StripeList<StripeSubscription>>;
   cancel(
     id: string,
     params?: { invoice_now?: boolean; prorate?: boolean },
@@ -821,6 +831,34 @@ function stripeSdk(): StripeSDK {
  */
 export function getStripeClient(): StripeClient {
   return stripeSdk();
+}
+
+export async function listAllStripeSubscriptions(
+  stripe: StripeClient,
+  params: StripeSubscriptionListParams,
+  signal?: AbortSignal,
+): Promise<readonly StripeSubscription[]> {
+  const subscriptions: StripeSubscription[] = [];
+  let startingAfter: string | undefined;
+  while (true) {
+    const page = await stripe.subscriptions.list({
+      ...params,
+      limit: 100,
+      ...(startingAfter ? { starting_after: startingAfter } : {}),
+    });
+    signal?.throwIfAborted();
+    subscriptions.push(...page.data);
+    if (!page.has_more) {
+      return subscriptions;
+    }
+    const last = page.data.at(-1);
+    if (!last) {
+      throw new Error(
+        "Stripe returned an empty subscription page with has_more",
+      );
+    }
+    startingAfter = last.id;
+  }
 }
 
 export function mockStripeClient(fakeSdk: unknown): void {

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -11730,6 +11730,31 @@ describe("usage pack allocation management", () => {
       post_payment_amount: 2500,
       refunds: [],
     });
+    const invoicePaymentIntentId = "pi_usage_pack_removal";
+    context.mocks.stripe.invoices.retrieve.mockResolvedValue({
+      id: "in_usage_pack_removal",
+      payments: {
+        data: [
+          {
+            status: "paid",
+            amount_paid: 5000,
+            payment: {
+              type: "payment_intent",
+              payment_intent: invoicePaymentIntentId,
+            },
+          },
+        ],
+      },
+    });
+    context.mocks.stripe.refunds.create
+      .mockResolvedValueOnce({
+        id: "re_usage_pack_removal_failed",
+        status: "failed",
+      })
+      .mockResolvedValueOnce({
+        id: "re_usage_pack_removal",
+        status: "succeeded",
+      });
     context.mocks.stripe.creditNotes.create.mockResolvedValue({
       id: "cn_usage_pack_removal",
       status: "issued",
@@ -11741,10 +11766,6 @@ describe("usage pack allocation management", () => {
           refund: "re_usage_pack_removal",
         },
       ],
-    });
-    context.mocks.stripe.refunds.retrieve.mockResolvedValue({
-      id: "re_usage_pack_removal",
-      status: "succeeded",
     });
 
     const responsePromise = setupApp({ context, routes: orgMembersRoutes })(
@@ -11774,6 +11795,22 @@ describe("usage pack allocation management", () => {
 
     const response = await accept(responsePromise, [200]);
     expect(response.body.message).toBe(`Removed ${targetEmail} from org`);
+    const retryPending = await readUsagePackState(
+      fixture.orgId,
+      fixture.usagePackSubscriptionId,
+    );
+    expect(retryPending.refunds).toContainEqual(
+      expect.objectContaining({
+        userId: targetUserId,
+        status: "pending",
+        stripeCreditNoteId: null,
+        stripeRefundId: null,
+      }),
+    );
+    expect(context.mocks.stripe.creditNotes.create).not.toHaveBeenCalled();
+
+    await runBillingReconciliation(fixture.orgId);
+
     const duplicateEvent = {
       type: "organizationMembership.deleted",
       data: {
@@ -11842,6 +11879,31 @@ describe("usage pack allocation management", () => {
       context.mocks.stripe.subscriptionSchedules.create,
     ).not.toHaveBeenCalled();
     expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledTimes(1);
+    expect(context.mocks.stripe.refunds.create).toHaveBeenCalledTimes(2);
+    expect(context.mocks.stripe.refunds.create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        payment_intent: invoicePaymentIntentId,
+        amount: 2500,
+      }),
+      expect.objectContaining({
+        idempotencyKey: expect.stringMatching(
+          /^usage-pack-credit-refund:[0-9a-f-]+:1:refund$/u,
+        ),
+      }),
+    );
+    expect(context.mocks.stripe.refunds.create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        payment_intent: invoicePaymentIntentId,
+        amount: 2500,
+      }),
+      expect.objectContaining({
+        idempotencyKey: expect.stringMatching(
+          /^usage-pack-credit-refund:[0-9a-f-]+:2:refund$/u,
+        ),
+      }),
+    );
     expect(context.mocks.stripe.creditNotes.create).toHaveBeenCalledTimes(1);
     expect(context.mocks.stripe.creditNotes.create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -11853,11 +11915,16 @@ describe("usage pack allocation management", () => {
             amount: 2500,
           }),
         ],
-        refund_amount: 2500,
+        refunds: [
+          {
+            refund: "re_usage_pack_removal",
+            amount_refunded: 2500,
+          },
+        ],
       }),
       expect.objectContaining({
         idempotencyKey: expect.stringMatching(
-          /^usage-pack-credit-refund:[0-9a-f-]+:1$/u,
+          /^usage-pack-credit-refund:[0-9a-f-]+:2:credit-note$/u,
         ),
       }),
     );
@@ -11959,6 +12026,26 @@ describe("usage pack allocation management", () => {
       post_payment_amount: 2000,
       refunds: [],
     });
+    const invoicePaymentIntentId = "pi_last_usage_pack_removal";
+    context.mocks.stripe.invoices.retrieve.mockResolvedValue({
+      id: "in_last_usage_pack_removal",
+      payments: {
+        data: [
+          {
+            status: "paid",
+            amount_paid: 2000,
+            payment: {
+              type: "payment_intent",
+              payment_intent: invoicePaymentIntentId,
+            },
+          },
+        ],
+      },
+    });
+    context.mocks.stripe.refunds.create.mockResolvedValue({
+      id: "re_last_usage_pack_removal",
+      status: "succeeded",
+    });
     context.mocks.stripe.creditNotes.create.mockResolvedValue({
       id: "cn_last_usage_pack_removal",
       status: "issued",
@@ -11970,10 +12057,6 @@ describe("usage pack allocation management", () => {
           refund: "re_last_usage_pack_removal",
         },
       ],
-    });
-    context.mocks.stripe.refunds.retrieve.mockResolvedValue({
-      id: "re_last_usage_pack_removal",
-      status: "succeeded",
     });
 
     await accept(
@@ -12017,11 +12100,27 @@ describe("usage pack allocation management", () => {
       expect.objectContaining({
         invoice: expect.stringMatching(/^in_/u),
         amount: 2000,
-        refund_amount: 2000,
+        refunds: [
+          {
+            refund: "re_last_usage_pack_removal",
+            amount_refunded: 2000,
+          },
+        ],
       }),
       expect.objectContaining({
         idempotencyKey: expect.stringMatching(
-          /^usage-pack-credit-refund:[0-9a-f-]+:1$/u,
+          /^usage-pack-credit-refund:[0-9a-f-]+:1:credit-note$/u,
+        ),
+      }),
+    );
+    expect(context.mocks.stripe.refunds.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payment_intent: invoicePaymentIntentId,
+        amount: 2000,
+      }),
+      expect.objectContaining({
+        idempotencyKey: expect.stringMatching(
+          /^usage-pack-credit-refund:[0-9a-f-]+:1:refund$/u,
         ),
       }),
     );
@@ -12117,6 +12216,295 @@ describe("usage pack allocation management", () => {
     expect(state.changes[0]).toStrictEqual(
       expect.objectContaining({ kind: "removal", status: "scheduled" }),
     );
+  });
+
+  it("recovers a failed refund from an already-issued invoice credit note", async () => {
+    const userId = `user_${randomUUID()}`;
+    const fixture = await seedManagedUsagePack([{ userId, usagePackUsd: 20 }]);
+    await usagePackStateAction({
+      action: "set-grant-remaining",
+      orgId: fixture.orgId,
+      userId,
+      grantType: "purchased",
+      remainingAmount: 10_000,
+      prepareRefund: true,
+      refundState: {
+        status: "failed",
+        refundedAmountCents: 1000,
+        stripeCreditNoteId: "cn_historical_failed",
+        stripeRefundId: "re_historical_failed",
+        attempt: 1,
+        failureReason: "stripe_refund_failed",
+      },
+    });
+    context.mocks.stripe.creditNotes.retrieve.mockResolvedValue({
+      id: "cn_historical_failed",
+      status: "issued",
+      pre_payment_amount: 0,
+      post_payment_amount: 1000,
+      refunds: [{ amount_refunded: 1000, refund: "re_historical_failed" }],
+    });
+    context.mocks.stripe.refunds.retrieve.mockResolvedValue({
+      id: "re_historical_failed",
+      status: "failed",
+    });
+
+    await runBillingReconciliation(fixture.orgId);
+
+    const retryPending = await readUsagePackState(
+      fixture.orgId,
+      fixture.usagePackSubscriptionId,
+    );
+    expect(retryPending.refunds).toContainEqual(
+      expect.objectContaining({
+        userId,
+        status: "pending",
+        attempt: 2,
+        stripeCreditNoteId: "cn_historical_failed",
+        stripeRefundId: null,
+      }),
+    );
+
+    const recoveryPaymentIntentId = "pi_historical_recovery";
+    context.mocks.stripe.invoices.retrieve.mockResolvedValue({
+      id: "in_historical_recovery",
+      payments: {
+        data: [
+          {
+            status: "paid",
+            amount_paid: 2000,
+            payment: {
+              type: "payment_intent",
+              payment_intent: recoveryPaymentIntentId,
+            },
+          },
+        ],
+      },
+    });
+    context.mocks.stripe.refunds.create.mockResolvedValue({
+      id: "re_historical_recovery",
+      status: "succeeded",
+    });
+
+    await runBillingReconciliation(fixture.orgId);
+
+    const recovered = await readUsagePackState(
+      fixture.orgId,
+      fixture.usagePackSubscriptionId,
+    );
+    expect(recovered.refunds).toContainEqual(
+      expect.objectContaining({
+        userId,
+        status: "succeeded",
+        attempt: 2,
+        stripeCreditNoteId: "cn_historical_failed",
+        stripeRefundId: "re_historical_recovery",
+      }),
+    );
+    expect(context.mocks.stripe.refunds.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payment_intent: recoveryPaymentIntentId,
+        amount: 1000,
+      }),
+      expect.objectContaining({
+        idempotencyKey: expect.stringMatching(
+          /^usage-pack-credit-refund:[0-9a-f-]+:2:refund$/u,
+        ),
+      }),
+    );
+    expect(context.mocks.stripe.creditNotes.create).not.toHaveBeenCalled();
+  });
+
+  it("stops retrying an invoice refund after the third failed attempt", async () => {
+    const userId = `user_${randomUUID()}`;
+    const fixture = await seedManagedUsagePack([{ userId, usagePackUsd: 20 }]);
+    await usagePackStateAction({
+      action: "set-grant-remaining",
+      orgId: fixture.orgId,
+      userId,
+      grantType: "purchased",
+      remainingAmount: 10_000,
+      prepareRefund: true,
+    });
+    context.mocks.stripe.creditNotes.preview.mockResolvedValue({
+      id: "cn_preview_terminal_refund",
+      status: "issued",
+      pre_payment_amount: 0,
+      post_payment_amount: 1000,
+      refunds: [],
+    });
+    context.mocks.stripe.invoices.retrieve.mockResolvedValue({
+      id: "in_terminal_refund",
+      payments: {
+        data: [
+          {
+            status: "paid",
+            amount_paid: 2000,
+            payment: {
+              type: "payment_intent",
+              payment_intent: "pi_terminal_refund",
+            },
+          },
+        ],
+      },
+    });
+    context.mocks.stripe.refunds.create
+      .mockResolvedValueOnce({ id: "re_failed_1", status: "failed" })
+      .mockResolvedValueOnce({ id: "re_failed_2", status: "canceled" })
+      .mockResolvedValueOnce({
+        id: "re_failed_3",
+        status: "failed",
+        failure_reason: "declined",
+      });
+
+    await runBillingReconciliation(fixture.orgId);
+    await runBillingReconciliation(fixture.orgId);
+    await runBillingReconciliation(fixture.orgId);
+    await runBillingReconciliation(fixture.orgId);
+
+    const failed = await readUsagePackState(
+      fixture.orgId,
+      fixture.usagePackSubscriptionId,
+    );
+    expect(failed.refunds).toContainEqual(
+      expect.objectContaining({
+        userId,
+        status: "failed",
+        attempt: 3,
+        failureReason: "stripe_refund_failed:declined",
+        stripeCreditNoteId: null,
+        stripeRefundId: "re_failed_3",
+      }),
+    );
+    expect(context.mocks.stripe.refunds.create).toHaveBeenCalledTimes(3);
+    expect(context.mocks.stripe.creditNotes.create).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when an invoice has multiple refundable PaymentIntents", async () => {
+    const userId = `user_${randomUUID()}`;
+    const fixture = await seedManagedUsagePack([{ userId, usagePackUsd: 20 }]);
+    await usagePackStateAction({
+      action: "set-grant-remaining",
+      orgId: fixture.orgId,
+      userId,
+      grantType: "purchased",
+      remainingAmount: 10_000,
+      prepareRefund: true,
+    });
+    context.mocks.stripe.creditNotes.preview.mockResolvedValue({
+      id: "cn_preview_ambiguous_refund",
+      status: "issued",
+      pre_payment_amount: 0,
+      post_payment_amount: 1000,
+      refunds: [],
+    });
+    context.mocks.stripe.invoices.retrieve.mockResolvedValue({
+      id: "in_ambiguous_refund",
+      payments: {
+        data: ["first", "second"].map((suffix) => {
+          return {
+            status: "paid",
+            amount_paid: 2000,
+            payment: {
+              type: "payment_intent",
+              payment_intent: `pi_ambiguous_${suffix}`,
+            },
+          };
+        }),
+      },
+    });
+
+    await runBillingReconciliation(fixture.orgId);
+
+    const failed = await readUsagePackState(
+      fixture.orgId,
+      fixture.usagePackSubscriptionId,
+    );
+    expect(failed.refunds).toContainEqual(
+      expect.objectContaining({
+        userId,
+        status: "failed",
+        attempt: 1,
+        failureReason: "invoice_refund_payment_intent_count_2",
+        stripeCreditNoteId: null,
+        stripeRefundId: null,
+      }),
+    );
+    expect(context.mocks.stripe.refunds.create).not.toHaveBeenCalled();
+    expect(context.mocks.stripe.creditNotes.create).not.toHaveBeenCalled();
+  });
+
+  it("continues reconciling refunds after one candidate throws", async () => {
+    const firstUserId = `user_${randomUUID()}`;
+    const secondUserId = `user_${randomUUID()}`;
+    const fixture = await seedManagedUsagePack([
+      { userId: firstUserId, usagePackUsd: 20 },
+      { userId: secondUserId, usagePackUsd: 20 },
+    ]);
+    for (const userId of [firstUserId, secondUserId]) {
+      await usagePackStateAction({
+        action: "set-grant-remaining",
+        orgId: fixture.orgId,
+        userId,
+        grantType: "purchased",
+        remainingAmount: 10_000,
+        prepareRefund: true,
+      });
+    }
+    context.mocks.stripe.creditNotes.preview.mockResolvedValue({
+      id: "cn_preview_isolated_refund",
+      status: "issued",
+      pre_payment_amount: 0,
+      post_payment_amount: 1000,
+      refunds: [],
+    });
+    context.mocks.stripe.invoices.retrieve
+      .mockRejectedValueOnce(new Error("bad Stripe invoice"))
+      .mockResolvedValueOnce({
+        id: "in_isolated_refund",
+        payments: {
+          data: [
+            {
+              status: "paid",
+              amount_paid: 4000,
+              payment: {
+                type: "payment_intent",
+                payment_intent: "pi_isolated_refund",
+              },
+            },
+          ],
+        },
+      });
+    context.mocks.stripe.refunds.create.mockResolvedValue({
+      id: "re_isolated_refund",
+      status: "succeeded",
+    });
+    context.mocks.stripe.creditNotes.create.mockResolvedValue({
+      id: "cn_isolated_refund",
+      status: "issued",
+      pre_payment_amount: 0,
+      post_payment_amount: 1000,
+      refunds: [{ amount_refunded: 1000, refund: "re_isolated_refund" }],
+    });
+
+    await runBillingReconciliation(fixture.orgId);
+
+    const state = await readUsagePackState(
+      fixture.orgId,
+      fixture.usagePackSubscriptionId,
+    );
+    expect(
+      state.refunds.filter((refund) => {
+        return refund.status === "processing";
+      }),
+    ).toHaveLength(1);
+    expect(
+      state.refunds.filter((refund) => {
+        return refund.status === "succeeded";
+      }),
+    ).toHaveLength(1);
+    expect(context.mocks.stripe.refunds.create).toHaveBeenCalledTimes(1);
+    expect(context.mocks.stripe.creditNotes.create).toHaveBeenCalledTimes(1);
   });
 
   it.each(["pro", "team"] as const)(

--- a/turbo/apps/api/src/signals/routes/test-usage-pack-subscription-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-usage-pack-subscription-state.ts
@@ -21,6 +21,7 @@ import { z } from "zod";
 
 import { executeRawRows } from "../../lib/db-raw-rows";
 import { testOverride } from "../../lib/singleton";
+import { nowDate } from "../../lib/time";
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import { type Db, writeDb$ } from "../external/db";
@@ -108,6 +109,17 @@ const actionBodySchema = z.discriminatedUnion("action", [
     userId: z.string().min(1),
     grantType: z.enum(["purchased", "bonus"]),
     remainingAmount: z.number().int().nonnegative(),
+    prepareRefund: z.boolean().optional(),
+    refundState: z
+      .object({
+        status: z.enum(["pending", "processing", "succeeded", "failed"]),
+        refundedAmountCents: z.number().int().nonnegative().nullable(),
+        stripeCreditNoteId: z.string().nullable(),
+        stripeRefundId: z.string().nullable(),
+        attempt: z.number().int().positive(),
+        failureReason: z.string().nullable(),
+      })
+      .optional(),
   }),
   z.object({
     action: z.literal("delete-refund-source"),
@@ -229,6 +241,9 @@ const readStateSchema = z.object({
       creditGrantId: z.string().uuid(),
       userId: z.string(),
       sourceType: z.enum(["invoice", "payment_intent"]),
+      stripeInvoiceId: z.string().nullable(),
+      stripeInvoiceLineId: z.string().nullable(),
+      stripePaymentIntentId: z.string().nullable(),
       sourceAmountCents: z.number().int().nonnegative(),
       status: z.enum([
         "available",
@@ -242,6 +257,8 @@ const readStateSchema = z.object({
       refundedAmountCents: z.number().int().nonnegative().nullable(),
       stripeCreditNoteId: z.string().nullable(),
       stripeRefundId: z.string().nullable(),
+      attempt: z.number().int().positive(),
+      failureReason: z.string().nullable(),
     }),
   ),
   fulfillmentInvoiceIds: z.array(z.string()),
@@ -718,6 +735,9 @@ async function readUsagePackCreditRefunds(db: Db, orgId: string) {
       creditGrantId: refund.creditGrantId,
       userId: refund.userId,
       sourceType: refund.sourceType,
+      stripeInvoiceId: refund.stripeInvoiceId,
+      stripeInvoiceLineId: refund.stripeInvoiceLineId,
+      stripePaymentIntentId: refund.stripePaymentIntentId,
       sourceAmountCents: refund.sourceAmountCents,
       status: refund.status,
       refundCredits: refund.refundCredits,
@@ -725,6 +745,8 @@ async function readUsagePackCreditRefunds(db: Db, orgId: string) {
       refundedAmountCents: refund.refundedAmountCents,
       stripeCreditNoteId: refund.stripeCreditNoteId,
       stripeRefundId: refund.stripeRefundId,
+      attempt: refund.attempt,
+      failureReason: refund.failureReason,
     };
   });
 }
@@ -1089,6 +1111,29 @@ async function setGrantRemaining(
   signal.throwIfAborted();
   if (rows.length !== 1) {
     throw new Error("Expected one usage pack credit grant to update");
+  }
+  if (body.prepareRefund) {
+    await prepareUsagePackMemberCreditRefunds(db, body);
+    signal.throwIfAborted();
+  }
+  if (body.refundState) {
+    const refunds = await db
+      .update(usagePackCreditRefunds)
+      .set({
+        ...body.refundState,
+        updatedAt: nowDate(),
+      })
+      .where(
+        and(
+          eq(usagePackCreditRefunds.orgId, body.orgId),
+          eq(usagePackCreditRefunds.userId, body.userId),
+        ),
+      )
+      .returning({ creditGrantId: usagePackCreditRefunds.creditGrantId });
+    signal.throwIfAborted();
+    if (refunds.length !== 1) {
+      throw new Error("Expected one usage pack credit refund to update");
+    }
   }
 }
 

--- a/turbo/apps/api/src/signals/services/billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-checkout.service.ts
@@ -19,6 +19,7 @@ import { nowDate } from "../../lib/time";
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import {
   getStripeClient,
+  listAllStripeSubscriptions,
   type StripeClient,
   type StripeCheckoutSessionCreateParams,
   type StripeInvoice,
@@ -853,16 +854,15 @@ async function planPurchaseSubscriptionState(
   readonly existing: StripeSubscription | null;
   readonly hasCompetingPurchase: boolean;
 }> {
-  const subscriptions = await args.stripe.subscriptions.list({
-    customer: args.customerId,
-    status: "all",
-    limit: 100,
-  });
-  signal.throwIfAborted();
-  const exactPurchase = subscriptions.data.find((subscription) => {
+  const subscriptions = await listAllStripeSubscriptions(
+    args.stripe,
+    { customer: args.customerId, status: "all" },
+    signal,
+  );
+  const exactPurchase = subscriptions.find((subscription) => {
     return subscription.metadata?.billingPurchaseId === args.purchaseId;
   });
-  const resumablePurchase = subscriptions.data.find((subscription) => {
+  const resumablePurchase = subscriptions.find((subscription) => {
     return (
       subscription.metadata?.orgId === args.orgId &&
       subscription.metadata.billingPurchaseId !== undefined &&
@@ -872,7 +872,7 @@ async function planPurchaseSubscriptionState(
     );
   });
   const existingSummary = exactPurchase ?? resumablePurchase;
-  const hasCompetingPurchase = subscriptions.data.some((subscription) => {
+  const hasCompetingPurchase = subscriptions.some((subscription) => {
     const tier = tierForKnownPriceId(
       knownPlanPriceItem(subscription.items.data)?.price.id ?? "",
     );

--- a/turbo/apps/api/src/signals/services/cron-billing-entitlements.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-billing-entitlements.service.ts
@@ -25,6 +25,7 @@ import { clerk$ } from "../external/clerk";
 import {
   getStripeClient,
   isStripeResourceMissingError,
+  listAllStripeSubscriptions,
   listUndeliveredStripePaidCheckoutSessions,
   listUndeliveredStripePaidInvoices,
   type StripeInvoice,
@@ -274,28 +275,14 @@ async function listStripeSubscriptionPages(
   },
   signal: AbortSignal,
 ): Promise<readonly StripeSubscription[]> {
-  const subscriptions: StripeSubscription[] = [];
-  let startingAfter: string | undefined;
-  while (true) {
-    const page = await stripe.subscriptions.list({
+  return await listAllStripeSubscriptions(
+    stripe,
+    {
       ...params,
-      limit: 100,
       expand: ["data.latest_invoice"],
-      ...(startingAfter ? { starting_after: startingAfter } : {}),
-    });
-    signal.throwIfAborted();
-    subscriptions.push(...page.data);
-    if (!page.has_more) {
-      return subscriptions;
-    }
-    const last = page.data.at(-1);
-    if (!last) {
-      throw new Error(
-        "Stripe returned an empty subscription page with has_more",
-      );
-    }
-    startingAfter = last.id;
-  }
+    },
+    signal,
+  );
 }
 
 async function loadScopedStripeCustomerIds(

--- a/turbo/apps/api/src/signals/services/org-deletion-billing.service.ts
+++ b/turbo/apps/api/src/signals/services/org-deletion-billing.service.ts
@@ -10,6 +10,7 @@ import type { ReadonlyDb } from "../external/db";
 import {
   getStripeClient,
   isStripeResourceMissingError,
+  listAllStripeSubscriptions,
   type StripeClient,
   type StripeCreditNote,
   type StripeInvoice,
@@ -110,26 +111,14 @@ async function listCustomerSubscriptions(
   customerId: string,
   signal: AbortSignal,
 ): Promise<readonly StripeSubscription[]> {
-  const subscriptions: StripeSubscription[] = [];
-  let startingAfter: string | undefined;
-  while (true) {
-    const page = await stripe.subscriptions.list({
+  return await listAllStripeSubscriptions(
+    stripe,
+    {
       customer: customerId,
       status: "all",
-      limit: STRIPE_PAGE_SIZE,
-      ...(startingAfter ? { starting_after: startingAfter } : {}),
-    });
-    signal.throwIfAborted();
-    subscriptions.push(...page.data);
-    const nextCursor = nextPageCursor(
-      page,
-      `Stripe customer ${customerId} subscriptions`,
-    );
-    if (nextCursor === null) {
-      return subscriptions;
-    }
-    startingAfter = nextCursor;
-  }
+    },
+    signal,
+  );
 }
 
 async function retrieveSubscriptionIfPresent(

--- a/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
@@ -29,6 +29,7 @@ import {
   sql,
 } from "drizzle-orm";
 import { pgBooleanDecoder } from "../../lib/db-structured-result";
+import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
 import {
@@ -45,6 +46,7 @@ import {
   type StripeSubscription,
   type StripeSubscriptionUpdateItemParam,
 } from "../external/stripe-client";
+import { settle } from "../utils";
 import { createUsagePackCreditGrant } from "./usage-pack-credit.service";
 import {
   assertUsagePackMemberCreditRefundReady,
@@ -68,6 +70,7 @@ const CHANGE_RECONCILIATION_DELAY_MS = 5 * 60 * 1000;
 const STRIPE_INVOICE_LINE_PAGE_SIZE = 100;
 const CREDITS_PER_DOLLAR = 1000;
 const CREDITS_PER_CENT = CREDITS_PER_DOLLAR / 100;
+const L = logger("UsagePackAllocationChange");
 const OPEN_CHANGE_STATUSES = [
   "previewed",
   "applying",
@@ -3708,6 +3711,86 @@ async function usagePackChangeCandidateSubscriptionIds(
   ];
 }
 
+async function reconcileUsagePackAllocationChangeCandidate(
+  db: Db,
+  usagePackSubscriptionId: string,
+  at: Date,
+  signal: AbortSignal,
+): Promise<{
+  readonly reconciled: number;
+  readonly orgIds: readonly string[];
+}> {
+  let reconciled = 0;
+  const orgIds = new Set<string>();
+  const context = await loadUsagePackChangeContextBySubscriptionId(
+    db,
+    usagePackSubscriptionId,
+  );
+  signal.throwIfAborted();
+  if (!context?.subscription.stripeSubscriptionId) {
+    return { reconciled, orgIds: [...orgIds] };
+  }
+  const subscription = await getStripeClient().subscriptions.retrieve(
+    context.subscription.stripeSubscriptionId,
+    { expand: ["latest_invoice"] },
+  );
+  signal.throwIfAborted();
+  const result = await reconcileUsagePackAllocationChangeSubscription(
+    db,
+    subscription,
+  );
+  reconciled += result.reconciled;
+  if (result.orgId) {
+    orgIds.add(result.orgId);
+  }
+  signal.throwIfAborted();
+
+  const refreshed = await loadUsagePackChangeContextBySubscriptionId(
+    db,
+    usagePackSubscriptionId,
+  );
+  if (!refreshed) {
+    return { reconciled, orgIds: [...orgIds] };
+  }
+  reconciled += await retryApplyingDeferredUsagePackChange(
+    db,
+    refreshed,
+    subscription,
+    signal,
+  );
+  const hasOpenUpgrade = refreshed.changes.some((change) => {
+    return change.subscriptionChangeId === null && change.kind === "upgrade";
+  });
+  if (hasOpenUpgrade) {
+    const invoice = await paidUpgradeInvoiceForSubscription(subscription);
+    signal.throwIfAborted();
+    if (invoice) {
+      const outcome = await handleUsagePackAllocationChangeInvoicePaid(
+        db,
+        invoice,
+      );
+      reconciled += outcome.handled ? 1 : 0;
+      if (outcome.orgId) {
+        orgIds.add(outcome.orgId);
+      }
+    }
+  }
+  const afterInvoice = await loadUsagePackChangeContextBySubscriptionId(
+    db,
+    usagePackSubscriptionId,
+  );
+  if (afterInvoice) {
+    reconciled += await failExpiredUsagePackUpgrade(
+      db,
+      afterInvoice,
+      subscription,
+      at,
+    );
+  }
+  signal.throwIfAborted();
+  return { reconciled, orgIds: [...orgIds] };
+}
+
 export async function reconcileUsagePackAllocationChanges(
   db: Db,
   scope: BillingReconciliationScope | undefined,
@@ -3752,72 +3835,26 @@ export async function reconcileUsagePackAllocationChanges(
   const orgIds = new Set<string>();
   let reconciled = expiredPreviews.length;
   for (const usagePackSubscriptionId of subscriptionIds) {
-    const context = await loadUsagePackChangeContextBySubscriptionId(
-      db,
-      usagePackSubscriptionId,
-    );
-    signal.throwIfAborted();
-    if (!context?.subscription.stripeSubscriptionId) {
-      continue;
-    }
-    const subscription = await getStripeClient().subscriptions.retrieve(
-      context.subscription.stripeSubscriptionId,
-      { expand: ["latest_invoice"] },
-    );
-    signal.throwIfAborted();
-    const result = await reconcileUsagePackAllocationChangeSubscription(
-      db,
-      subscription,
-    );
-    reconciled += result.reconciled;
-    if (result.orgId) {
-      orgIds.add(result.orgId);
-    }
-    signal.throwIfAborted();
-
-    const refreshed = await loadUsagePackChangeContextBySubscriptionId(
-      db,
-      usagePackSubscriptionId,
-    );
-    if (!refreshed) {
-      continue;
-    }
-    reconciled += await retryApplyingDeferredUsagePackChange(
-      db,
-      refreshed,
-      subscription,
+    const result = await settle(
+      reconcileUsagePackAllocationChangeCandidate(
+        db,
+        usagePackSubscriptionId,
+        at,
+        signal,
+      ),
       signal,
     );
-    const hasOpenUpgrade = refreshed.changes.some((change) => {
-      return change.subscriptionChangeId === null && change.kind === "upgrade";
-    });
-    if (hasOpenUpgrade) {
-      const invoice = await paidUpgradeInvoiceForSubscription(subscription);
-      signal.throwIfAborted();
-      if (invoice) {
-        const outcome = await handleUsagePackAllocationChangeInvoicePaid(
-          db,
-          invoice,
-        );
-        reconciled += outcome.handled ? 1 : 0;
-        if (outcome.orgId) {
-          orgIds.add(outcome.orgId);
-        }
-      }
+    if (!result.ok) {
+      L.error("usage pack allocation change reconciliation failed", {
+        usagePackSubscriptionId,
+        error: result.error,
+      });
+      continue;
     }
-    const afterInvoice = await loadUsagePackChangeContextBySubscriptionId(
-      db,
-      usagePackSubscriptionId,
-    );
-    if (afterInvoice) {
-      reconciled += await failExpiredUsagePackUpgrade(
-        db,
-        afterInvoice,
-        subscription,
-        at,
-      );
+    reconciled += result.value.reconciled;
+    for (const orgId of result.value.orgIds) {
+      orgIds.add(orgId);
     }
-    signal.throwIfAborted();
   }
   return { reconciled, orgIds: [...orgIds] };
 }

--- a/turbo/apps/api/src/signals/services/usage-pack-credit-refund.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-credit-refund.service.ts
@@ -711,6 +711,10 @@ async function processInvoiceRefund(
   row: UsagePackCreditRefundRow,
 ): Promise<void> {
   const stripe = getStripeClient();
+  // The previous API could persist a failed or processing invoice refund after
+  // issuing its Credit Note. This is backend persisted-state compatibility for
+  // the documented ~102-minute rollout exposure. Remove with #28580 only after
+  // that API has drained and production has zero unresolved Credit-Note rows.
   const existingCreditNote = row.stripeCreditNoteId
     ? await stripe.creditNotes.retrieve(row.stripeCreditNoteId)
     : null;
@@ -792,6 +796,8 @@ async function processCreditRefund(
 }
 
 function retryableFailedInvoiceRefundCondition() {
+  // Keep the legacy failed rows described in processInvoiceRefund eligible
+  // until the bounded compatibility cleanup tracked by #28580.
   return and(
     eq(usagePackCreditRefunds.sourceType, "invoice"),
     eq(usagePackCreditRefunds.status, "failed"),

--- a/turbo/apps/api/src/signals/services/usage-pack-credit-refund.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-credit-refund.service.ts
@@ -4,21 +4,27 @@ import {
   type UsagePackCreditRefundSourceType,
 } from "@okouai/db/schema/usage-pack-credit-refund";
 import { usagePackInvitationPurchases } from "@okouai/db/schema/usage-pack-subscription";
-import { and, asc, eq, gt, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, gt, inArray, like, lt, or, sql } from "drizzle-orm";
 
 import { pgBooleanDecoder } from "../../lib/db-structured-result";
+import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
 import {
   getStripeClient,
+  type StripeClient,
   type StripeCreditNote,
   type StripeCreditNoteParams,
   type StripeRefund,
+  type StripeRef,
 } from "../external/stripe-client";
+import { settle } from "../utils";
 import type { BillingReconciliationScope } from "./billing-reconciliation-scope";
 
 const CREDITS_PER_CENT = 10;
 const RECONCILIATION_LIMIT = 100;
+const MAX_REFUND_ATTEMPTS = 3;
+const L = logger("UsagePackCreditRefund");
 
 type UsagePackCreditRefundRow = typeof usagePackCreditRefunds.$inferSelect;
 type UsagePackCreditGrantRow = typeof usagePackCreditGrants.$inferSelect;
@@ -357,12 +363,14 @@ async function markRefundSucceeded(
   row: UsagePackCreditRefundRow,
   stripeRefundId: string,
   refundedAmountCents: number,
+  stripeCreditNoteId = row.stripeCreditNoteId,
 ): Promise<void> {
   const at = nowDate();
   await db
     .update(usagePackCreditRefunds)
     .set({
       status: "succeeded",
+      stripeCreditNoteId,
       stripeRefundId,
       refundedAmountCents,
       failureReason: null,
@@ -391,67 +399,107 @@ async function markRefundNotRequired(
     .where(eq(usagePackCreditRefunds.creditGrantId, row.creditGrantId));
 }
 
-async function applyPaymentIntentRefundState(
+function stripeRefundFailureReason(refund: StripeRefund): string {
+  const status = refund.status ?? "unknown";
+  return refund.failure_reason
+    ? `stripe_refund_${status}:${refund.failure_reason}`
+    : `stripe_refund_${status}`;
+}
+
+function logTerminalRefundFailure(
+  row: UsagePackCreditRefundRow,
+  args: {
+    readonly stripeCreditNoteId?: string | null;
+    readonly stripeRefundId?: string | null;
+    readonly failureReason: string;
+  },
+): void {
+  L.error("usage pack credit refund requires manual recovery", {
+    creditGrantId: row.creditGrantId,
+    orgId: row.orgId,
+    userId: row.userId,
+    stripeInvoiceId: row.stripeInvoiceId,
+    stripeCreditNoteId:
+      args.stripeCreditNoteId ?? row.stripeCreditNoteId ?? null,
+    stripeRefundId: args.stripeRefundId ?? row.stripeRefundId ?? null,
+    attempt: row.attempt,
+    failureReason: args.failureReason,
+  });
+}
+
+async function markRefundFailed(
+  db: Pick<Db, "update">,
+  row: UsagePackCreditRefundRow,
+  failureReason: string,
+): Promise<void> {
+  await db
+    .update(usagePackCreditRefunds)
+    .set({
+      status: "failed",
+      failureReason,
+      updatedAt: nowDate(),
+    })
+    .where(eq(usagePackCreditRefunds.creditGrantId, row.creditGrantId));
+  logTerminalRefundFailure(row, {
+    failureReason,
+  });
+}
+
+type StripeRefundState = "succeeded" | "waiting" | "failed";
+
+async function applyStripeRefundState(
   db: Pick<Db, "update">,
   row: UsagePackCreditRefundRow,
   refund: StripeRefund,
-): Promise<void> {
-  if (!row.requestedAmountCents) {
-    throw new Error(`Usage pack refund ${row.creditGrantId} has no amount`);
-  }
+  refundedAmountCents?: number,
+): Promise<StripeRefundState> {
   if (refund.status === "succeeded") {
-    await markRefundSucceeded(db, row, refund.id, row.requestedAmountCents);
-    return;
-  }
-  if (refund.status === "failed" || refund.status === "canceled") {
     await db
       .update(usagePackCreditRefunds)
       .set({
-        status: "pending",
-        stripeRefundId: null,
-        attempt: row.attempt + 1,
-        failureReason: `stripe_refund_${refund.status}`,
+        status: "processing",
+        stripeRefundId: refund.id,
+        ...(refundedAmountCents === undefined ? {} : { refundedAmountCents }),
+        failureReason: null,
         updatedAt: nowDate(),
       })
       .where(eq(usagePackCreditRefunds.creditGrantId, row.creditGrantId));
-    return;
+    return "succeeded";
+  }
+  if (refund.status === "failed" || refund.status === "canceled") {
+    const failureReason = stripeRefundFailureReason(refund);
+    const terminal = row.attempt >= MAX_REFUND_ATTEMPTS;
+    await db
+      .update(usagePackCreditRefunds)
+      .set({
+        status: terminal ? "failed" : "pending",
+        stripeRefundId: terminal ? refund.id : null,
+        ...(refundedAmountCents === undefined ? {} : { refundedAmountCents }),
+        attempt: terminal ? row.attempt : row.attempt + 1,
+        failureReason,
+        updatedAt: nowDate(),
+      })
+      .where(eq(usagePackCreditRefunds.creditGrantId, row.creditGrantId));
+    if (terminal) {
+      logTerminalRefundFailure(row, {
+        stripeRefundId: refund.id,
+        failureReason,
+      });
+      return "failed";
+    }
+    return "waiting";
   }
   await db
     .update(usagePackCreditRefunds)
     .set({
       status: "processing",
       stripeRefundId: refund.id,
+      ...(refundedAmountCents === undefined ? {} : { refundedAmountCents }),
+      failureReason: null,
       updatedAt: nowDate(),
     })
     .where(eq(usagePackCreditRefunds.creditGrantId, row.creditGrantId));
-}
-
-async function applyInvoiceRefundState(
-  db: Pick<Db, "update">,
-  row: UsagePackCreditRefundRow,
-  refund: StripeRefund,
-  refundedAmountCents: number,
-): Promise<void> {
-  if (refund.status === "succeeded") {
-    await markRefundSucceeded(db, row, refund.id, refundedAmountCents);
-    return;
-  }
-  await db
-    .update(usagePackCreditRefunds)
-    .set({
-      status:
-        refund.status === "failed" || refund.status === "canceled"
-          ? "failed"
-          : "processing",
-      stripeRefundId: refund.id,
-      refundedAmountCents,
-      failureReason:
-        refund.status === "failed" || refund.status === "canceled"
-          ? `stripe_refund_${refund.status}`
-          : null,
-      updatedAt: nowDate(),
-    })
-    .where(eq(usagePackCreditRefunds.creditGrantId, row.creditGrantId));
+  return "waiting";
 }
 
 async function processPaymentIntentRefund(
@@ -481,28 +529,25 @@ async function processPaymentIntentRefund(
           idempotencyKey: `usage-pack-credit-refund:${row.creditGrantId}:${row.attempt}`,
         },
       );
-  await applyPaymentIntentRefundState(db, row, refund);
+  const state = await applyStripeRefundState(db, row, refund);
+  if (state === "succeeded") {
+    await markRefundSucceeded(db, row, refund.id, row.requestedAmountCents);
+  }
 }
 
-async function loadOrCreateCreditNote(
-  db: Pick<Db, "update">,
+function creditNoteParams(
   row: UsagePackCreditRefundRow,
-): Promise<StripeCreditNote | null> {
-  const stripe = getStripeClient();
-  if (row.stripeCreditNoteId) {
-    return await stripe.creditNotes.retrieve(row.stripeCreditNoteId);
-  }
+): StripeCreditNoteParams {
   if (!row.stripeInvoiceId) {
     throw new Error(
       `Usage pack refund ${row.creditGrantId} has no Stripe invoice`,
     );
   }
-  const lineParams = creditNoteLineParams(row);
-  const commonParams = {
+  return {
     invoice: row.stripeInvoiceId,
-    ...lineParams,
-    email_type: "none" as const,
-    reason: "order_change" as const,
+    ...creditNoteLineParams(row),
+    email_type: "none",
+    reason: "order_change",
     metadata: {
       purpose: "usage_pack_member_credit_refund",
       orgId: row.orgId,
@@ -510,13 +555,20 @@ async function loadOrCreateCreditNote(
       creditGrantId: row.creditGrantId,
     },
   };
+}
+
+async function loadInvoiceRefundAmount(
+  db: Pick<Db, "update">,
+  stripe: StripeClient,
+  row: UsagePackCreditRefundRow,
+): Promise<number | null> {
   let refundAmountCents = row.refundedAmountCents;
   if (refundAmountCents === 0) {
     await markRefundNotRequired(db, row);
     return null;
   }
   if (refundAmountCents === null) {
-    const preview = await stripe.creditNotes.preview(commonParams);
+    const preview = await stripe.creditNotes.preview(creditNoteParams(row));
     if (preview.pre_payment_amount === 0 && preview.post_payment_amount === 0) {
       await markRefundNotRequired(db, row);
       return null;
@@ -532,49 +584,187 @@ async function loadOrCreateCreditNote(
       .set({ refundedAmountCents: refundAmountCents, updatedAt: nowDate() })
       .where(eq(usagePackCreditRefunds.creditGrantId, row.creditGrantId));
   }
-  return await stripe.creditNotes.create(
-    { ...commonParams, refund_amount: refundAmountCents },
+  return refundAmountCents;
+}
+
+function stripeRefId(ref: StripeRef | undefined): string | null {
+  if (!ref) {
+    return null;
+  }
+  return typeof ref === "string" ? ref : ref.id;
+}
+
+async function loadRefundableInvoicePaymentIntentId(
+  db: Pick<Db, "update">,
+  stripe: StripeClient,
+  row: UsagePackCreditRefundRow,
+  refundAmountCents: number,
+): Promise<string | null> {
+  if (!row.stripeInvoiceId) {
+    throw new Error(
+      `Usage pack refund ${row.creditGrantId} has no Stripe invoice`,
+    );
+  }
+  const invoice = await stripe.invoices.retrieve(row.stripeInvoiceId, {
+    expand: ["payments.data.payment.payment_intent"],
+  });
+  const refundablePaymentIntentIds = new Set(
+    (invoice.payments?.data ?? []).flatMap((payment) => {
+      const paymentIntentId = stripeRefId(payment.payment.payment_intent);
+      return payment.status === "paid" &&
+        payment.payment.type === "payment_intent" &&
+        paymentIntentId &&
+        (payment.amount_paid ?? 0) >= refundAmountCents
+        ? [paymentIntentId]
+        : [];
+    }),
+  );
+  if (refundablePaymentIntentIds.size === 1) {
+    return [...refundablePaymentIntentIds][0] ?? null;
+  }
+  await markRefundFailed(
+    db,
+    row,
+    `invoice_refund_payment_intent_count_${refundablePaymentIntentIds.size}`,
+  );
+  return null;
+}
+
+async function loadOrCreateInvoiceRefund(
+  db: Pick<Db, "update">,
+  stripe: StripeClient,
+  row: UsagePackCreditRefundRow,
+  refundAmountCents: number,
+  fallbackRefundId?: string | null,
+): Promise<StripeRefund | null> {
+  const stripeRefundId = row.stripeRefundId ?? fallbackRefundId;
+  if (stripeRefundId) {
+    return await stripe.refunds.retrieve(stripeRefundId);
+  }
+  const paymentIntentId = await loadRefundableInvoicePaymentIntentId(
+    db,
+    stripe,
+    row,
+    refundAmountCents,
+  );
+  if (!paymentIntentId) {
+    return null;
+  }
+  return await stripe.refunds.create(
     {
-      idempotencyKey: `usage-pack-credit-refund:${row.creditGrantId}:${row.attempt}`,
+      payment_intent: paymentIntentId,
+      amount: refundAmountCents,
+      metadata: {
+        purpose: "usage_pack_member_credit_refund",
+        orgId: row.orgId,
+        userId: row.userId,
+        creditGrantId: row.creditGrantId,
+      },
+    },
+    {
+      idempotencyKey: `usage-pack-credit-refund:${row.creditGrantId}:${row.attempt}:refund`,
     },
   );
+}
+
+function requireIssuedRefundCreditNote(
+  row: UsagePackCreditRefundRow,
+  creditNote: StripeCreditNote,
+): number {
+  if (creditNote.status !== "issued" || creditNote.post_payment_amount <= 0) {
+    throw new Error(
+      `Usage pack refund ${row.creditGrantId} has an invalid credit note`,
+    );
+  }
+  return creditNote.post_payment_amount;
+}
+
+async function createLinkedCreditNote(
+  stripe: StripeClient,
+  row: UsagePackCreditRefundRow,
+  refund: StripeRefund,
+  refundAmountCents: number,
+): Promise<StripeCreditNote> {
+  const creditNote = await stripe.creditNotes.create(
+    {
+      ...creditNoteParams(row),
+      refunds: [{ refund: refund.id, amount_refunded: refundAmountCents }],
+    },
+    {
+      idempotencyKey: `usage-pack-credit-refund:${row.creditGrantId}:${row.attempt}:credit-note`,
+    },
+  );
+  const linkedRefundId = creditNoteRefundId(creditNote);
+  if (
+    requireIssuedRefundCreditNote(row, creditNote) !== refundAmountCents ||
+    linkedRefundId !== refund.id
+  ) {
+    throw new Error(
+      `Usage pack refund ${row.creditGrantId} credit note is not linked to its refund`,
+    );
+  }
+  return creditNote;
 }
 
 async function processInvoiceRefund(
   db: Db,
   row: UsagePackCreditRefundRow,
 ): Promise<void> {
-  const creditNote = await loadOrCreateCreditNote(db, row);
-  if (!creditNote) {
+  const stripe = getStripeClient();
+  const existingCreditNote = row.stripeCreditNoteId
+    ? await stripe.creditNotes.retrieve(row.stripeCreditNoteId)
+    : null;
+  const refundAmountCents = existingCreditNote
+    ? requireIssuedRefundCreditNote(row, existingCreditNote)
+    : await loadInvoiceRefundAmount(db, stripe, row);
+  if (refundAmountCents === null) {
     return;
   }
-  if (creditNote.status !== "issued" || creditNote.post_payment_amount <= 0) {
-    throw new Error(
-      `Usage pack refund ${row.creditGrantId} has an invalid credit note`,
-    );
+  const fallbackRefundId =
+    existingCreditNote && row.attempt === 1
+      ? creditNoteRefundId(existingCreditNote)
+      : null;
+  const stripeRefund = await loadOrCreateInvoiceRefund(
+    db,
+    stripe,
+    row,
+    refundAmountCents,
+    fallbackRefundId,
+  );
+  if (!stripeRefund) {
+    return;
   }
-  const stripeRefundId = creditNoteRefundId(creditNote);
-  if (!stripeRefundId) {
-    throw new Error(
-      `Usage pack refund ${row.creditGrantId} credit note has no refund`,
-    );
-  }
-  await db
-    .update(usagePackCreditRefunds)
-    .set({
-      status: "processing",
-      stripeCreditNoteId: creditNote.id,
-      stripeRefundId,
-      refundedAmountCents: creditNote.post_payment_amount,
-      updatedAt: nowDate(),
-    })
-    .where(eq(usagePackCreditRefunds.creditGrantId, row.creditGrantId));
-  const stripeRefund = await getStripeClient().refunds.retrieve(stripeRefundId);
-  await applyInvoiceRefundState(
+  const state = await applyStripeRefundState(
     db,
     row,
     stripeRefund,
-    creditNote.post_payment_amount,
+    refundAmountCents,
+  );
+  if (state !== "succeeded") {
+    return;
+  }
+  if (existingCreditNote) {
+    await markRefundSucceeded(
+      db,
+      row,
+      stripeRefund.id,
+      refundAmountCents,
+      existingCreditNote.id,
+    );
+    return;
+  }
+  const creditNote = await createLinkedCreditNote(
+    stripe,
+    row,
+    stripeRefund,
+    refundAmountCents,
+  );
+  await markRefundSucceeded(
+    db,
+    row,
+    stripeRefund.id,
+    refundAmountCents,
+    creditNote.id,
   );
 }
 
@@ -588,7 +778,10 @@ async function processCreditRefund(
     .where(
       and(
         eq(usagePackCreditRefunds.creditGrantId, row.creditGrantId),
-        inArray(usagePackCreditRefunds.status, ["pending", "processing"]),
+        or(
+          inArray(usagePackCreditRefunds.status, ["pending", "processing"]),
+          retryableFailedInvoiceRefundCondition(),
+        ),
       ),
     );
   if (row.sourceType === "payment_intent") {
@@ -596,6 +789,18 @@ async function processCreditRefund(
     return;
   }
   await processInvoiceRefund(db, row);
+}
+
+function retryableFailedInvoiceRefundCondition() {
+  return and(
+    eq(usagePackCreditRefunds.sourceType, "invoice"),
+    eq(usagePackCreditRefunds.status, "failed"),
+    lt(usagePackCreditRefunds.attempt, MAX_REFUND_ATTEMPTS),
+    or(
+      like(usagePackCreditRefunds.failureReason, "stripe_refund_failed%"),
+      like(usagePackCreditRefunds.failureReason, "stripe_refund_canceled%"),
+    ),
+  );
 }
 
 export async function refundUsagePackMemberCredits(
@@ -643,15 +848,28 @@ export async function reconcileUsagePackCreditRefunds(
         scope
           ? inArray(usagePackCreditRefunds.orgId, [...scope.orgIds])
           : undefined,
-        inArray(usagePackCreditRefunds.status, ["pending", "processing"]),
+        or(
+          inArray(usagePackCreditRefunds.status, ["pending", "processing"]),
+          retryableFailedInvoiceRefundCondition(),
+        ),
       ),
     )
     .orderBy(asc(usagePackCreditRefunds.updatedAt))
     .limit(RECONCILIATION_LIMIT);
   signal.throwIfAborted();
   for (const refund of refunds) {
-    await processCreditRefund(db, refund);
-    signal.throwIfAborted();
+    const result = await settle(processCreditRefund(db, refund), signal);
+    if (!result.ok) {
+      L.error("usage pack credit refund reconciliation failed", {
+        creditGrantId: refund.creditGrantId,
+        orgId: refund.orgId,
+        userId: refund.userId,
+        stripeInvoiceId: refund.stripeInvoiceId,
+        stripeCreditNoteId: refund.stripeCreditNoteId,
+        stripeRefundId: refund.stripeRefundId,
+        error: result.error,
+      });
+    }
   }
   return refunds.length;
 }

--- a/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
@@ -27,6 +27,7 @@ import {
 
 import { pgBooleanDecoder } from "../../lib/db-structured-result";
 import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import {
   createClerkReadContext,
@@ -70,13 +71,14 @@ import {
   loadBillingOrganizationMemberships,
   loadBillingOrganizationPendingInvitations,
 } from "./billing-clerk-directory.service";
-import { onRejection } from "../utils";
+import { onRejection, settle } from "../utils";
 
 const PURPOSE = "usage_pack_invitation_purchase";
 const PURCHASE_ID_METADATA_KEY = "usagePackInvitationPurchaseId";
 const RECONCILIATION_DELAY_MS = 5 * 60 * 1000;
 const MIN_CHECKOUT_DURATION_SECONDS = 30 * 60;
 const MAX_CHECKOUT_DURATION_SECONDS = 24 * 60 * 60;
+const L = logger("UsagePackInvitationPurchase");
 const OPEN_INVITATION_PURCHASE_STATUSES = [
   "checkout_pending",
   "payment_succeeded",
@@ -2323,6 +2325,66 @@ export async function revokeUsagePackInvitationPurchase(
   return { status: result };
 }
 
+async function reconcileUsagePackInvitationPurchaseCandidate(
+  db: Db,
+  clerk: ClerkClient,
+  purchase: UsagePackInvitationPurchaseRow,
+  at: Date,
+  signal: AbortSignal,
+): Promise<boolean> {
+  switch (purchase.status) {
+    case "payment_succeeded":
+    case "creating_invitation": {
+      await ensurePaidInvitationCreated(db, clerk, purchase.id, true, signal);
+      return true;
+    }
+    case "invitation_pending": {
+      if (purchase.currentPeriodEnd <= at) {
+        await revokeAndRefundPurchase(db, clerk, purchase, signal);
+        return true;
+      }
+      const membership = await membershipForPurchase(
+        clerk,
+        purchase,
+        createClerkReadContext(),
+        signal,
+      );
+      signal.throwIfAborted();
+      if (!membership || !purchase.clerkInvitationId) {
+        return false;
+      }
+      await handleUsagePackInvitationAccepted(
+        db,
+        {
+          orgId: purchase.orgId,
+          invitationId: purchase.clerkInvitationId,
+          userId: membership.userId,
+          acceptedAt: membership.createdAt,
+          normalizedEmail: membership.email,
+        },
+        signal,
+      );
+      return true;
+    }
+    case "accepted_pending_activation":
+    case "activating": {
+      await activateAcceptedPurchase(db, purchase.id, signal, true);
+      return true;
+    }
+    case "refund_pending":
+    case "refunding": {
+      await refundPurchase(db, purchase.id, true);
+      return true;
+    }
+    case "checkout_pending":
+    case "accepted":
+    case "refunded":
+    case "failed": {
+      return false;
+    }
+  }
+}
+
 export async function reconcileUsagePackInvitationPurchases(
   db: Db,
   clerk: ClerkClient,
@@ -2372,62 +2434,29 @@ export async function reconcileUsagePackInvitationPurchases(
   signal.throwIfAborted();
   let reconciled = 0;
   for (const purchase of candidates) {
-    switch (purchase.status) {
-      case "payment_succeeded":
-      case "creating_invitation": {
-        await ensurePaidInvitationCreated(db, clerk, purchase.id, true, signal);
-        reconciled += 1;
-        break;
-      }
-      case "invitation_pending": {
-        if (purchase.currentPeriodEnd <= at) {
-          await revokeAndRefundPurchase(db, clerk, purchase, signal);
-          reconciled += 1;
-          break;
-        }
-        const membership = await membershipForPurchase(
-          clerk,
-          purchase,
-          createClerkReadContext(),
-          signal,
-        );
-        signal.throwIfAborted();
-        if (membership && purchase.clerkInvitationId) {
-          await handleUsagePackInvitationAccepted(
-            db,
-            {
-              orgId: purchase.orgId,
-              invitationId: purchase.clerkInvitationId,
-              userId: membership.userId,
-              acceptedAt: membership.createdAt,
-              normalizedEmail: membership.email,
-            },
-            signal,
-          );
-          reconciled += 1;
-        }
-        break;
-      }
-      case "accepted_pending_activation":
-      case "activating": {
-        await activateAcceptedPurchase(db, purchase.id, signal, true);
-        reconciled += 1;
-        break;
-      }
-      case "refund_pending":
-      case "refunding": {
-        await refundPurchase(db, purchase.id, true);
-        reconciled += 1;
-        break;
-      }
-      case "checkout_pending":
-      case "accepted":
-      case "refunded":
-      case "failed": {
-        break;
-      }
+    const result = await settle(
+      reconcileUsagePackInvitationPurchaseCandidate(
+        db,
+        clerk,
+        purchase,
+        at,
+        signal,
+      ),
+      signal,
+    );
+    if (!result.ok) {
+      L.error("usage pack invitation purchase reconciliation failed", {
+        purchaseId: purchase.id,
+        orgId: purchase.orgId,
+        clerkInvitationId: purchase.clerkInvitationId,
+        status: purchase.status,
+        error: result.error,
+      });
+      continue;
     }
-    signal.throwIfAborted();
+    if (result.value) {
+      reconciled += 1;
+    }
   }
   return reconciled;
 }

--- a/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
@@ -25,6 +25,7 @@ import {
   sql,
 } from "drizzle-orm";
 import { pgBooleanDecoder } from "../../lib/db-structured-result";
+import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
 import {
@@ -43,6 +44,7 @@ import {
   type StripeSubscriptionScheduleUpdateParams,
   type StripeSubscriptionUpdateItemParam,
 } from "../external/stripe-client";
+import { settle } from "../utils";
 import {
   calculateUsagePackAdditionCreditGrant,
   calculateUsagePackUpgradeCreditGrants,
@@ -72,6 +74,7 @@ import {
 const PREVIEW_TTL_MS = 15 * 60 * 1000;
 const RECONCILIATION_DELAY_MS = 5 * 60 * 1000;
 const PAYMENT_CONFIRMATION_TTL_MS = 24 * 60 * 60 * 1000;
+const L = logger("UsagePackPlanChange");
 const OPEN_ALLOCATION_CHANGE_STATUSES = [
   "previewed",
   "applying",
@@ -3552,18 +3555,30 @@ export async function reconcileUsagePackSubscriptionChanges(
   const orgIds = new Set<string>();
   let reconciled = expiredCount;
   for (const root of candidates) {
-    const reconciledOrgId = await reconcileSubscriptionChangeCandidate(
-      db,
-      {
-        root,
-        at,
-        paymentExpiredBefore,
-      },
+    const result = await settle(
+      reconcileSubscriptionChangeCandidate(
+        db,
+        {
+          root,
+          at,
+          paymentExpiredBefore,
+        },
+        signal,
+      ),
       signal,
     );
-    if (reconciledOrgId) {
+    if (!result.ok) {
+      L.error("usage pack subscription change reconciliation failed", {
+        subscriptionChangeId: root.id,
+        orgId: root.orgId,
+        usagePackSubscriptionId: root.usagePackSubscriptionId,
+        error: result.error,
+      });
+      continue;
+    }
+    if (result.value) {
       reconciled += 1;
-      orgIds.add(reconciledOrgId);
+      orgIds.add(result.value);
     }
   }
   return { reconciled, orgIds: [...orgIds] };

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
@@ -33,12 +33,14 @@ import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
 import {
   getStripeClient,
+  listAllStripeSubscriptions,
   type StripeClient,
   type StripeInvoice,
   type StripeMetadataParam,
   type StripePrice,
   type StripeSubscription,
 } from "../external/stripe-client";
+import { settle } from "../utils";
 import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
 import { persistOrgAcquisitionAttribution$ } from "./acquisition-attribution.service";
 import { upsertOrgPlanEntitlement } from "./org-plan-entitlements.service";
@@ -1487,19 +1489,18 @@ async function existingUsagePackPurchaseResult(
   ) {
     return { status: "invalid_preview" };
   }
-  const subscriptions = await stripe.subscriptions.list({
-    customer: preview.customerId,
-    status: "all",
-    limit: 100,
-  });
-  signal.throwIfAborted();
-  const existingSummary = subscriptions.data.find((candidate) => {
+  const subscriptions = await listAllStripeSubscriptions(
+    stripe,
+    { customer: preview.customerId, status: "all" },
+    signal,
+  );
+  const existingSummary = subscriptions.find((candidate) => {
     return (
       candidate.metadata?.[USAGE_PACK_SUBSCRIPTION_ID_METADATA_KEY] ===
       preview.usagePackSubscriptionId
     );
   });
-  const competing = subscriptions.data.some((candidate) => {
+  const competing = subscriptions.some((candidate) => {
     return (
       candidate.id !== preview.sourceSubscriptionId &&
       candidate.metadata?.orgId === orgId &&
@@ -3593,15 +3594,28 @@ export async function reconcileUsagePackSubscriptions(
   let reconciled =
     subscriptionChanges.reconciled + allocationChanges.reconciled;
   for (const candidate of candidates) {
-    const result = await reconcileUsagePackSubscriptionCandidate(
-      db,
-      stripe,
-      candidate,
-      pendingSnapshotStaleBefore,
+    const result = await settle(
+      reconcileUsagePackSubscriptionCandidate(
+        db,
+        stripe,
+        candidate,
+        pendingSnapshotStaleBefore,
+        signal,
+      ),
       signal,
     );
-    reconciled += result.reconciled;
-    for (const orgId of result.orgIds) {
+    if (!result.ok) {
+      L.error("usage pack subscription reconciliation failed", {
+        usagePackSubscriptionId: candidate.id,
+        orgId: candidate.orgId,
+        stripeSubscriptionId: candidate.stripeSubscriptionId,
+        stripeCheckoutSessionId: candidate.stripeCheckoutSessionId,
+        error: result.error,
+      });
+      continue;
+    }
+    reconciled += result.value.reconciled;
+    for (const orgId of result.value.orgIds) {
       orgIds.add(orgId);
     }
   }

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -49,7 +49,10 @@ import {
 import { nowDate } from "../../lib/time";
 import { publishCancelToRunnerGroup } from "../external/realtime";
 import { deleteWebhook } from "../external/telegram-client";
-import { getStripeClient } from "../external/stripe-client";
+import {
+  getStripeClient,
+  listAllStripeSubscriptions,
+} from "../external/stripe-client";
 import { settle, tapError } from "../utils";
 import { decryptPersistentSecretValue } from "./crypto.utils";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
@@ -271,26 +274,12 @@ async function cancelStripeSubscriptionsForDeletedOrg(
   };
 
   if (meta.stripeCustomerId) {
-    let startingAfter: string | undefined;
-
-    while (true) {
-      const subscriptions = await stripe.subscriptions.list({
-        customer: meta.stripeCustomerId,
-        status: "all",
-        limit: 100,
-        ...(startingAfter ? { starting_after: startingAfter } : {}),
-      });
-
-      for (const subscription of subscriptions.data) {
-        queueStripeSubscriptionCleanup(targets, subscription);
-      }
-
-      const lastSubscription =
-        subscriptions.data[subscriptions.data.length - 1];
-      if (!subscriptions.has_more || !lastSubscription) {
-        break;
-      }
-      startingAfter = lastSubscription.id;
+    const subscriptions = await listAllStripeSubscriptions(stripe, {
+      customer: meta.stripeCustomerId,
+      status: "all",
+    });
+    for (const subscription of subscriptions) {
+      queueStripeSubscriptionCleanup(targets, subscription);
     }
   }
 

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -20,6 +20,7 @@ import { writeDb$, type Db } from "../external/db";
 import {
   getStripeClient,
   isStripeResourceMissingError,
+  listAllStripeSubscriptions,
   type StripeCheckoutSession,
   type StripeInvoice,
   type StripePaymentIntent,
@@ -3160,13 +3161,12 @@ async function replacedPlanSubscriptionIdsForCustomer(args: {
   }
 
   const stripe = getStripeClient();
-  const subscriptions = await stripe.subscriptions.list({
+  const subscriptions = await listAllStripeSubscriptions(stripe, {
     customer: args.customerId,
     status: "all",
-    limit: 100,
   });
 
-  return subscriptions.data
+  return subscriptions
     .filter((subscription) => {
       return isReplaceablePlanSubscription({
         newSubscriptionId: args.newSubscriptionId,
@@ -3255,13 +3255,12 @@ async function replacedAtomGrantSubscriptionIdsForCustomer(args: {
   readonly customerId: string;
 }): Promise<readonly string[]> {
   const stripe = getStripeClient();
-  const subscriptions = await stripe.subscriptions.list({
+  const subscriptions = await listAllStripeSubscriptions(stripe, {
     customer: args.customerId,
     status: "all",
-    limit: 100,
   });
 
-  return subscriptions.data
+  return subscriptions
     .filter((subscription) => {
       return isReplaceablePaidSubscriptionForAtomGrant(subscription);
     })


### PR DESCRIPTION
## Summary

- create and retry invoice-backed Stripe Refunds before issuing the linked Credit Note, including legacy issued-Credit-Note recovery, a three-attempt cap, and actionable terminal logging
- isolate usage-pack subscription, change, refund, and invitation reconciliation per candidate so one malformed record does not block later work
- route every billing Subscription list through one complete Stripe pagination helper

## Fallbacks

- `turbo/apps/api/src/signals/services/usage-pack-credit-refund.service.ts:processInvoiceRefund` / `retryableFailedInvoiceRefundCondition` — lets the new API recover failed invoice-refund rows written by the previous API after it had already issued the Stripe Credit Note. Surface: backend persisted state / DB-API rollout, up to the documented ~102-minute maximum exposure plus the time needed to drain legacy rows. Remove after the previous API is outside the drain and rollback window and a production-safe query shows zero unresolved invoice refunds with an existing Credit Note; follow-up #28580.

## Testing

- `pnpm -F api run check-types:gateways`
- `pnpm -F api run check-types:core`
- `pnpm -F api run check-types:tests`
- targeted Oxlint, type-aware Oxlint, and ESLint on all changed files
- targeted billing integration tests were attempted, but the local PostgreSQL test service was unavailable on port 5432; the PR pipeline will run them
