### PR TITLE
docs(rust): document session history probe telemetry semantics

### DIFF
--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -12,6 +12,24 @@
 //! single point that consumes the task result, and cancellation takes priority
 //! over a completed download so cancelled runs do not proceed into restore.
 //!
+//! `SessionHistoryProbe` is runner-process-local, in-memory telemetry
+//! observation for hash-backed references. It does not cache session-history
+//! bytes, suppress or deduplicate downloads, or coordinate observations across
+//! runners. A reference identity is the tuple of hash, encoding, raw size, and
+//! encoded size; URL and download source are not part of that identity. The
+//! default probe treats observations as recent for one hour and bounds the
+//! tracked set to 4,096 identities.
+//!
+//! Probe observations are sampled before the current materializer registers its
+//! download. `session_history_ref_seen_recently` therefore reports whether a
+//! matching identity had a prior observation within the probe window, while
+//! `session_history_ref_download_inflight` reports whether a prior matching
+//! registration was active at that sampling point. Expiry and bounded capacity
+//! eviction make both fields best-effort signals; they do not establish byte
+//! availability or authoritative global activity. Registrations are released
+//! through the shared guard across task completion, cancellation, task abort,
+//! and materializer or guard drop.
+//!
 //! Download diagnostics must not expose presigned URL query strings, and the
 //! downloaded bytes must satisfy the declared size, byte cap, and hash contract
 //! before they are restored into the sandbox.
@@ -56,6 +74,13 @@ pub(crate) struct SessionHistoryMaterializer {
     state: SessionHistoryMaterializerState,
 }
 
+/// Runner-process-local, in-memory observation of session-history ref activity.
+///
+/// The probe exists only to annotate download telemetry. It does not store
+/// history bytes, suppress downloads, deduplicate requests, or share state
+/// across runners. Its default one-hour observation window and 4,096-entry
+/// capacity bound the state, so observations can be lost through expiry or
+/// eviction and must be interpreted as best-effort signals.
 #[derive(Clone)]
 pub(crate) struct SessionHistoryProbe {
     inner: Arc<Mutex<SessionHistoryProbeState>>,

--- a/crates/runner/src/telemetry/session_history.rs
+++ b/crates/runner/src/telemetry/session_history.rs
@@ -9,6 +9,12 @@ use crate::types::{
     SessionHistorySizeBucket,
 };
 
+/// Low-cardinality session-history telemetry fields emitted with a sandbox op.
+///
+/// The ref observation fields are produced by the runner-local
+/// [`SessionHistoryProbe`](crate::executor::SessionHistoryProbe). They describe
+/// probe state at materializer start, not a storage-cache hit or global
+/// download coordination state.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 pub(crate) struct SessionHistoryTelemetryFields {
     encoding: &'static str,
@@ -22,11 +28,15 @@ pub(crate) struct SessionHistoryTelemetryFields {
         rename = "session_history_ref_seen_recently",
         skip_serializing_if = "Option::is_none"
     )]
+    /// Whether a matching ref identity had a prior observation within the
+    /// probe's one-hour default window at materializer start.
     ref_seen_recently: Option<&'static str>,
     #[serde(
         rename = "session_history_ref_download_inflight",
         skip_serializing_if = "Option::is_none"
     )]
+    /// Whether a prior matching probe registration was active before the
+    /// current materializer registered its own download.
     ref_download_inflight: Option<&'static str>,
     #[serde(
         rename = "session_history_content_length_state",
@@ -61,6 +71,21 @@ pub(crate) struct SessionHistoryTelemetryMetadata {
     response: Option<SessionHistoryResponseTelemetryMetadata>,
 }
 
+/// Best-effort, runner-local observation attached to a session-history download.
+///
+/// The probe identity is the tuple of hash, encoding, raw size, and encoded
+/// size. URL and download source are not part of the identity. The default
+/// probe retains observations for one hour and tracks at most 4,096 identities;
+/// expiry and capacity eviction can therefore make either observation false,
+/// including for an entry that was previously active. This metadata does not
+/// indicate that history bytes are cached or that a download was suppressed.
+///
+/// Both values are sampled before the current materializer adds its
+/// registration. `seen_recently` means that the prior matching entry was seen
+/// within the observation window. `download_inflight` means that the prior
+/// matching entry had an active registration at that moment. Registrations are
+/// cleared by the materializer/worker lifecycle and shared guard cleanup on
+/// completion, cancellation, abort, and drop.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct SessionHistoryCacheProbeMetadata {
     seen_recently: bool,

--- a/crates/runner/src/telemetry/session_history.rs
+++ b/crates/runner/src/telemetry/session_history.rs
@@ -75,10 +75,11 @@ pub(crate) struct SessionHistoryTelemetryMetadata {
 ///
 /// The probe identity is the tuple of hash, encoding, raw size, and encoded
 /// size. URL and download source are not part of the identity. The default
-/// probe retains observations for one hour and tracks at most 4,096 identities;
-/// expiry and capacity eviction can therefore make either observation false,
-/// including for an entry that was previously active. This metadata does not
-/// indicate that history bytes are cached or that a download was suppressed.
+/// probe uses one hour as its recent-observation window and tracks at most
+/// 4,096 identities; expiry and capacity eviction can therefore make either
+/// observation false, including for an entry that was previously active. This
+/// metadata does not indicate that history bytes are cached or that a download
+/// was suppressed.
 ///
 /// Both values are sampled before the current materializer adds its
 /// registration. `seen_recently` means that the prior matching entry was seen


### PR DESCRIPTION
## Summary

- Document `SessionHistoryProbe` as runner-process-local, in-memory telemetry observation rather than a byte cache or download deduplicator.
- Define the ref identity, one-hour recent-observation window, 4,096-entry bound, observation ordering, and best-effort expiry/eviction behavior.
- Document the serialized probe fields and registration cleanup lifecycle across completion, cancellation, abort, and drop.

## Scope

This is a documentation-only change in the runner crate. Runtime algorithms, constructors, tests, serialized field names and values, API contracts, and download behavior are unchanged.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check` ✅
- `cargo check --manifest-path crates/Cargo.toml -p runner` ✅
- `CARGO_BUILD_JOBS=1 CARGO_PROFILE_DEV_DEBUG=0 cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps` ✅
- `cargo test --manifest-path crates/Cargo.toml -p runner probe_` could not complete in this environment: the normal test build is blocked by the pre-existing unused `AsyncReadExt` import at `crates/runner/src/network_logs.rs:716`, and a warning-relaxed, low-debug retry reached test linking but was killed with exit 137 under the 3.8 GiB/no-swap environment.
- Final diff inspection confirms only the two planned Rust source files changed.

Closes #28564
