### PR TITLE
style(chat): lighten the start card thumbnail wash

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-start-cards.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-start-cards.tsx
@@ -50,11 +50,17 @@ function kindAccent(kind: StartCardKind): string {
   }
 }
 
-// One colour per kind, laid down at four strengths: the tile wash, the rules
-// and edges, the muted marks, and the solid shapes. Nothing inside a tile is
-// grey — a neutral border reads as a different material from the wash it sits
-// on, so every edge is the same colour a few steps darker.
-const TILE_ALPHA = "24";
+// One colour per kind, laid down at five strengths: the tile wash, the bands
+// filled inside a drawing, the rules and edges, the muted marks, and the solid
+// shapes. Nothing inside a tile is grey — a neutral border reads as a different
+// material from the wash it sits on, so every edge is the same colour a few
+// steps darker.
+//
+// The wash is the largest area of colour on the page — three 72px squares in a
+// row — so it is the one strength that carries no drawing and is laid down
+// lighter than the bands inside the art, which have white paper under them.
+const TILE_ALPHA = "1A";
+const BAND_ALPHA = "24";
 const LINE_ALPHA = "59";
 const SOFT_ALPHA = "40";
 const FILL_ALPHA = "8C";
@@ -100,7 +106,7 @@ function WebsiteArt({ accent }: { accent: string }) {
         className="flex h-[10px] items-center gap-[2px] border-b px-[3px]"
         style={{
           borderColor: `${accent}${LINE_ALPHA}`,
-          backgroundColor: `${accent}${TILE_ALPHA}`,
+          backgroundColor: `${accent}${BAND_ALPHA}`,
         }}
       >
         <span


### PR DESCRIPTION
## What

The start card thumbnail slot laid its kind accent down at 14% (`TILE_ALPHA = "24"`). Three 72px squares in a row is the largest area of colour on the home page, so the row read as colour blocks before it read as titles. This drops the wash to 10% (`"1A"`).

The old constant was shared with the browser chrome bar inside the website drawing, which sits on white paper rather than on the card, so it is split onto its own `BAND_ALPHA` and keeps its previous strength.

## Before / after

Rendered from the real tokens (0.7px `gray-400` border, `--zero-card-radius`, platform type scale) at four strengths — A is today, B is this PR:

![tile wash comparison](https://cdn.vm0.io/artifacts/xxcq10c3oy.png)

Removing the wash entirely was also on the table (D). It loses the shared 72px slot the differently-sized drawings align inside, and the slides/website art is white paper on a white card, so it was not taken.

## Note

#28549 refactors the same component; the two touch different lines, but that PR should land first if both are open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)