### PR TITLE
perf(guest-agent): bound reuse cleanup memory

### DIFF
--- a/crates/guest-agent/src/nofollow_fs.rs
+++ b/crates/guest-agent/src/nofollow_fs.rs
@@ -5,27 +5,41 @@
 //! `O_NOFOLLOW`, children are opened relative to their parent fd with
 //! `openat`, and directory iteration goes through `/proc/self/fd/{fd}`.
 //!
-//! Callers still own recursive traversal policy and business error
-//! handling. This module should only expose the primitive operations needed
-//! to safely open directories and regular-file candidates.
+//! Recursive removal copies one bounded `getdents64` chunk at a time from the
+//! live directory descriptor. A continuing cursor avoids rescanning removed
+//! slots, and full passes restart from offset zero until one removes nothing.
+//! Callers still own business error handling. This module should only expose
+//! the primitive operations needed to safely open directories and regular-file
+//! candidates.
 
 #[cfg(target_os = "linux")]
-use std::ffi::{CString, OsStr};
+use std::ffi::{CString, OsStr, OsString};
 #[cfg(target_os = "linux")]
 use std::fs::{self, File, OpenOptions};
 #[cfg(target_os = "linux")]
 use std::io;
 #[cfg(target_os = "linux")]
+use std::mem::MaybeUninit;
+#[cfg(target_os = "linux")]
 use std::os::fd::{AsRawFd, FromRawFd};
 #[cfg(target_os = "linux")]
-use std::os::unix::ffi::OsStrExt;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::OpenOptionsExt;
 #[cfg(target_os = "linux")]
 use std::path::{Path, PathBuf};
 
 #[cfg(target_os = "linux")]
-use rustix::fs::{AtFlags, StatxFlags};
+use rustix::fs::{AtFlags, RawDir, SeekFrom, StatxFlags};
+
+#[cfg(target_os = "linux")]
+const REMOVE_RAW_DIR_BUFFER_BYTES: usize = 4 * 1024;
+#[cfg(target_os = "linux")]
+const REMOVE_ENTRY_CHUNK_MAX_NAMES: usize = 256;
+#[cfg(target_os = "linux")]
+const REMOVE_ENTRY_CHUNK_MAX_NAME_BYTES: usize = REMOVE_RAW_DIR_BUFFER_BYTES;
+#[cfg(target_os = "linux")]
+const REMOVE_DIRECTORY_MAX_DEPTH: usize = 256;
 
 #[cfg(target_os = "linux")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -165,42 +179,181 @@ impl Dir {
         unlink_child(&self.0, name, 0)
     }
 
