### PR TITLE
test(guest-agent): stabilize connect-timeout classification

### DIFF
--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -137,7 +137,11 @@ impl HttpClient {
     /// [`Self::for_config`] for production guest-agent initialization.
     #[doc(hidden)]
     pub fn with_retry_delay(retry_delay: Duration) -> Result<Self, AgentError> {
-        Self::build(None, retry_delay)
+        Self::build(
+            None,
+            retry_delay,
+            Duration::from_secs(constants::HTTP_CONNECT_TIMEOUT_SECS),
+        )
     }
 
     #[doc(hidden)]
@@ -148,6 +152,29 @@ impl HttpClient {
         client_session_id: impl Into<String>,
         retry_delay: Duration,
     ) -> Result<Self, AgentError> {
+        Self::with_api_config_and_connect_timeout(
+            base_url,
+            token,
+            vercel_bypass,
+            client_session_id,
+            retry_delay,
+            Duration::from_secs(constants::HTTP_CONNECT_TIMEOUT_SECS),
+        )
+    }
+
+    /// Build an API-configured client with a custom connection timeout.
+    ///
+    /// Integration tests use this to exercise stalled connection setup without
+    /// advancing the runtime's global clock.
+    #[doc(hidden)]
+    pub fn with_api_config_and_connect_timeout(
+        base_url: impl Into<String>,
+        token: impl Into<String>,
+        vercel_bypass: impl Into<String>,
+        client_session_id: impl Into<String>,
+        retry_delay: Duration,
+        connect_timeout: Duration,
+    ) -> Result<Self, AgentError> {
         Self::build(
             Some(ApiHttpConfig::new(
                 base_url.into(),
@@ -156,12 +183,17 @@ impl HttpClient {
                 client_session_id.into(),
             )?),
             retry_delay,
+            connect_timeout,
         )
     }
 
-    fn build(api: Option<ApiHttpConfig>, retry_delay: Duration) -> Result<Self, AgentError> {
+    fn build(
+        api: Option<ApiHttpConfig>,
+        retry_delay: Duration,
+        connect_timeout: Duration,
+    ) -> Result<Self, AgentError> {
         let inner = Client::builder()
-            .connect_timeout(Duration::from_secs(constants::HTTP_CONNECT_TIMEOUT_SECS))
+            .connect_timeout(connect_timeout)
             .timeout(Duration::from_secs(constants::HTTP_TIMEOUT_SECS))
             .build()
             .map_err(|e| {
@@ -204,7 +236,11 @@ impl HttpClient {
                 DEFAULT_RETRY_DELAY
             }
         };
-        Self::build(Some(api), retry_delay)
+        Self::build(
+            Some(api),
+            retry_delay,
+            Duration::from_secs(constants::HTTP_CONNECT_TIMEOUT_SECS),
+        )
     }
 
     pub fn has_api(&self) -> bool {

--- a/crates/guest-agent/tests/event_delivery_transport_classification.rs
+++ b/crates/guest-agent/tests/event_delivery_transport_classification.rs
@@ -9,8 +9,6 @@ use guest_contracts::diagnostics::{
 };
 use serde_json::json;
 use std::io;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 #[tokio::test]
@@ -159,13 +157,14 @@ async fn run_connect_timeout_failure() -> Result<EventDeliveryDiagnostic, Box<dy
     let tmp = tempfile::tempdir()?;
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let base_url = format!("https://{}", listener.local_addr()?);
-    let accepted_count = Arc::new(AtomicUsize::new(0));
-    let server_accepted_count = Arc::clone(&accepted_count);
+    let (accepted_tx, mut accepted_rx) = tokio::sync::mpsc::unbounded_channel();
     let server = tokio::spawn(async move {
         let mut connections = Vec::new();
         while let Ok((connection, _)) = listener.accept().await {
-            server_accepted_count.fetch_add(1, Ordering::SeqCst);
             connections.push(connection);
+            if accepted_tx.send(()).is_err() {
+                break;
+            }
         }
     });
     let prompt = format!(
@@ -180,15 +179,16 @@ async fn run_connect_timeout_failure() -> Result<EventDeliveryDiagnostic, Box<dy
     }
     let mut runtime = common::guest_runtime_from_process_env()?;
     let run_id = runtime.config.run_id.clone();
-    runtime.http = guest_agent::http::HttpClient::with_api_config(
+    runtime.http = guest_agent::http::HttpClient::with_api_config_and_connect_timeout(
         &base_url,
         "test-token",
         "",
         run_id,
         Duration::ZERO,
+        Duration::from_millis(250),
     )?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
-    let execution = tokio::spawn(async move {
+    let mut execution = tokio::spawn(async move {
         common::execute_cli_for_runtime(
             &runtime,
             &SecretMasker::from_raw(""),
@@ -197,30 +197,25 @@ async fn run_connect_timeout_failure() -> Result<EventDeliveryDiagnostic, Box<dy
         .await
     });
 
-    tokio::time::timeout(Duration::from_secs(5), async {
-        while accepted_count.load(Ordering::SeqCst) == 0 {
-            tokio::task::yield_now().await;
+    let bounded_execution = tokio::time::timeout(Duration::from_secs(5), async {
+        for attempt in 1..=3 {
+            accepted_rx.recv().await.ok_or_else(|| {
+                io::Error::other(format!(
+                    "connect-timeout server stopped before accepting attempt {attempt}"
+                ))
+            })?;
         }
+        Ok::<_, io::Error>((&mut execution).await)
     })
-    .await
-    .map_err(|_| io::Error::other("connect-timeout server accepted no request"))?;
-
-    tokio::time::pause();
-    for _ in 0..35 {
-        if execution.is_finished() {
-            break;
-        }
-        tokio::time::advance(Duration::from_secs(1)).await;
-        tokio::task::yield_now().await;
-    }
-    assert!(
-        execution.is_finished(),
-        "connect-timeout delivery should exhaust three attempts"
-    );
-    assert_eq!(accepted_count.load(Ordering::SeqCst), 3);
-    let joined = execution.await;
-    tokio::time::resume();
+    .await;
+    execution.abort();
     server.abort();
+    let joined = bounded_execution
+        .map_err(|_| io::Error::other("connect-timeout delivery exceeded its retry budget"))??;
+    assert!(
+        accepted_rx.try_recv().is_err(),
+        "connect-timeout delivery should make exactly three attempts"
+    );
     let result = joined??;
 
     result


### PR DESCRIPTION
## Summary

- let GuestAgent integration tests configure a short real HTTP connect timeout while every existing constructor keeps the production timeout
- synchronize the stalled loopback TLS scenario on three accepted connections and bounded task completion
- remove global Tokio time advancement and `JoinHandle::is_finished()` sampling from the flaky classification test

## Problem

The coverage job could report that connect-timeout delivery had not exhausted its attempts even after logging all three failed HTTP attempts and `Event delivery complete`. The test advanced the global virtual clock with one scheduler yield per step, then sampled task completion. That timing also crossed unrelated CLI post-result cleanup deadlines and produced SIGTERM/SIGKILL activity.

## Compatibility and scope

- production connect timeout remains 10 seconds
- production request timeout, retry count, retry delay, acknowledgement, and diagnostic behavior are unchanged
- no API, wire, schema, migration, persisted-state, runner, or deployment changes
- connect-only and transport-only classification scenarios remain unchanged

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test event_delivery_transport_classification`
- 25 repeated focused test runs
- 10 repeated coverage-instrumented focused test runs with `cargo llvm-cov`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- repository pre-commit and commit-message hooks

Closes #28572
