### PR TITLE
fix(runner): recover evicted websocket usage pricing

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -174,8 +174,11 @@ Model-provider usage
 - ``MODEL_PROVIDER_USAGE_TIERS``: bounded insertion-ordered mapping from
   WebSocket response id to the concrete billing tier decision selected from
   its input partition. Zero-only decisions remain provisional until the first
-  positive billing item. Written by model-provider billing and cleared at the
-  WebSocket terminal lifecycle boundary.
+  positive billing item. Evicted decisions can be recovered while their
+  concrete source keys remain in the separately bounded usage admission
+  history; otherwise positive usage uses a conservative tier. Written by
+  model-provider billing and cleared at the WebSocket terminal lifecycle
+  boundary.
 - ``MODEL_USAGE_PROVIDER``: optional ``str`` canonical model id from registry VM
   info. Read by model-provider usage observability and reported-model selection.
 - ``MODEL_JSON_USAGE_FINALIZED``: ``bool`` written when JSON usage finalization

--- a/crates/runner/mitm-addon/src/usage/buffer/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/__init__.py
@@ -64,6 +64,7 @@ __all__ = [
     "drain_usage_events_after_executor_shutdown",
     "flush_usage_events",
     "reset_usage_buffer_for_tests",
+    "seen_source_idempotency_keys",
 ]
 
 _usage_event_buffer = UsageEventBuffer()
@@ -188,6 +189,11 @@ def flush_usage_events(*, trigger: UsageFlushTrigger) -> int:
     schedule another timer.
     """
     return _usage_event_buffer.flush_usage_events(trigger=trigger)
+
+
+def seen_source_idempotency_keys(source_keys: Iterable[str]) -> set[str]:
+    """Return candidate source keys retained by process-local admission history."""
+    return _usage_event_buffer.seen_source_idempotency_keys(source_keys)
 
 
 def drain_usage_events_after_executor_shutdown() -> None:

--- a/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
@@ -205,6 +205,11 @@ class UsageEventBuffer:
         """
         return self._flush_usage_events(trigger=trigger)
 
+    def seen_source_idempotency_keys(self, source_keys: Iterable[str]) -> set[str]:
+        """Return candidate source keys retained by admission history."""
+        with self._lock:
+            return self._state.seen_source_idempotency_keys(source_keys)
+
     def drain_usage_events_after_executor_shutdown(self) -> None:
         """Synchronously drain work retained by completed executor callbacks.
 

--- a/crates/runner/mitm-addon/src/usage/buffer/state.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/state.py
@@ -302,6 +302,10 @@ class _UsageBufferState:
         while len(self._seen_source_keys) > MAX_SOURCE_IDEMPOTENCY_KEYS:
             self._seen_source_keys.popitem(last=False)
 
+    def seen_source_idempotency_keys(self, source_keys: Iterable[str]) -> set[str]:
+        """Return candidate source keys retained by admission history."""
+        return {source_key for source_key in source_keys if source_key in self._seen_source_keys}
+
     def should_flush(self) -> bool:
         if self._source_event_count >= MAX_BUFFERED_SOURCE_EVENTS:
             return True

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -39,6 +39,7 @@ from ..buffer import (
     buffer_source_model_usage_observations,
     buffer_source_usage_events,
     buffer_usage_events,
+    seen_source_idempotency_keys,
 )
 from ..idempotency import (
     USAGE_EVENT_NAMESPACE_MODEL,
@@ -248,8 +249,10 @@ def report_model_provider_usage_source(
     returns: observable flows carry the canonical ``MODEL_USAGE_PROVIDER``, so
     zero-usage source model hints do not need to be retained for later
     same-response-id frames. Tiered models retain only their bounded concrete
-    tier decision so later or duplicate output-only frames derive the same
-    billable category.
+    tier decision. Evicted decisions are recovered from bounded source-key
+    admission history when possible so later or duplicate output-only frames
+    derive the same billable category; otherwise positive usage receives a
+    conservative billable fallback.
     """
     usage_events: list[UsageEvent] = []
     observations: list[ModelUsageObservation] = []
