### PR TITLE
fix(platform): bind chat actions to current thread

### DIFF
--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -28,17 +28,20 @@ state creation inside React render.
 The body parser accepts platform links in common message forms:
 
 ```markdown
-https://app.vm0.ai/agents/agent-123/permissions?connectorSlug=slack&permission=messages.write
+https://app.vm0.ai/agents/c0000000-0000-4000-a000-000000000001/permissions?connectorSlug=slack&permission=messages.write
 
-[Review permission](https://app.vm0.ai/agents/agent-123/permissions?connectorSlug=slack&permission=messages.write)
+[Review permission](https://app.vm0.ai/agents/c0000000-0000-4000-a000-000000000001/permissions?connectorSlug=slack&permission=messages.write)
 
 /computer-use/authorize/request-token
 ```
 
 Absolute URLs must use an allowed VM0 platform origin. Relative paths resolve
 against the configured platform origin. A URL becomes a card only when its path
-and required parameters match a card parser exactly. An unrecognized or invalid
-link remains ordinary Markdown.
+and required parameters match a card parser exactly. Unrecognized links remain
+ordinary Markdown. Recognized connector and permission actions are different:
+their URL targets are untrusted claims and must match the authenticated chat
+thread's agent and optional callback thread. A mismatch renders an inert
+unavailable card instead of a link or command.
 
 Current link-backed card patterns include:
 
@@ -67,9 +70,11 @@ that card type exists.
 
 ### 1. Parse content into pure descriptors
 
-`parseChatEventBodyBlocks` extracts renderable content from a `ChatEvent`
-and passes it to `parseBodyBlocks`. The parser separates normal Markdown from
-recognized cards.
+`chatEventTreePlan` extracts renderable content from a `ChatEvent` and passes it
+to `eventBodyPlan`. The parser separates normal Markdown from recognized cards.
+The current thread ID and server-derived primary agent ID are supplied as
+immutable planning context. Parsing is synchronous and does not query an API or
+database.
 
 A recognized card is first represented as a pure `ParsedBodyBlock`:
 
@@ -85,6 +90,13 @@ The descriptor contains parsed domain data only. It must not create `state`,
 `computed`, `command`, subscriptions, or other runtime resources. This keeps
 parsing deterministic and safe to run for persistent, IndexedDB, realtime, and
 optimistic messages.
+
+Connector and permission descriptors are created only after their URL agent ID
+matches the context agent ID and any callback contains both a non-empty prompt
+and the context thread ID. Valid descriptors use the context identities rather
+than copying URL claims. Recognized context-invalid actions produce only a
+static unavailable descriptor, so they register no action signals and cannot
+fall back to a clickable Markdown slot.
 
 ### 2. Derive a stable resource key
 
@@ -356,7 +368,8 @@ When adding a new link-backed card:
 7. Add the React component case and pass only the typed signals object.
 8. Cover absolute, relative, and Markdown link forms that the card accepts.
 9. Test repeated-resource sharing, persistent and optimistic message paths,
-   loading and mutation behavior, and invalid links falling back to Markdown.
+   loading and mutation behavior. Define explicitly whether invalid recognized
+   links remain Markdown or render inertly; mutating actions must fail closed.
 
 Do not create signals in the parser, transcript computed, or React component.
 Do not use a root-lifetime URL cache. Do not add a card to a shared aggregate
@@ -365,10 +378,12 @@ registry.
 ## Relevant Implementation Files
 
 - `turbo/apps/platform/src/signals/chat-page/chat-event-body-blocks.ts`
+- `turbo/apps/platform/src/signals/chat-page/chat-action-context.ts`
 - `turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts`
 - `turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts`
 - `turbo/apps/platform/src/signals/chat-page/artifact-card-signals.ts`
 - `turbo/apps/platform/src/signals/chat-page/connector-action-block.ts`
+- `turbo/apps/platform/src/signals/chat-page/permission-action-block.ts`
 - `turbo/apps/platform/src/signals/chat-page/permission-card-signals.ts`
 - `turbo/apps/platform/src/signals/chat-page/mail-draft.ts`
 - `turbo/apps/platform/src/signals/chat-page/browser-session-block.ts`

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1501,6 +1501,10 @@
       "stop": "Stoppen",
       "view": "Anzeigen"
     },