-    pub(crate) fn remove_child_tree(
+    pub(crate) fn remove_children_except(
         &self,
-        name: &OsStr,
+        excluded_names: &[OsString],
         filesystem: FileIdentity,
         protected: &[FileIdentity],
-    ) -> io::Result<()> {
-        match self.open_child_dir(name) {
-            Ok(child) => {
-                let identity = child.identity()?;
-                identity.ensure_same_mount(filesystem)?;
-                if protected.contains(&identity) {
-                    return Err(io::Error::new(
-                        io::ErrorKind::PermissionDenied,
-                        "refusing to remove a protected runtime directory",
-                    ));
-                }
-                let entries = child
-                    .read_dir()?
-                    .map(|entry| entry.map(|entry| entry.file_name()))
-                    .collect::<io::Result<Vec<_>>>()?;
-                for child_name in entries {
-                    child.remove_child_tree(&child_name, filesystem, protected)?;
-                }
-                unlink_child(&self.0, name, libc::AT_REMOVEDIR)
+    ) -> io::Result<u64> {
+        let mut raw_dir_buffer = [MaybeUninit::<u8>::uninit(); REMOVE_RAW_DIR_BUFFER_BYTES];
+        self.remove_children(
+            excluded_names,
+            filesystem,
+            protected,
+            0,
+            &mut raw_dir_buffer,
+        )
+    }
+
+    fn remove_children(
+        &self,
+        excluded_names: &[OsString],
+        filesystem: FileIdentity,
+        protected: &[FileIdentity],
+        depth: usize,
+        raw_dir_buffer: &mut [MaybeUninit<u8>],
+    ) -> io::Result<u64> {
+        let mut removed = 0u64;
+        loop {
+            rustix::fs::seek(&self.0, SeekFrom::Start(0))?;
+            let removed_in_pass = self.remove_children_pass(
+                excluded_names,
+                filesystem,
+                protected,
+                depth,
+                raw_dir_buffer,
+            )?;
+            if removed_in_pass == 0 {
+                return Ok(removed);
             }
-            Err(error)
-                if matches!(
-                    error.raw_os_error(),
-                    Some(libc::ENOTDIR) | Some(libc::ELOOP)
-                ) =>
-            {
-                unlink_child(&self.0, name, 0)
-            }
-            Err(error) => Err(error),
+            removed = removed.saturating_add(removed_in_pass);
         }
     }
+
+    fn remove_children_pass(
+        &self,
+        excluded_names: &[OsString],
+        filesystem: FileIdentity,
+        protected: &[FileIdentity],
+        depth: usize,
+        raw_dir_buffer: &mut [MaybeUninit<u8>],
+    ) -> io::Result<u64> {
+        let mut removed = 0u64;
+        while let Some(names) = self.read_child_chunk(excluded_names, raw_dir_buffer)? {
+            removed = removed.saturating_add(self.remove_child_chunk(
+                names,
+                filesystem,
+                protected,
+                depth,
+                raw_dir_buffer,
+            )?);
+        }
+        Ok(removed)
+    }
+
+    fn read_child_chunk(
+        &self,
+        excluded_names: &[OsString],
+        raw_dir_buffer: &mut [MaybeUninit<u8>],
+    ) -> io::Result<Option<Vec<OsString>>> {
+        loop {
+            let (mut names, reached_end) = {
+                let mut entries = RawDir::new(&self.0, raw_dir_buffer);
+                let mut names = Vec::new();
+                let mut name_bytes = 0usize;
+                let reached_end = loop {
+                    let Some(entry) = entries.next() else {
+                        break true;
+                    };
+                    let entry = entry?;
+                    let bytes = entry.file_name().to_bytes();
+                    if bytes != b"."
+                        && bytes != b".."
+                        && !excluded_names
+                            .iter()
+                            .any(|excluded| excluded.as_bytes() == bytes)
+                    {
+                        if names.len() >= REMOVE_ENTRY_CHUNK_MAX_NAMES {
+                            return Err(entry_chunk_budget_error());
+                        }
+                        let mut name = OsString::from_vec(bytes.to_vec());
+                        name.shrink_to_fit();
+                        name_bytes = name_bytes
+                            .checked_add(name.capacity())
+                            .filter(|bytes| *bytes <= REMOVE_ENTRY_CHUNK_MAX_NAME_BYTES)
+                            .ok_or_else(entry_chunk_budget_error)?;
+                        names.push(name);
+                    }
+                    if entries.is_buffer_empty() {
+                        break false;
+                    }
+                };
+                (names, reached_end)
+            };
+            if !names.is_empty() {
+                names.shrink_to_fit();
+                return Ok(Some(names));
+            }
+            if reached_end {
+                return Ok(None);
+            }
+        }
+    }
+
+    fn remove_child_chunk(
+        &self,
+        names: Vec<OsString>,
+        filesystem: FileIdentity,
+        protected: &[FileIdentity],
+        depth: usize,
+        raw_dir_buffer: &mut [MaybeUninit<u8>],
+    ) -> io::Result<u64> {
+        let mut removed = 0u64;
+        for name in names {
+            match self.open_child_dir(&name) {
+                Ok(child) => {
+                    let child_depth = depth
+                        .checked_add(1)
+                        .filter(|depth| *depth <= REMOVE_DIRECTORY_MAX_DEPTH)
+                        .ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "runtime cleanup directory depth exceeds limit",
+                            )
+                        })?;
+                    let identity = child.identity()?;
+                    identity.ensure_same_mount(filesystem)?;
+                    if protected.contains(&identity) {
+                        return Err(io::Error::new(
+                            io::ErrorKind::PermissionDenied,
+                            "refusing to remove a protected runtime directory",
+                        ));
+                    }
+                    child.remove_children(
+                        &[],
+                        filesystem,
+                        protected,
+                        child_depth,
+                        raw_dir_buffer,
+                    )?;
+                    if unlink_child_if_present(&self.0, &name, libc::AT_REMOVEDIR)? {
+                        removed = removed.saturating_add(1);
+                    }
+                }
+                Err(error)
+                    if matches!(
+                        error.raw_os_error(),
+                        Some(libc::ENOTDIR) | Some(libc::ELOOP)
+                    ) =>
+                {
+                    if unlink_child_if_present(&self.0, &name, 0)? {
+                        removed = removed.saturating_add(1);
+                    }
+                }
+                Err(error) if error.raw_os_error() == Some(libc::ENOENT) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(removed)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn entry_chunk_budget_error() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        "runtime cleanup directory-entry chunk exceeds limit",
+    )
 }
 
 #[cfg(target_os = "linux")]
@@ -264,6 +417,15 @@ fn unlink_child(parent: &File, name: &OsStr, flags: i32) -> io::Result<()> {
         Ok(())
     } else {
         Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn unlink_child_if_present(parent: &File, name: &OsStr, flags: i32) -> io::Result<bool> {
+    match unlink_child(parent, name, flags) {
+        Ok(()) => Ok(true),
+        Err(error) if error.raw_os_error() == Some(libc::ENOENT) => Ok(false),
+        Err(error) => Err(error),
     }
 }
 

--- a/crates/guest-agent/src/nofollow_fs.rs
+++ b/crates/guest-agent/src/nofollow_fs.rs
@@ -3,14 +3,14 @@
 //! This module owns the low-level invariant for opening directory trees
 //! without following symlinks: root directories are opened with
 //! `O_NOFOLLOW`, children are opened relative to their parent fd with
-//! `openat`, and directory iteration goes through `/proc/self/fd/{fd}`.
+//! `openat`, and standard-library directory reads are anchored through
+//! `/proc/self/fd/{fd}`.
 //!
 //! Recursive removal copies one bounded `getdents64` chunk at a time from the
 //! live directory descriptor. A continuing cursor avoids rescanning removed
 //! slots, and full passes restart from offset zero until one removes nothing.
-//! Callers still own business error handling. This module should only expose
-//! the primitive operations needed to safely open directories and regular-file
-//! candidates.
+//! Callers still own business error handling. This module owns the no-follow
+//! filesystem primitives and bounded recursive removal needed by those callers.
 
 #[cfg(target_os = "linux")]
 use std::ffi::{CString, OsStr, OsString};

--- a/crates/guest-agent/src/reuse_preparation.rs
+++ b/crates/guest-agent/src/reuse_preparation.rs
@@ -26,8 +26,11 @@
 //! Runtime paths are opened component by component without following symlinks, and child opens and
 //! deletions are descriptor-relative. Recursive removal refuses to cross filesystem or mount
 //! boundaries, and protected entries are checked by both name and identity so replacement races
-//! cannot redirect deletion through protected state. A symlinked stale entry is unlinked without
-//! following its target. Unsafe path, identity, or mount changes fail closed.
+//! cannot redirect deletion through protected state. Cleanup copies bounded chunks from each live
+//! directory descriptor and verifies every mutating pass with a fresh pass from offset zero; one
+//! shared raw buffer, bounded copied chunks, and fixed traversal depth cap aggregate memory use. A
+//! symlinked stale entry is unlinked without following its target. Unsafe path, identity, mount, or
+//! cleanup resource-limit changes fail closed.
 //!
 //! Request validation and process-containment checks finish before filesystem mutation. Cleanup
 //! itself is not a rollback transaction: once deletion starts, a failure on a later entry,
@@ -213,22 +216,9 @@ fn prepare(
         .iter()
         .map(|entry| entry.name.clone())
         .collect::<Vec<_>>();
-    let entries = parent
-        .read_dir()
-        .map_err(ReusePreparationError::Cleanup)?
-        .map(|entry| entry.map(|entry| entry.file_name()))
-        .collect::<io::Result<Vec<_>>>()
+    let removed_entries = parent
+        .remove_children_except(&protected_names, parent_identity, &protected_identities)
         .map_err(ReusePreparationError::Cleanup)?;
-    let mut removed_entries = 0u64;
-    for name in entries {
-        if protected_names.contains(&name) {
-            continue;
-        }
-        parent
-            .remove_child_tree(&name, parent_identity, &protected_identities)
-            .map_err(ReusePreparationError::Cleanup)?;
-        removed_entries = removed_entries.saturating_add(1);
-    }
 
     for entry in &protected {
         let identity = parent

--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -163,6 +163,135 @@ fn prepare_for_reuse_preserves_generation_when_candidate_runtime_is_absent() -> 
 }
 
 #[test]
+fn prepare_for_reuse_removes_multiple_wide_parent_chunks() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let runs = dir.path().join("runtime/runs");
+    let current = runs.join("current");
+    let retained = runs.join("retained");
+    std::fs::create_dir_all(&current)?;
+    std::fs::create_dir_all(&retained)?;
+    for index in 0..300 {
+        std::fs::write(runs.join(format!("stale-{index:04}")), b"stale")?;
+    }
+
+    let output = run_helper(&ReusePreparationRequest {
+        current_runtime_dir: path_string(&current),
+        retained_runtime_dir: Some(path_string(&retained)),
+    })?;
+
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report = serde_json::from_slice::<ReusePreparationReport>(&output.stdout)?;
+    assert_eq!(report.removed_entries, 300);
+    assert!(current.exists());
+    assert!(retained.exists());
+    assert_eq!(std::fs::read_dir(&runs)?.count(), 2);
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_removes_nested_wide_chunks() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let runs = dir.path().join("runtime/runs");
+    let current = runs.join("current");
+    let stale = runs.join("stale");
+    let nested = stale.join("nested");
+    std::fs::create_dir_all(&current)?;
+    std::fs::create_dir_all(&nested)?;
+    for index in 0..300 {
+        std::fs::write(stale.join(format!("outer-{index:04}")), b"stale")?;
+        std::fs::write(nested.join(format!("inner-{index:04}")), b"stale")?;
+    }
+
+    let output = run_helper(&ReusePreparationRequest {
+        current_runtime_dir: path_string(&current),
+        retained_runtime_dir: None,
+    })?;
+
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report = serde_json::from_slice::<ReusePreparationReport>(&output.stdout)?;
+    assert_eq!(report.removed_entries, 1);
+    assert!(current.exists());
+    assert!(!stale.exists());
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_removes_tree_at_cleanup_depth_limit() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let runs = dir.path().join("runtime/runs");
+    let current = runs.join("current");
+    let stale = runs.join("stale");
+    std::fs::create_dir_all(&current)?;
+    std::fs::create_dir_all(&stale)?;
+    let mut deepest = stale.clone();
+    for _ in 1..256 {
+        deepest.push("nested");
+        std::fs::create_dir(&deepest)?;
+    }
+    std::fs::write(deepest.join("stale"), b"stale")?;
+
+    let output = run_helper(&ReusePreparationRequest {
+        current_runtime_dir: path_string(&current),
+        retained_runtime_dir: None,
+    })?;
+
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report = serde_json::from_slice::<ReusePreparationReport>(&output.stdout)?;
+    assert_eq!(report.removed_entries, 1);
+    assert!(current.exists());
+    assert!(!stale.exists());
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_tree_beyond_cleanup_depth_limit() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let runs = dir.path().join("runtime/runs");
+    let current = runs.join("current");
+    let stale = runs.join("stale");
+    std::fs::create_dir_all(&current)?;
+    std::fs::create_dir_all(&stale)?;
+    let mut deepest = stale.clone();
+    for _ in 0..256 {
+        deepest.push("nested");
+        std::fs::create_dir(&deepest)?;
+    }
+    std::fs::write(deepest.join("keep"), b"stale")?;
+
+    let output = run_helper(&ReusePreparationRequest {
+        current_runtime_dir: path_string(&current),
+        retained_runtime_dir: None,
+    })?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CLEANUP_FAILED)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("runtime cleanup directory depth exceeds limit")
+    );
+    assert!(current.exists());
+    assert_eq!(std::fs::read(deepest.join("keep"))?, b"stale");
+    Ok(())
+}
+
+#[test]
 fn prepare_for_reuse_rejects_missing_protected_generation_before_cleanup() -> TestResult {
     let dir = tempfile::tempdir()?;
     let runs = dir.path().join("runtime/runs");


### PR DESCRIPTION
## Summary

- replace eager runtime-directory entry collection with a bounded Linux `RawDir` traversal
- share one 4 KiB raw directory buffer across recursion, cap copied names and traversal depth, and verify mutation with fresh passes from offset zero
- preserve descriptor-relative no-follow deletion, mount/protected identity checks, top-level removal counts, and fail-closed behavior
- cover wide parent and nested directories plus the exact depth boundary through the real `prepare-for-reuse` helper

## Performance

Measured with the real helper on synthetic valid containment trees, excluding fixture creation:

| Fixture | Implementation | Elapsed | Peak RSS |
| --- | --- | ---: | ---: |
| 100,000 stale entries | existing eager collection | 5.879–6.173 s | 17.84–17.91 MiB |
| 100,000 stale entries | bounded traversal | 6.015–6.381 s | 8.028–8.036 MiB |
| 1,000 stale entries | bounded traversal | 0.041 s | 8.024 MiB |

Peak RSS remains effectively flat as entry count increases and is about 55% lower at 100,000 entries. Median cleanup time increased by about 5% and remains below the issue's 10-second guardrail.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent --no-deps`
- `cargo test -p guest-agent --test reuse_preparation_helper`
- `cargo test -p guest-agent`
- `cargo build --target aarch64-unknown-linux-musl -p guest-agent --profile ci`
- `cargo build --target x86_64-unknown-linux-musl -p guest-agent --profile ci`

## Scope

This does not change the runner/guest protocol, API contracts, persisted state, protected-runtime selection, or cleanup timeout policy.

Closes #28567