@@ -260,14 +263,13 @@ def report_model_provider_usage_source(
     if can_report_usage:
         pricing = _source_model_usage_pricing(
             flow,
+            run_id,
+            source_id,
             message_id,
             provider,
             source_usage,
         )
-        if pricing is None:
-            if has_positive_model_provider_usage(source_usage):
-                _log_model_usage_tier_unresolved(flow, run_id, provider)
-        else:
+        if pricing is not None:
             billing_tier, fast = pricing
             usage_events = _build_usage_events(
                 run_id,
@@ -780,6 +782,8 @@ def _build_usage_events(
 
 def _source_model_usage_pricing(
     flow: http.HTTPFlow,
+    run_id: str,
+    source_id: str,
     message_id: str,
     provider: str,
     usage: dict,
@@ -806,7 +810,29 @@ def _source_model_usage_pricing(
         tiers.move_to_end(message_id)
         return tier, fast
     if billing_tier is None:
-        return None
+        if not has_positive_model_provider_usage(usage):
+            return None
+        recovered_pricing = _recover_source_model_usage_pricing(run_id, source_id)
+        billing_tier, fast = recovered_pricing or (
+            _MODEL_USAGE_TIER_LONG_CONTEXT,
+            observed_fast is True,
+        )
+        if recovered_pricing is None:
+            _log_model_usage_tier_fallback(
+                flow,
+                run_id,
+                provider,
+                billing_tier,
+                fast,
+            )
+        tiers[message_id] = _ModelUsageTierDecision(
+            tier=billing_tier,
+            fast=fast,
+            committed=True,
+        )
+        if len(tiers) > _MODEL_PROVIDER_USAGE_TIER_SOURCE_LIMIT:
+            tiers.popitem(last=False)
+        return billing_tier, fast
 
     tiers[message_id] = _ModelUsageTierDecision(
         tier=billing_tier,
@@ -816,6 +842,32 @@ def _source_model_usage_pricing(
     if len(tiers) > _MODEL_PROVIDER_USAGE_TIER_SOURCE_LIMIT:
         tiers.popitem(last=False)
     return billing_tier, observed_fast is True
+
+
+def _recover_source_model_usage_pricing(
+    run_id: str,
+    source_id: str,
+) -> tuple[_ModelUsageTier, bool] | None:
+    pricing_by_source_key: dict[str, tuple[_ModelUsageTier, bool]] = {
+        derive_usage_idempotency_key(
+            USAGE_EVENT_NAMESPACE_MODEL,
+            (
+                run_id,
+                source_id,
+                _billable_model_usage_category(category, billing_tier, fast),
+            ),
+        ): (billing_tier, fast)
+        for category in MODEL_USAGE_CATEGORIES
+        for billing_tier in (_MODEL_USAGE_TIER_BASE, _MODEL_USAGE_TIER_LONG_CONTEXT)
+        for fast in (False, True)
+    }
+    seen_keys = seen_source_idempotency_keys(pricing_by_source_key)
+    if not seen_keys:
+        return None
+    decisions = {pricing_by_source_key[source_key] for source_key in seen_keys}
+    if len(decisions) != 1:
+        raise RuntimeError("Model usage source keys resolved to conflicting pricing decisions")
+    return decisions.pop()
 
 
 def _model_provider_usage_tiers(
@@ -873,6 +925,26 @@ def _log_model_usage_tier_unresolved(
         "risk",
         run_id=run_id,
         provider=provider,
+    )
+
+
+def _log_model_usage_tier_fallback(
+    flow: http.HTTPFlow,
+    run_id: str,
+    provider: str,
+    billing_tier: _ModelUsageTier,
+    fast: bool,
+) -> None:
+    log_usage_underbilling(
+        flow_metadata.proxy_log_path(flow.metadata),
+        "Billing tiered model usage with a conservative category fallback",
+        "model_long_context_tier_unresolved",
+        "risk",
+        run_id=run_id,
+        provider=provider,
+        usage_billed=True,
+        fallback_billing_tier=billing_tier,
+        fallback_fast=fast,
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage_aggregation.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage_aggregation.py
@@ -47,6 +47,14 @@ def _openai_websocket_zero_usage_frame(response_id: str, *, model: str | None = 
     ).encode()
 
 
+def _pressure_model_usage_tier_state(flow: http.HTTPFlow) -> None:
+    for index in range(100):
+        feed_websocket_server_message(
+            flow,
+            _openai_websocket_zero_usage_frame(f"resp_ws_pressure_{index}"),
+        )
+
+
 class TestModelProviderWebSocketUsageAggregation:
     """Tests for per-response WebSocket usage reconciliation and tiering."""
 
@@ -246,6 +254,154 @@ class TestModelProviderWebSocketUsageAggregation:
         ]
         assert underbilling_entries == []
 
+    def test_model_websocket_late_output_recovers_evicted_long_context_fast_tier(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_server_message(
+                flow,
+                json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_ws_evicted",
+                            "model": "gpt-5.5",
+                            "service_tier": "priority",
+                            "usage": {"input_tokens": 272_001},
+                        },
+                    }
+                ).encode(),
+            )
+            _pressure_model_usage_tier_state(flow)
+
+            tiers = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_TIERS]
+            assert isinstance(tiers, dict)
+            assert len(tiers) == 100
+            assert "resp_ws_evicted" not in tiers
+
+            feed_websocket_server_message(
+                flow,
+                json.dumps(
+                    {
+                        "type": "response.done",
+                        "response": {
+                            "id": "resp_ws_evicted",
+                            "model": "gpt-5.5",
+                            "usage": {"output_tokens": 12},
+                        },
+                    }
+                ).encode(),
+            )
+
+            recovered = tiers["resp_ws_evicted"]
+            assert len(tiers) == 100
+            assert recovered.tier == "long_context"
+            assert recovered.fast is True
+            assert recovered.committed is True
+
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        assert metadata_keys.MODEL_PROVIDER_USAGE_TIERS not in flow.metadata
+        assert_usage_event_rows(
+            webhook.usage_events(),
+            "provider",
+            [
+                ("gpt-5.5", "tokens.input.long_context.fast", 272_001),
+                ("gpt-5.5", "tokens.output.long_context.fast", 12),
+            ],
+        )
+        assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            [
+                ("gpt-5.5", "tokens.input", 272_001),
+                ("gpt-5.5", "tokens.output", 12),
+            ],
+        )
+        underbilling_entries = [
+            entry
+            for entry in read_jsonl_entries_after_flush(
+                Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+            )
+            if entry.get("type") == "usage_underbilling"
+        ]
+        assert underbilling_entries == []
+
+    def test_model_websocket_duplicate_output_recovers_evicted_source_category(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame(
+                    "resp_ws_evicted_duplicate",
+                    input_tokens=20,
+                    output_tokens=12,
+                ),
+            )
+            _pressure_model_usage_tier_state(flow)
+
+            tiers = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_TIERS]
+            assert "resp_ws_evicted_duplicate" not in tiers
+
+            feed_websocket_server_message(
+                flow,
+                json.dumps(
+                    {
+                        "type": "response.done",
+                        "response": {
+                            "id": "resp_ws_evicted_duplicate",
+                            "model": "gpt-5.5",
+                            "usage": {"output_tokens": 7},
+                        },
+                    }
+                ).encode(),
+            )
+
+            recovered = tiers["resp_ws_evicted_duplicate"]
+            assert recovered.tier == "base"
+            assert recovered.fast is False
+            assert recovered.committed is True
+
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        assert_usage_event_rows(
+            webhook.usage_events(),
+            "provider",
+            [
+                ("gpt-5.5", "tokens.input", 20),
+                ("gpt-5.5", "tokens.output", 12),
+            ],
+        )
+        assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            [
+                ("gpt-5.5", "tokens.input", 20),
+                ("gpt-5.5", "tokens.output", 12),
+            ],
+        )
+        duplicate_entry = next(
+            entry
+            for entry in model_usage_source_entries(flow)
+            if entry["usage"] == {"tokens.output": 7}
+        )
+        [duplicate_event] = duplicate_entry["usage_events"]
+        assert duplicate_event["category"] == "tokens.output"
+        assert duplicate_event["buffer_accepted"] is False
+
     def test_model_websocket_explicit_zero_input_selects_base_tier_for_late_output(
         self,
         tmp_path,
@@ -289,7 +445,7 @@ class TestModelProviderWebSocketUsageAggregation:
             [("gpt-5.5", "tokens.output", 12)],
         )
 
-    def test_model_websocket_output_without_input_skips_unclassifiable_billing(
+    def test_model_websocket_output_without_input_uses_conservative_billing_fallback(
         self,
         tmp_path,
         real_flow,
@@ -311,7 +467,11 @@ class TestModelProviderWebSocketUsageAggregation:
             ).encode(),
         )
 
-        assert webhook.usage_events() == []
+        assert_usage_event_rows(
+            webhook.usage_events(),
+            "provider",
+            [("gpt-5.5", "tokens.output.long_context", 12)],
+        )
         assert_usage_event_rows(
             webhook.model_usage_observation_events(),
             "model",
@@ -328,6 +488,9 @@ class TestModelProviderWebSocketUsageAggregation:
         assert entry["underbilling_class"] == "risk"
         assert entry["run_id"] == "run-abc-123"
         assert entry["provider"] == "gpt-5.5"
+        assert entry["usage_billed"] is True
+        assert entry["fallback_billing_tier"] == "long_context"
+        assert entry["fallback_fast"] is False
 
     def test_model_websocket_tier_state_is_bounded_and_terminally_released(
         self,


### PR DESCRIPTION
## Summary

- recover an evicted WebSocket response's exact context and service tier from the usage buffer's existing bounded source-key admission history
- bill positive output with a conservative long-context fallback, plus an uncertainty diagnostic, when neither bounded state store can classify it
- preserve the current source UUID protocol, duplicate suppression, memory bounds, and terminal flow cleanup

## Behavior

The 100-entry flow-local tier map remains the fast path. On a miss for positive output-only usage, the runner derives the possible concrete source keys and inspects the existing 10,000-key admission history under one lock. A retained input-family or output key recovers the original base/long-context and standard/fast decision. The recovered decision is put back into the flow LRU so later frames remain consistent.

If no retained key can classify the source, the runner emits a long-context billable item instead of dropping the usage. Explicit priority/fast evidence is preserved; otherwise the existing standard default is used. The `model_long_context_tier_unresolved` record now shows that conservative billing occurred.

## Scope

- no API payload or database changes
- no idempotency namespace or UUID input changes
- no new cache or increased memory bound
- no frontend or production-pricing changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest -q tests/test_model_provider_websocket_usage_aggregation.py -k 'late_output_recovers_evicted_long_context_fast_tier or duplicate_output_recovers_evicted_source_category or output_without_input_uses_conservative_billing_fallback'` (3 passed)
- `uv run --no-sync python -m pytest -q tests/test_model_provider_websocket_usage_aggregation.py` (24 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (6,444 passed)
- `lefthook run pre-commit`

Closes #28568