+    "actionUnavailable": {
+      "description": "Diese Aktion gehört nicht zu diesem Chat oder ist nicht mehr gültig.",
+      "title": "Aktion nicht verfügbar"
+    },
     "agentPage": {
       "growth": {
         "addInSlack": "{{assistantName}} in Slack hinzufügen",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1501,6 +1501,10 @@
       "stop": "Stop",
       "view": "View"
     },
+    "actionUnavailable": {
+      "description": "This action does not belong to this chat or is no longer valid.",
+      "title": "Action unavailable"
+    },
     "agentPage": {
       "growth": {
         "addInSlack": "Add {{assistantName}} in Slack",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1525,6 +1525,10 @@
       "stop": "Detener",
       "view": "Ver"
     },
+    "actionUnavailable": {
+      "description": "Esta acción no pertenece a este chat o ya no es válida.",
+      "title": "Acción no disponible"
+    },
     "agentPage": {
       "growth": {
         "addInSlack": "Añadir {{assistantName}} en Slack",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1525,6 +1525,10 @@
       "stop": "Arrêter",
       "view": "Afficher"
     },
+    "actionUnavailable": {
+      "description": "Cette action n’appartient pas à cette discussion ou n’est plus valide.",
+      "title": "Action indisponible"
+    },
     "agentPage": {
       "growth": {
         "addInSlack": "Ajouter {{assistantName}} dans Slack",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1501,6 +1501,10 @@
       "stop": "रोकें",
       "view": "देखें"
     },
+    "actionUnavailable": {
+      "description": "यह कार्रवाई इस चैट से संबंधित नहीं है या अब मान्य नहीं है।",
+      "title": "कार्रवाई उपलब्ध नहीं है"
+    },
     "agentPage": {
       "growth": {
         "addInSlack": "Slack में {{assistantName}} जोड़ें",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1501,6 +1501,10 @@
       "stop": "Hentikan",
       "view": "Lihat"
     },
+    "actionUnavailable": {
+      "description": "Tindakan ini bukan milik chat ini atau sudah tidak valid.",
+      "title": "Tindakan tidak tersedia"
+    },
     "agentPage": {
       "growth": {
         "addInSlack": "Tambahkan {{assistantName}} di Slack",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1525,6 +1525,10 @@
       "stop": "Interrompi",
       "view": "Visualizza"
     },
+    "actionUnavailable": {
+      "description": "Questa azione non appartiene a questa chat o non è più valida.",
+      "title": "Azione non disponibile"
+    },
     "agentPage": {
       "growth": {
         "addInSlack": "Aggiungi {{assistantName}} su Slack",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1501,6 +1501,10 @@
       "stop": "停止",
       "view": "見る"
     },
+    "actionUnavailable": {
+      "description": "このアクションはこのチャットのものではないか、無効になっています。",
+      "title": "アクションを利用できません"
+    },
     "agentPage": {
       "growth": {
         "addInSlack": "Slack に {{assistantName}} を追加",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1501,6 +1501,10 @@
       "stop": "중지",
       "view": "보기"
     },
+    "actionUnavailable": {
+      "description": "이 작업은 이 채팅에 속하지 않거나 더 이상 유효하지 않습니다.",
+      "title": "작업을 사용할 수 없음"
+    },
     "agentPage": {
       "growth": {
         "addInSlack": "Slack에 {{assistantName}} 추가",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1525,6 +1525,10 @@
       "stop": "Parar",
       "view": "Ver"
     },
+    "actionUnavailable": {
+      "description": "Esta ação não pertence a este chat ou não é mais válida.",
+      "title": "Ação indisponível"
+    },
     "agentPage": {
       "growth": {
         "addInSlack": "Adicionar {{assistantName}} no Slack",

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/event-body-plan.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/event-body-plan.test.ts
@@ -14,10 +14,18 @@ import {
 } from "../parse-body-blocks.ts";
 
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const THREAD_ID = "e4000000-0000-4000-a000-000000000001";
 const CONNECTOR_URL = `${window.location.origin}/connectors/github/authorize?agentId=${AGENT_ID}`;
 
 const store = createStore();
 const connectorRegistry = createConnectorCardSignalsRegistry();
+
+function planBody(content: string) {
+  return eventBodyPlan(content, {
+    previews: true,
+    chatActionContext: { agentId: AGENT_ID, threadId: THREAD_ID },
+  });
+}
 
 function connectorRef(descriptor: CardDescriptorBlock): MarkdownCardRef {
   if (descriptor.type !== "connector-action") {
@@ -31,9 +39,7 @@ function connectorRef(descriptor: CardDescriptorBlock): MarkdownCardRef {
 
 describe("eventBodyPlan", () => {
   it("plans one document with the card standing on its own link paragraph", () => {
-    const plan = eventBodyPlan(`before\n\n${CONNECTOR_URL}\n\nafter`, {
-      previews: true,
-    });
+    const plan = planBody(`before\n\n${CONNECTOR_URL}\n\nafter`);
 
     expect(
       plan.descriptors.map((descriptor) => {
@@ -46,10 +52,7 @@ describe("eventBodyPlan", () => {
   });
 
   it("keeps an inline label in prose and plans the card after it", () => {
-    const plan = eventBodyPlan(
-      `Please [connect GitHub](${CONNECTOR_URL}) first.`,
-      { previews: true },
-    );
+    const plan = planBody(`Please [connect GitHub](${CONNECTOR_URL}) first.`);
 
     expect(plan.treeSource).toBe(
       `Please connect GitHub first.\n\n[${CONNECTOR_URL}](<${CONNECTOR_URL}>)`,
@@ -57,7 +60,7 @@ describe("eventBodyPlan", () => {
   });
 
   it("plans a body without cards as the prose itself", () => {
-    const plan = eventBodyPlan("just some **prose**", { previews: true });
+    const plan = planBody("just some **prose**");
 
     expect(plan.descriptors).toStrictEqual([]);
     expect(plan.treeSource).toBe("just some **prose**");
@@ -66,9 +69,7 @@ describe("eventBodyPlan", () => {
 
 describe("card slots in the tree", () => {
   it("replaces a registered slot with a card node and keeps prose around it", () => {
-    const plan = eventBodyPlan(`before\n\n${CONNECTOR_URL}\n\nafter`, {
-      previews: true,
-    });
+    const plan = planBody(`before\n\n${CONNECTOR_URL}\n\nafter`);
     const ref = connectorRef(plan.descriptors[0]!);
     const cards = new Map([
       [markdownCardKey(cardSlotUrl(plan.descriptors[0]!)), ref],
@@ -95,7 +96,7 @@ describe("card slots in the tree", () => {
   });
 
   it("keeps an unresolved slot as an ordinary link", () => {
-    const plan = eventBodyPlan(CONNECTOR_URL, { previews: true });
+    const plan = planBody(CONNECTOR_URL);
 
     const tree = parseMarkdownTree(plan.treeSource, {
       mathEnabled: true,
@@ -121,9 +122,7 @@ describe("card slots in the tree", () => {
         cards: new Map([
           [
             markdownCardKey(CONNECTOR_URL),
-            connectorRef(
-              eventBodyPlan(CONNECTOR_URL, { previews: true }).descriptors[0]!,
-            ),
+            connectorRef(planBody(CONNECTOR_URL).descriptors[0]!),
           ],
         ]),
       },

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/parse-body-blocks-cards.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/parse-body-blocks-cards.test.ts
@@ -9,10 +9,14 @@ import { parseBodyBlocks } from "../parse-body-blocks.ts";
  * the same card for the same source once the scanner is gone.
  */
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const THREAD_ID = "e4000000-0000-4000-a000-000000000001";
 const CONNECTOR_URL = `${window.location.origin}/connectors/github/authorize?agentId=${AGENT_ID}`;
 
 function shapeOf(content: string): string {
-  return parseBodyBlocks(content, { previews: true })
+  return parseBodyBlocks(content, {
+    previews: true,
+    chatActionContext: { agentId: AGENT_ID, threadId: THREAD_ID },
+  })
     .blocks.map((block) => {
       return block.type === "markdown"
         ? `markdown(${JSON.stringify(block.content)})`
@@ -54,9 +58,9 @@ describe("card recognition in a message body", () => {
     );
   });
 
-  it("leaves a connector-shaped url without an agent id as prose", () => {
+  it("makes a connector-shaped url without an agent id unavailable", () => {
     const url = `${window.location.origin}/connectors/github/authorize`;
 
-    expect(shapeOf(url)).toBe(`markdown(${JSON.stringify(url)})`);
+    expect(shapeOf(url)).toBe("unavailable-action");
   });
 });

--- a/turbo/apps/platform/src/signals/chat-page/action-callback.ts
+++ b/turbo/apps/platform/src/signals/chat-page/action-callback.ts
@@ -3,16 +3,36 @@ import { zeroClient$ } from "../api-client.ts";
 import { searchParams$ } from "../route.ts";
 import { textToMessageDocument } from "../zero-page/user-message-document-codec.ts";
 import { sendChatEvent } from "./chat-event-api.ts";
+import {
+  chatActionIdMatches,
+  type ChatActionContext,
+} from "./chat-action-context.ts";
 
 export interface ChatActionCallback {
   readonly callbackPrompt: string | null;
   readonly threadId: string | null;
 }
 
-export function chatActionCallbackFromUrl(url: URL): ChatActionCallback {
+export function chatActionCallbackFromUrl(
+  url: URL,
+  context: ChatActionContext,
+): ChatActionCallback | null {
+  const callbackPrompt = url.searchParams.get("callbackPrompt");
+  const threadId = url.searchParams.get("threadId");
+  if (callbackPrompt === null && threadId === null) {
+    return { callbackPrompt: null, threadId: null };
+  }
+  if (
+    callbackPrompt === null ||
+    callbackPrompt.trim() === "" ||
+    threadId === null ||
+    !chatActionIdMatches(threadId, context.threadId)
+  ) {
+    return null;
+  }
   return {
-    callbackPrompt: url.searchParams.get("callbackPrompt"),
-    threadId: url.searchParams.get("threadId"),
+    callbackPrompt,
+    threadId: context.threadId,
   };
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-action-context.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-action-context.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export interface ChatActionContext {
+  readonly agentId: string;
+  readonly threadId: string;
+}
+
+export type ChatActionParseResult<T> =
+  | { readonly status: "unrelated" }
+  | { readonly status: "invalid"; readonly originalUrl: string }
+  | { readonly status: "valid"; readonly descriptor: T };
+
+const chatActionIdSchema = z.uuid();
+
+export function chatActionIdMatches(
+  claimedId: string,
+  authoritativeId: string,
+): boolean {
+  const claimed = chatActionIdSchema.safeParse(claimedId);
+  const authoritative = chatActionIdSchema.safeParse(authoritativeId);
+  return (
+    claimed.success &&
+    authoritative.success &&
+    claimed.data.toLowerCase() === authoritative.data.toLowerCase()
+  );
+}

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-body-blocks.ts
@@ -13,10 +13,9 @@ import {
 } from "./chat-event-state.ts";
 import {
   eventBodyPlan,
-  parseBodyBlocks,
   type CardDescriptorBlock,
-  type ParsedBodyBlock,
 } from "./parse-body-blocks.ts";
+import type { ChatActionContext } from "./chat-action-context.ts";
 import type { ChatEvent } from "./chat-event-types.ts";
 
 function chatEventBodyContent(event: ChatEvent): string {
@@ -41,17 +40,6 @@ function chatEventBodyContent(event: ChatEvent): string {
     return content.trim();
   }
   return event.content?.trim() ?? "";
-}
-
-export function parseChatEventBodyBlocks(
-  event: ChatEvent,
-  threadId: string,
-): ParsedBodyBlock[] {
-  const content = chatEventBodyContent(event);
-  return parseBodyBlocks(content, {
-    previews: chatEventCompatibilityRole(event.eventType) === "assistant",
-    browserThreadId: threadId,
-  }).blocks;
 }
 
 function skipsEventBodyRendering(event: ChatEvent): boolean {
@@ -99,7 +87,7 @@ interface ChatEventTreePlan {
  */
 export function chatEventTreePlan(
   event: ChatEvent,
-  threadId: string,
+  chatActionContext: ChatActionContext,
 ): ChatEventTreePlan | null {
   const content = chatEventTreeContent(event);
   if (content === null) {
@@ -107,7 +95,7 @@ export function chatEventTreePlan(
   }
   const plan = eventBodyPlan(content, {
     previews: true,
-    browserThreadId: threadId,
+    chatActionContext,
   });
   return {
     content,

--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -31,6 +31,11 @@ import {
   type ChatActionCallback,
 } from "./action-callback.ts";
 import {
+  chatActionIdMatches,
+  type ChatActionContext,
+  type ChatActionParseResult,
+} from "./chat-action-context.ts";
+import {
   createCardSignalsRegistry,
   type CardSignalsRegistry,
 } from "./card-signal-map.ts";
@@ -103,49 +108,62 @@ export const closeChatConnectorActionConnectDialog$ = command(({ set }) => {
 
 export function parseConnectorAuthorizeUrl(
   value: string,
-): ConnectorActionDescriptor | null {
+  context: ChatActionContext | undefined,
+): ChatActionParseResult<ConnectorActionDescriptor> {
   const appOrigin = window.location.origin;
   const canonicalAppOrigin = resolvePlatformOriginForTarget("app");
   if (!URL.canParse(value, appOrigin)) {
-    return null;
+    return { status: "unrelated" };
   }
   const url = new URL(value, appOrigin);
   if (url.origin !== appOrigin && url.origin !== canonicalAppOrigin) {
-    return null;
+    return { status: "unrelated" };
   }
 
   const match = url.pathname.match(
     /^\/connectors\/([^/]+)\/(authorize|connect)$/u,
   );
+  if (!match) {
+    return { status: "unrelated" };
+  }
   const connectorSlug = match?.[1]?.toLowerCase();
   const action = match?.[2];
   const agentId = url.searchParams.get("agentId");
-  if (!agentId) {
-    return null;
+  if (!context || !agentId || !chatActionIdMatches(agentId, context.agentId)) {
+    return { status: "invalid", originalUrl: value };
   }
 
-  const callback = chatActionCallbackFromUrl(url);
+  const callback = chatActionCallbackFromUrl(url, context);
+  if (!callback) {
+    return { status: "invalid", originalUrl: value };
+  }
   const parsedCatalogSlug = connectorSlugSchema.safeParse(connectorSlug);
   if (parsedCatalogSlug.success) {
     return {
-      kind: "catalog",
-      connectorSlug: parsedCatalogSlug.data,
-      agentId,
-      originalUrl: value,
-      ...callback,
+      status: "valid",
+      descriptor: {
+        kind: "catalog",
+        connectorSlug: parsedCatalogSlug.data,
+        agentId: context.agentId,
+        originalUrl: value,
+        ...callback,
+      },
     };
   }
 
   const parsedCustomSlug = customConnectorSlugSchema.safeParse(connectorSlug);
   if (!parsedCustomSlug.success || action !== "connect") {
-    return null;
+    return { status: "invalid", originalUrl: value };
   }
   return {
-    kind: "custom",
-    connectorSlug: parsedCustomSlug.data,
-    agentId,
-    originalUrl: value,
-    ...callback,
+    status: "valid",
+    descriptor: {
+      kind: "custom",
+      connectorSlug: parsedCustomSlug.data,
+      agentId: context.agentId,
+      originalUrl: value,
+      ...callback,
+    },
   };
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -149,6 +149,7 @@ import {
   chatEventTreeContent,
   chatEventTreePlan,
 } from "./chat-event-body-blocks.ts";
+import type { ChatActionContext } from "./chat-action-context.ts";
 import type { Root } from "hast";
 import {
   markdownCardKey,
@@ -1771,7 +1772,7 @@ function createArtifactPreviewImageUrls(
 }
 
 interface EventTreeRegistries {
-  readonly threadId: string;
+  readonly chatActionContext: ChatActionContext;
   readonly artifactCardSignals: ArtifactCardSignalsRegistry;
   readonly connectorCardSignals: ReturnType<
     typeof createConnectorCardSignalsRegistry
@@ -1794,7 +1795,7 @@ interface EventTreeRegistries {
 }
 
 function createEventTreeSignals({
-  threadId,
+  chatActionContext,
   artifactCardSignals,
   connectorCardSignals,
   permissionCardSignals,
@@ -1826,7 +1827,7 @@ function createEventTreeSignals({
           return {
             kind: descriptor.type,
             signals: set(artifactCardSignals.register$, descriptor.descriptor),
-            threadId,
+            threadId: chatActionContext.threadId,
           };
         }
         case "connector-action": {
@@ -1843,6 +1844,9 @@ function createEventTreeSignals({
               descriptor.descriptor,
             ),
           };
+        }
+        case "unavailable-action": {
+          return { kind: descriptor.type };
         }
         case "computer-use-authorization": {
           return {
@@ -1893,7 +1897,7 @@ function createEventTreeSignals({
         if (content === null || current.get(event.id)?.content === content) {
           continue;
         }
-        const plan = chatEventTreePlan(event, threadId);
+        const plan = chatEventTreePlan(event, chatActionContext);
         if (plan === null) {
           continue;
         }
@@ -1928,12 +1932,13 @@ function createEventTreeSignals({
 }
 
 function createPagedEventResources(
-  threadId: string,
+  chatActionContext: ChatActionContext,
   chatEvents$: Computed<ChatEvent[]>,
   previewImageUrlsByUrl$: Computed<Promise<ReadonlyMap<string, string>>>,
   browserLifecycleOptimisticEvents: BrowserLifecycleOptimisticEvents,
   ownerSignal: AbortSignal,
 ) {
+  const { threadId } = chatActionContext;
   const mailDraftCardSignals = createMailDraftCardSignalsRegistry(threadId);
   const browserSessionSignals = createBrowserSessionSignals(
     threadId,
@@ -1970,7 +1975,7 @@ function createPagedEventResources(
   );
 
   const { eventTrees$, ensureEventTrees$ } = createEventTreeSignals({
-    threadId,
+    chatActionContext,
     artifactCardSignals,
     connectorCardSignals,
     permissionCardSignals,
@@ -2268,16 +2273,17 @@ function createReadyScrollAfterRenderRequest(
 
 function createChatThreadMessagePipeline(
   {
-    threadId,
+    chatActionContext,
     chatEvents,
     previewImageUrlsByUrl$,
   }: {
-    threadId: string;
+    chatActionContext: ChatActionContext;
     chatEvents: ChatEventSignals;
     previewImageUrlsByUrl$: Computed<Promise<ReadonlyMap<string, string>>>;
   },
   ownerSignal: AbortSignal,
 ) {
+  const { threadId } = chatActionContext;
   const browserLifecycleOptimisticEvents: BrowserLifecycleOptimisticEvents = {
     append$: command(
       async (
@@ -2299,7 +2305,7 @@ function createChatThreadMessagePipeline(
   // with the window's ensure step.
   const position = createThreadScrollPositionSignals(threadId);
   const resources = createPagedEventResources(
-    threadId,
+    chatActionContext,
     chatEvents.chatEvents$,
     previewImageUrlsByUrl$,
     browserLifecycleOptimisticEvents,
@@ -4000,7 +4006,7 @@ function createChatPanelSignalsWithDraft(
   const messages: MessageListSignals = {
     ...createChatThreadMessagePipeline(
       {
-        threadId,
+        chatActionContext: { threadId, agentId },
         chatEvents,
         previewImageUrlsByUrl$: createArtifactPreviewImageUrls(
           artifact.artifacts$,

--- a/turbo/apps/platform/src/signals/chat-page/markdown-card-ref.ts
+++ b/turbo/apps/platform/src/signals/chat-page/markdown-card-ref.ts
@@ -20,6 +20,7 @@ export type MarkdownCardRef =
     }
   | { readonly kind: "connector-action"; readonly signals: ConnectorSignals }
   | { readonly kind: "permission-action"; readonly signals: PermissionSignals }
+  | { readonly kind: "unavailable-action" }
   | {
       readonly kind: "computer-use-authorization";
       readonly signals: ComputerUseAuthorizationSignals;

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-events.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-events.ts
@@ -1,12 +1,10 @@
 import { command, computed, state } from "ccstate";
 import type { ChatEvent } from "@okouai/api-contracts/contracts/chat-threads";
 import { logger } from "../log.ts";
-import { parseChatEventBodyBlocks } from "./chat-event-body-blocks.ts";
 import type {
   OptimisticChatEvent,
   OptimisticUserMessageAssociation,
 } from "./chat-event-types.ts";
-import type { ParsedBodyBlock } from "./parse-body-blocks.ts";
 import {
   chatEventDebugSummaries,
   chatEventTraceTime,
@@ -18,17 +16,12 @@ export interface OptimisticChatEventInput {
   optimisticUserMessageAssociation?: OptimisticUserMessageAssociation;
 }
 
-export interface OptimisticChatEventEntry extends OptimisticChatEventInput {
-  parsedBodyBlocks: ParsedBodyBlock[];
-}
+export type OptimisticChatEventEntry = OptimisticChatEventInput;
 
 export function createOptimisticChatEventEntry(
   input: OptimisticChatEventInput,
 ): OptimisticChatEventEntry {
-  return {
-    ...input,
-    parsedBodyBlocks: parseChatEventBodyBlocks(input.event, input.threadId),
-  };
+  return { ...input };
 }
 
 const L = logger("OptimisticChatEvents");

--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -1065,10 +1065,7 @@ export function parseBodyBlocks(
       ? createActionBlockFromLine(line, options.chatActionContext)
       : null;
     if (actionBlock) {
-      if (
-        actionBlock.type === "connector-action" ||
-        actionBlock.type === "unavailable-action"
-      ) {
+      if (actionBlock.type === "connector-action") {
         const retainedMarkdown = retainedActionMarkdown(
           line,
           actionBlock.descriptor.originalUrl,

--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -2,6 +2,7 @@ import {
   parseConnectorAuthorizeUrl,
   type ConnectorActionDescriptor,
 } from "./connector-action-block.ts";
+import type { ChatActionContext } from "./chat-action-context.ts";
 import {
   parsePermissionActionUrl,
   permissionActionResourceKey,
@@ -61,6 +62,11 @@ export type ParsedBodyBlock =
       descriptor: PermissionActionDescriptor;
     }
   | {
+      type: "unavailable-action";
+      resourceKey: string;
+      descriptor: { readonly originalUrl: string };
+    }
+  | {
       type: "computer-use-authorization";
       resourceKey: string;
       descriptor: ComputerUseAuthorizationDescriptor;
@@ -103,7 +109,7 @@ type OpenMarkdownFence = {
 
 interface ParseBodyBlocksOptions {
   readonly previews?: boolean;
-  readonly browserThreadId?: string;
+  readonly chatActionContext?: ChatActionContext;
 }
 
 // ---------------------------------------------------------------------------
@@ -782,13 +788,14 @@ function extractActionUrlFromLine(line: string): string | null {
 
 function createActionBlockFromLine(
   line: string,
-  browserThreadId: string | undefined,
+  chatActionContext: ChatActionContext | undefined,
 ): Extract<
   ParsedBodyBlock,
   {
     type:
       | "connector-action"
       | "permission-action"
+      | "unavailable-action"
       | "computer-use-authorization"
       | "plan-upgrade"
       | "mail-draft"
@@ -800,21 +807,35 @@ function createActionBlockFromLine(
     return null;
   }
 
-  const connectorAction = parseConnectorAuthorizeUrl(url);
-  if (connectorAction) {
+  const connectorAction = parseConnectorAuthorizeUrl(url, chatActionContext);
+  if (connectorAction.status === "valid") {
     return {
       type: "connector-action",
+      resourceKey: connectorAction.descriptor.originalUrl,
+      descriptor: connectorAction.descriptor,
+    };
+  }
+  if (connectorAction.status === "invalid") {
+    return {
+      type: "unavailable-action",
       resourceKey: connectorAction.originalUrl,
-      descriptor: connectorAction,
+      descriptor: { originalUrl: connectorAction.originalUrl },
     };
   }
 
-  const permissionAction = parsePermissionActionUrl(url);
-  if (permissionAction) {
+  const permissionAction = parsePermissionActionUrl(url, chatActionContext);
+  if (permissionAction.status === "valid") {
     return {
       type: "permission-action",
-      resourceKey: permissionActionResourceKey(permissionAction),
-      descriptor: permissionAction,
+      resourceKey: permissionActionResourceKey(permissionAction.descriptor),
+      descriptor: permissionAction.descriptor,
+    };
+  }
+  if (permissionAction.status === "invalid") {
+    return {
+      type: "unavailable-action",
+      resourceKey: permissionAction.originalUrl,
+      descriptor: { originalUrl: permissionAction.originalUrl },
     };
   }
 
@@ -846,7 +867,10 @@ function createActionBlockFromLine(
   }
 
   const browserSession = parseBrowserSessionUrl(url);
-  if (browserSession && browserSession.threadId === browserThreadId) {
+  if (
+    browserSession &&
+    browserSession.threadId === chatActionContext?.threadId
+  ) {
     return {
       type: "browser-session",
       resourceKey: browserSession.href,
@@ -857,9 +881,9 @@ function createActionBlockFromLine(
   return null;
 }
 
-function retainedConnectorActionMarkdown(
+function retainedActionMarkdown(
   line: string,
-  action: ConnectorActionDescriptor,
+  originalUrl: string,
 ): string | null {
   const candidate = stripMarkdownLineDecorations(line);
   const standaloneMarkdownLink = candidate.match(
@@ -875,7 +899,7 @@ function retainedConnectorActionMarkdown(
   return line.replace(
     new RegExp(String.raw`\[([^\]]+)\]\((${URL_TOKEN_PATTERN})\)`),
     (match: string, label: string, url: string) => {
-      return trimPreviewUrl(url) === action.originalUrl ? label : match;
+      return trimPreviewUrl(url) === originalUrl ? label : match;
     },
   );
 }
@@ -1038,13 +1062,16 @@ export function parseBodyBlocks(
     }
 
     const actionBlock = previews
-      ? createActionBlockFromLine(line, options.browserThreadId)
+      ? createActionBlockFromLine(line, options.chatActionContext)
       : null;
     if (actionBlock) {
-      if (actionBlock.type === "connector-action") {
-        const retainedMarkdown = retainedConnectorActionMarkdown(
+      if (
+        actionBlock.type === "connector-action" ||
+        actionBlock.type === "unavailable-action"
+      ) {
+        const retainedMarkdown = retainedActionMarkdown(
           line,
-          actionBlock.descriptor,
+          actionBlock.descriptor.originalUrl,
         );
         if (retainedMarkdown) {
           pushMarkdownLines([retainedMarkdown]);
@@ -1106,6 +1133,9 @@ export function cardSlotUrl(block: CardDescriptorBlock): string {
       return block.descriptor.originalUrl;
     }
     case "permission-action": {
+      return block.descriptor.originalUrl;
+    }
+    case "unavailable-action": {
       return block.descriptor.originalUrl;
     }
     case "computer-use-authorization": {

--- a/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
@@ -4,6 +4,11 @@ import {
   chatActionCallbackFromUrl,
   type ChatActionCallback,
 } from "./action-callback.ts";
+import {
+  chatActionIdMatches,
+  type ChatActionContext,
+  type ChatActionParseResult,
+} from "./chat-action-context.ts";
 import { parseTrustedPlatformUrl } from "./trusted-platform-url.ts";
 
 type PermissionAction = "allow" | "deny";
@@ -56,15 +61,16 @@ function parsePermissionActionPath(
 
 export function parsePermissionActionUrl(
   value: string,
-): PermissionActionDescriptor | null {
+  context: ChatActionContext | undefined,
+): ChatActionParseResult<PermissionActionDescriptor> {
   const url = parseTrustedPlatformUrl(value);
   if (!url) {
-    return null;
+    return { status: "unrelated" };
   }
 
   const path = parsePermissionActionPath(url.pathname);
   if (!path) {
-    return null;
+    return { status: "unrelated" };
   }
   // Historical permission links may use ref from before CLI 9.270.1.
   const connectorSlug =
@@ -78,29 +84,37 @@ export function parsePermissionActionUrl(
     action === "allow"
       ? parseUserPermissionGrantExpiresIn(url.searchParams.get("expiresIn"))
       : null;
-  const actionCallback = chatActionCallbackFromUrl(url);
+  const actionCallback = context
+    ? chatActionCallbackFromUrl(url, context)
+    : null;
 
   if (
+    !context ||
     !path.agentId ||
+    !chatActionIdMatches(path.agentId, context.agentId) ||
     !connectorSlug ||
     !permission ||
-    !isPermissionAction(action)
+    !isPermissionAction(action) ||
+    !actionCallback
   ) {
-    return null;
+    return { status: "invalid", originalUrl: value };
   }
 
   return {
-    scope: path.scope,
-    agentId: path.agentId,
-    connectorSlug,
-    permission,
-    action,
-    method,
-    path: requestPath,
-    reason,
-    expiresIn,
-    search: url.searchParams.toString(),
-    originalUrl: value,
-    ...actionCallback,
+    status: "valid",
+    descriptor: {
+      scope: path.scope,
+      agentId: context.agentId,
+      connectorSlug,
+      permission,
+      action,
+      method,
+      path: requestPath,
+      reason,
+      expiresIn,
+      search: url.searchParams.toString(),
+      originalUrl: value,
+      ...actionCallback,
+    },
   };
 }

--- a/turbo/apps/platform/src/views/components/__tests__/__benches__/markdown.bench.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/__benches__/markdown.bench.tsx
@@ -206,7 +206,10 @@ function ensurePass(
     if (content === null || cache.get(event.id)?.content === content) {
       continue;
     }
-    const plan = chatEventTreePlan(event, THREAD_ID);
+    const plan = chatEventTreePlan(event, {
+      agentId: "c0000000-0000-4000-a000-000000000001",
+      threadId: THREAD_ID,
+    });
     if (plan === null) {
       continue;
     }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -1134,7 +1134,6 @@ describe("chat event action cards", () => {
     );
     expect(unavailableCards).toHaveLength(2);
     for (const card of unavailableCards) {
-      expect(within(card).getByText("Action unavailable")).toBeInTheDocument();
       expect(queryAllByRoleFast("link", card)).toHaveLength(0);
       expect(queryAllByRoleFast("button", card)).toHaveLength(0);
     }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -1160,6 +1160,12 @@ describe("chat event action cards", () => {
       threadOnlyUrl,
       missingAgentUrl,
     ];
+    const invalidActionLines = [
+      `Please use ${wrongThreadUrl} to continue.`,
+      promptOnlyUrl,
+      threadOnlyUrl,
+      missingAgentUrl,
+    ];
     mockChatLifecycle(context, {
       threadId,
       threadTitle: "Invalid action callbacks",
@@ -1167,7 +1173,7 @@ describe("chat event action cards", () => {
         {
           id: "msg-assistant-invalid-action-callbacks",
           role: "assistant",
-          content: invalidUrls.join("\n\n"),
+          content: invalidActionLines.join("\n\n"),
           runId: "run-invalid-action-callbacks",
           createdAt: "2026-08-21T10:01:00Z",
         },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -1079,6 +1079,118 @@ describe("chat event action cards", () => {
     expect(untrustedLink).toHaveAttribute("href", untrustedUrl);
   });
 
+  it("keeps connector and permission actions for another agent inert", async () => {
+    const threadId = "e4000000-0000-4000-a000-000000000023";
+    const otherAgentId = "c0000000-0000-4000-a000-000000000002";
+    const connectorUrl = `${window.location.origin}/connectors/slack/authorize?agentId=${otherAgentId}`;
+    const permissionUrl = `https://app.vm0.ai/agents/${otherAgentId}/permissions?connectorSlug=slack&permission=channels.read&action=allow`;
+
+    context.mocks.api(agentsByIdContract.get, ({ params, respond }) => {
+      return respond(200, {
+        agentId: params.id,
+        ownerId: "test-user-123",
+        description: null,
+        displayName: "Public agent",
+        sound: null,
+        avatarUrl: null,
+        modelProviderId: null,
+        selectedModel: null,
+        preferPersonalProvider: false,
+        visibility: "public",
+      });
+    });
+    mockConnectorCatalogStatus([
+      publicConnectorStatusItem({ slug: "slack", label: "Slack" }),
+    ]);
+    context.mocks.api(connectorCatalogContract.permissions, ({ respond }) => {
+      return respond(200, {
+        permissions: catalogPermissionDetail({
+          connectorSlug: "slack",
+          label: "Slack",
+          permissions: [
+            { name: "channels.read", description: "Read channels" },
+          ],
+        }),
+      });
+    });
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Mismatched action agent",
+      chatEvents: [
+        {
+          id: "msg-assistant-mismatched-action-agent",
+          role: "assistant",
+          content: `${connectorUrl}\n\n${permissionUrl}`,
+          runId: "run-mismatched-action-agent",
+          createdAt: "2026-08-21T10:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const unavailableCards = await screen.findAllByTestId(
+      "unavailable-action-card",
+    );
+    expect(unavailableCards).toHaveLength(2);
+    for (const card of unavailableCards) {
+      expect(within(card).getByText("Action unavailable")).toBeInTheDocument();
+      expect(queryAllByRoleFast("link", card)).toHaveLength(0);
+      expect(queryAllByRoleFast("button", card)).toHaveLength(0);
+    }
+    expect(screen.queryByTestId("connector-action-card")).toBeNull();
+    expect(screen.queryByTestId("permission-action-card")).toBeNull();
+    const actionLinks = queryAllByRoleFast("link").filter((link) => {
+      const href = link.getAttribute("href");
+      return href === connectorUrl || href === permissionUrl;
+    });
+    expect(actionLinks).toHaveLength(0);
+  });
+
+  it("keeps mismatched and incomplete action callbacks inert", async () => {
+    const threadId = "e4000000-0000-4000-a000-000000000024";
+    const otherThreadId = "e4000000-0000-4000-a000-000000000025";
+    const callbackPrompt = encodeURIComponent("Continue after authorization");
+    const wrongThreadUrl = `${window.location.origin}/connectors/github/authorize?agentId=${AGENT_ID}&threadId=${otherThreadId}&callbackPrompt=${callbackPrompt}`;
+    const promptOnlyUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=slack&permission=channels.read&action=allow&callbackPrompt=${callbackPrompt}`;
+    const threadOnlyUrl = `${window.location.origin}/connectors/slack/authorize?agentId=${AGENT_ID}&threadId=${threadId}`;
+    const missingAgentUrl = `${window.location.origin}/connectors/gmail/connect`;
+    const invalidUrls = [
+      wrongThreadUrl,
+      promptOnlyUrl,
+      threadOnlyUrl,
+      missingAgentUrl,
+    ];
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Invalid action callbacks",
+      chatEvents: [
+        {
+          id: "msg-assistant-invalid-action-callbacks",
+          role: "assistant",
+          content: invalidUrls.join("\n\n"),
+          runId: "run-invalid-action-callbacks",
+          createdAt: "2026-08-21T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const unavailableCards = await screen.findAllByTestId(
+      "unavailable-action-card",
+    );
+    expect(unavailableCards).toHaveLength(invalidUrls.length);
+    for (const card of unavailableCards) {
+      expect(queryAllByRoleFast("link", card)).toHaveLength(0);
+      expect(queryAllByRoleFast("button", card)).toHaveLength(0);
+    }
+    const exposedActionLinks = queryAllByRoleFast("link").filter((link) => {
+      return invalidUrls.includes(link.getAttribute("href") ?? "");
+    });
+    expect(exposedActionLinks).toHaveLength(0);
+  });
+
   it("keeps mail feedback scoped to the chat that owns the draft in split view", async () => {
     const user = userEvent.setup({ delay: null });
     const leftThreadId = "c0000000-0000-4000-a000-000000000031";
@@ -3496,9 +3608,9 @@ describe("chat event action cards", () => {
     const releaseRequest = context.mocks.deferred<void>();
     const requestFinished = context.mocks.deferred<void>();
     const threadId = "b0000000-0000-4000-a000-000000000951";
-    const reloadedAgentId = "c0000000-0000-4000-a000-000000000002";
     const gmailPermissionUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=gmail&permission=messages.write&action=allow`;
-    const youtubePermissionUrl = `https://app.vm0.ai/agents/${reloadedAgentId}/permissions?connectorSlug=youtube&permission=videos.write&action=allow`;
+    const youtubePermissionUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=youtube&permission=videos.write&action=allow`;
+    let initialListRequests = 0;
     let pendingRequest = true;
     let staleRequestSignal: AbortSignal | undefined;
 
@@ -3518,11 +3630,12 @@ describe("chat event action cards", () => {
     });
     context.mocks.api(
       zeroUserPermissionGrantsContract.list,
-      async ({ query, signal, respond }) => {
-        if (query.agentId !== reloadedAgentId) {
+      async ({ signal, respond }) => {
+        if (!pendingRequest) {
           return respond(200, []);
         }
-        if (!pendingRequest) {
+        initialListRequests += 1;
+        if (initialListRequests === 1) {
           return respond(200, []);
         }
         pendingRequest = false;

--- a/turbo/apps/platform/src/views/zero-page/chat-body-cards.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-body-cards.tsx
@@ -285,6 +285,9 @@ export function MarkdownCardView({ card }: { card: MarkdownCardRef }) {
     case "permission-action": {
       return <PermissionActionCard signals={card.signals} />;
     }
+    case "unavailable-action": {
+      return <UnavailableActionCard />;
+    }
     case "computer-use-authorization": {
       return <ComputerUseAuthorizationCard signals={card.signals} />;
     }
@@ -388,6 +391,32 @@ function ArtifactCardView({
 }
 
 const CHAT_CONNECTOR_ACTION_CARD_HEIGHT_CLASS = "h-[136px] sm:h-[88px]";
+
+function UnavailableActionCard() {
+  const { t } = useTranslation();
+  return (
+    <div
+      data-testid="unavailable-action-card"
+      className="flex min-h-[88px] w-full items-center gap-3 rounded-lg border border-border/70 bg-background/85 p-3 text-left shadow-sm"
+    >
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40 text-muted-foreground">
+        <AlertCircle size={22} />
+      </div>
+      <div className="min-w-0">
+        <div className="text-[0.9375rem] font-medium text-foreground">
+          {t(($) => {
+            return $.chat.actionUnavailable.title;
+          })}
+        </div>
+        <div className="mt-0.5 text-sm leading-5 text-muted-foreground">
+          {t(($) => {
+            return $.chat.actionUnavailable.description;
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function ConnectorActionCardSkeleton() {
   return (


### PR DESCRIPTION
## Summary

- bind connector and permission chat actions to the authenticated thread's agent and thread IDs
- render malformed or mismatched protected actions as inert unavailable cards with no executable signals or links
- remove context-free optimistic parsing and document the trusted chat action boundary

## Testing

- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/chat-event-action-cards.test.tsx src/signals/chat-page/__tests__/event-body-plan.test.ts src/signals/chat-page/__tests__/parse-body-blocks-cards.test.ts src/signals/chat-page/__tests__/parse-body-blocks-safari-url.test.ts src/views/zero-page/__tests__/zero-artifact-image-navigation.test.ts --maxWorkers=4 --silent=passed-only`
- `pnpm knip --workspace @okouai/app`
- pre-commit hooks: Prettier, Knip, repository-wide TypeScript checks, file-size check

## Scope

- existing connector and permission routes and APIs are unchanged
- no database schema or backend changes

Closes #28573
