### PR TITLE
feat(api): add explicit single-account connector intent

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -403,6 +403,118 @@ describe("connector account lifecycle routes", () => {
     ).toHaveLength(1);
   });
 
+  it("reuses an explicit single account and rejects an ambiguous target", async () => {
+    const fixture = await seedFixture();
+    await setConnectorAccountsEnabled(fixture, true);
+
+    const first = await accept(
+      connectorClient().connect({
+        headers: authHeaders(),
+        params: { connectorSlug: "openai" },
+        body: {
+          authMethod: "api-token",
+          account: { intent: "single-account" },
+          values: { apiKey: "sk-single-first" },
+        },
+      }),
+      [200],
+    );
+    const replaced = await accept(
+      connectorClient().connect({
+        headers: authHeaders(),
+        params: { connectorSlug: "openai" },
+        body: {
+          authMethod: "api-token",
+          account: { intent: "single-account" },
+          values: { apiKey: "sk-single-replaced" },
+        },
+      }),
+      [200],
+    );
+    expect(replaced.body.id).toBe(first.body.id);
+
+    const sibling = await accept(
+      connectorClient().connect({
+        headers: authHeaders(),
+        params: { connectorSlug: "openai" },
+        body: {
+          authMethod: "api-token",
+          account: { intent: "add", displayName: "Sibling" },
+          values: { apiKey: "sk-single-sibling" },
+        },
+      }),
+      [200],
+    );
+    expect(sibling.body.id).not.toBe(first.body.id);
+
+    const ambiguous = await accept(
+      connectorClient().connect({
+        headers: authHeaders(),
+        params: { connectorSlug: "openai" },
+        body: {
+          authMethod: "api-token",
+          account: { intent: "single-account" },
+          values: { apiKey: "sk-single-ambiguous" },
+        },
+      }),
+      [409],
+    );
+    expect(ambiguous.body.error.message).toBe(
+      "Multiple connector accounts require an exact choice",
+    );
+
+    const accounts = await accept(
+      accountClient().connections({
+        headers: authHeaders(),
+        query: { kind: "builtin", connectorSlug: "openai", limit: 100 },
+      }),
+      [200],
+    );
+    expect(accounts.body.connections).toHaveLength(2);
+  });
+
+  it("serializes concurrent explicit single-account writes", async () => {
+    const fixture = await seedFixture();
+    await setConnectorAccountsEnabled(fixture, true);
+
+    const responses = await Promise.all(
+      ["first", "second"].map((suffix) => {
+        return accept(
+          connectorClient().connect({
+            headers: authHeaders(),
+            params: { connectorSlug: "openai" },
+            body: {
+              authMethod: "api-token",
+              account: { intent: "single-account" },
+              values: { apiKey: `sk-single-concurrent-${suffix}` },
+            },
+          }),
+          [200],
+        );
+      }),
+    );
+    expect(
+      responses.map((response) => {
+        return response.status;
+      }),
+    ).toStrictEqual([200, 200]);
+    expect(responses[1]?.body.id).toBe(responses[0]?.body.id);
+
+    const accounts = await accept(
+      accountClient().connections({
+        headers: authHeaders(),
+        query: { kind: "builtin", connectorSlug: "openai", limit: 100 },
+      }),
+      [200],
+    );
+    expect(accounts.body.connections).toHaveLength(1);
+    expect(accounts.body.connections[0]).toMatchObject({
+      id: responses[0]?.body.id,
+      displayName: null,
+      isDefault: true,
+    });
+  });
+
   it("paginates and searches more than one hundred accounts", async () => {
     const fixture = await seedFixture();
     await setConnectorAccountsEnabled(fixture, true);

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
@@ -299,7 +299,9 @@ describe("CONN-02: external-code session lifecycle", () => {
     const actor = await awsActor();
     const bdd = createBddApi(context);
 
-    const session = await connectorsApi.startExternalCode(actor, "aws", "cli");
+    const session = await connectorsApi.startExternalCode(actor, "aws", "cli", {
+      intent: "single-account",
+    });
     expect(session).toMatchObject({
       connectorSlug: "aws",
       status: "pending",

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
@@ -437,8 +437,7 @@ describe("Steam OpenID connector", () => {
     expect(connector.body).toStrictEqual(initial.body);
 
     const replacementAuthorizationUrl = await startSteamOpenId(actor, {
-      intent: "reconnect",
-      connectionId: initial.body.id,
+      intent: "single-account",
     });
     await completeSteamOpenIdCallback(replacementAuthorizationUrl);
     mockSession(actor);

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -574,7 +574,7 @@ describe("CONN-02: OAuth start and callback", () => {
     expect(failedConnector.body.error.code).toBe("NOT_FOUND");
   });
 
-  it("restores an explicit reconnect target across the OAuth callback", async () => {
+  it("restores explicit single-account and reconnect intents across OAuth callbacks", async () => {
     mockGitHubConnectorOAuth();
 
     const bdd = createBddApi(context);
@@ -592,6 +592,23 @@ describe("CONN-02: OAuth start and callback", () => {
       actor,
       "github",
     );
+
+    const singleAccountStart = await connectorsApi.startOauth(
+      actor,
+      "github",
+      "oauth",
+      undefined,
+      { intent: "single-account" },
+    );
+    await connectorsApi.completeOauthCallback("github", {
+      code: "github-single-account-code",
+      state: stateFromAuthorizationUrl(singleAccountStart.authorizationUrl),
+    });
+    const singleAccountConnection = await connectorsApi.readConnectorBySlug(
+      actor,
+      "github",
+    );
+    expect(singleAccountConnection.id).toBe(initialConnection.id);
 
     const reconnectStart = await connectorsApi.startOauth(
       actor,
@@ -832,6 +849,8 @@ describe("CONN-02: OAuth device authorization", () => {
       actor,
       "test-oauth-device",
       "oauth",
+      undefined,
+      { intent: "single-account" },
     );
     expect(session).toMatchObject({
       connectorSlug: "test-oauth-device",
@@ -2004,9 +2023,10 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     await connectorsApi.deleteCustomConnector(admin, created.id);
   });
 
-  it("uses the same first-account and sibling gate for HTTP and MCP custom connectors", async () => {
+  it("uses explicit single-account semantics for HTTP and MCP custom connectors", async () => {
     const admin = createBddApi(context).user({ orgRole: "org:admin" });
     await connectorsApi.updateFeatureSwitches(admin, {
+      [FeatureSwitchKey.ConnectorAccounts]: true,
       [FeatureSwitchKey.CustomConnectorMcp]: true,
     });
     const definitions = [
@@ -2047,20 +2067,38 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
         connector.id,
         [{ key: "secret", kind: "secret", value: "first-secret" }],
         [200],
-        { intent: "add", displayName: "Work" },
+        { intent: "single-account" },
       );
       expect(connected.body).toMatchObject({ connected: true });
+
+      const replaced = await connectorsApi.requestSetCustomConnectorValues(
+        admin,
+        connector.id,
+        [{ key: "secret", kind: "secret", value: "replacement-secret" }],
+        [200],
+        { intent: "single-account" },
+      );
+      expect(replaced.body).toMatchObject({ connected: true });
 
       const sibling = await connectorsApi.requestSetCustomConnectorValues(
         admin,
         connector.id,
         [{ key: "secret", kind: "secret", value: "sibling-secret" }],
-        [409],
+        [200],
         { intent: "add", displayName: "Personal" },
       );
-      expectApiError(sibling.body);
-      expect(sibling.body.error.message).toBe(
-        "Additional connector accounts are not enabled yet",
+      expect(sibling.body).toMatchObject({ connected: true });
+
+      const ambiguous = await connectorsApi.requestSetCustomConnectorValues(
+        admin,
+        connector.id,
+        [{ key: "secret", kind: "secret", value: "ambiguous-secret" }],
+        [409],
+        { intent: "single-account" },
+      );
+      expectApiError(ambiguous.body);
+      expect(ambiguous.body.error.message).toBe(
+        "Multiple connector accounts require an exact choice",
       );
       await expect(
         connectorsApi.readCustomConnector(admin, connector.id),
@@ -2169,6 +2207,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       member,
       created.id,
       agent.agentId,
+      { intent: "single-account" },
     );
     const authorization = new URL(authorizationUrl);
     expect(authorization.origin + authorization.pathname).toBe(

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -2135,7 +2135,7 @@ describe("Feishu integration", () => {
       customConnectorOAuthClient.start({
         headers: { authorization: "Bearer clerk-session" },
         params: { id: managedConnector.id },
-        body: {},
+        body: { account: { intent: "single-account" } },
       }),
       [403],
     );
@@ -2206,7 +2206,10 @@ describe("Feishu integration", () => {
       ).set({
         headers: { authorization: "Bearer clerk-session" },
         params: { id: managedConnector.id },
-        body: { values: [] },
+        body: {
+          values: [],
+          account: { intent: "single-account" },
+        },
       }),
       [403],
     );

--- a/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
@@ -3,9 +3,12 @@ import { connectors } from "@okouai/db/schema/connector";
 import { and, eq, sql } from "drizzle-orm";
 
 import type { Tx } from "../../lib/db-types";
+import { logger } from "../../lib/log";
 import { deleteConnectorOwnedCredentialRows } from "./connector-credential-storage-write.service";
 import type { ConnectorAccountMutation } from "./connector-account-mutation.service";
 import { lockConnectorAccountTarget } from "./auth-state-lock.service";
+
+const log = logger("api:connector-account-mutation");
 
 export interface StoredConnectorConnectionRow {
   readonly id: string;
@@ -90,6 +93,51 @@ export type ConnectorConnectionMutationResolution =
   | { readonly kind: "ambiguous" }
   | { readonly kind: "sibling-disabled" };
 
+type ConnectorConnectionMutationOutcome =
+  | ReadyConnectorConnectionMutation["kind"]
+  | Exclude<
+      ConnectorConnectionMutationResolution,
+      { readonly kind: "ready" }
+    >["kind"];
+
+type ConnectorConnectionSelectionCardinality = "zero" | "one" | "multiple";
+
+function connectorConnectionSelectionCardinality(
+  count: number,
+): ConnectorConnectionSelectionCardinality {
+  if (count === 0) {
+    return "zero";
+  }
+  return count === 1 ? "one" : "multiple";
+}
+
+function connectorConnectionMutationOutcome(
+  resolution: ConnectorConnectionMutationResolution,
+): ConnectorConnectionMutationOutcome {
+  return resolution.kind === "ready"
+    ? resolution.mutation.kind
+    : resolution.kind;
+}
+
+function observeConnectorConnectionMutation(
+  args: {
+    readonly targetKind: ConnectorAccountTarget["kind"];
+    readonly intent: ConnectorAccountMutation["intent"];
+    readonly selectedCount: number;
+  },
+  resolution: ConnectorConnectionMutationResolution,
+): ConnectorConnectionMutationResolution {
+  log.debug("Resolved connector account mutation", {
+    targetKind: args.targetKind,
+    intent: args.intent,
+    selectionCardinality: connectorConnectionSelectionCardinality(
+      args.selectedCount,
+    ),
+    outcome: connectorConnectionMutationOutcome(resolution),
+  });
+  return resolution;
+}
+
 function connectorConnectionSelection() {
   return {
     id: connectors.id,
@@ -149,9 +197,17 @@ export async function resolveConnectorConnectionMutation(
       )
       .for("update")
       .limit(1);
-    return existing
+    const resolution: ConnectorConnectionMutationResolution = existing
       ? { kind: "ready", mutation: { kind: "update", existing } }
       : { kind: "missing" };
+    return observeConnectorConnectionMutation(
+      {
+        targetKind: args.target.kind,
+        intent: args.mutation.intent,
+        selectedCount: existing ? 1 : 0,
+      },
+      resolution,
+    );
   }
 
   const existing = await db
@@ -167,29 +223,39 @@ export async function resolveConnectorConnectionMutation(
     .orderBy(connectors.id)
     .for("update")
     .limit(2);
+  let resolution: ConnectorConnectionMutationResolution;
   if (args.mutation.intent === "add") {
     if (existing.length > 0 && !args.allowSiblings) {
-      return { kind: "sibling-disabled" };
-    }
-    return {
-      kind: "ready",
-      mutation: {
-        kind: "insert",
-        displayName: args.mutation.displayName ?? null,
-        isDefault: existing.length === 0,
-      },
-    };
-  }
-  if (existing.length > 1) {
-    return { kind: "ambiguous" };
-  }
-  const [singleton] = existing;
-  return singleton
-    ? { kind: "ready", mutation: { kind: "update", existing: singleton } }
-    : {
+      resolution = { kind: "sibling-disabled" };
+    } else {
+      resolution = {
         kind: "ready",
-        mutation: { kind: "insert", displayName: null, isDefault: true },
+        mutation: {
+          kind: "insert",
+          displayName: args.mutation.displayName ?? null,
+          isDefault: existing.length === 0,
+        },
       };
+    }
+  } else if (existing.length > 1) {
+    resolution = { kind: "ambiguous" };
+  } else {
+    const [singleton] = existing;
+    resolution = singleton
+      ? { kind: "ready", mutation: { kind: "update", existing: singleton } }
+      : {
+          kind: "ready",
+          mutation: { kind: "insert", displayName: null, isDefault: true },
+        };
+  }
+  return observeConnectorConnectionMutation(
+    {
+      targetKind: args.target.kind,
+      intent: args.mutation.intent,
+      selectedCount: existing.length,
+    },
+    resolution,
+  );
 }
 
 export async function writeConnectorConnectionMetadata(

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
@@ -47,7 +47,18 @@ describe("connector account contracts", () => {
     ).toBe(false);
   });
 
-  it("distinguishes add from exact reconnect intent", () => {
+  it("distinguishes single-account, add, and exact reconnect intent", () => {
+    expect(
+      connectorAccountMutationIntentSchema.parse({
+        intent: "single-account",
+      }),
+    ).toStrictEqual({ intent: "single-account" });
+    expect(
+      connectorAccountMutationIntentSchema.safeParse({
+        intent: "single-account",
+        connectionId,
+      }).success,
+    ).toBe(false);
     expect(
       connectorAccountMutationIntentSchema.parse({
         intent: "add",

--- a/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
@@ -65,6 +65,11 @@ export const connectorAccountMutationIntentSchema = z.discriminatedUnion(
   [
     z
       .object({
+        intent: z.literal("single-account"),
+      })
+      .strict(),
+    z
+      .object({
         intent: z.literal("add"),
         displayName: connectorAccountDisplayNameSchema.optional(),
       })

--- a/turbo/packages/db/src/jsonb-contracts/connector-account-mutation.ts
+++ b/turbo/packages/db/src/jsonb-contracts/connector-account-mutation.ts
@@ -1,3 +1,5 @@
 import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
 
+// Authorization state persists this contract across API requests. Deploy new
+// readers before current clients begin writing a newly added intent value.
 export type StoredConnectorAccountMutation = ConnectorAccountMutationIntent;


### PR DESCRIPTION
## Summary

- add a strict `single-account` connector mutation intent for compact clients
- resolve zero, one, and multiple-account states atomically under the existing connector target lock
- preserve the intent through built-in OAuth, OpenID, device, external-code, and custom OAuth authorization state
- record non-sensitive intent, target kind, selection cardinality, and outcome telemetry
- cover built-in, custom HTTP/MCP, concurrency, malformed input, and Integration-managed Feishu boundaries

## Behavior

- zero matching accounts creates the default account without requiring a display label
- one matching account updates that exact row
- multiple matching accounts return a conflict without choosing a sibling
- omitted legacy intent, explicit `add`, and exact `reconnect` remain compatible and unchanged

## Exclusions

- no Platform or CLI caller migration
- no account-management UI or account-list exposure changes
- no deletion or legacy compatibility cleanup
- no generic connection support for Integration-managed custom connectors

## Lifecycle and permission boundary

`single-account` is a transitional operation for current compact callers. Once a caller exposes account-aware UX, it must use explicit `add` for a new account and an exact connection ID for operations on an existing account; it must not use `single-account` to select among accounts.

Connector authorization and permissions remain scoped to the logical connector (`connectorSlug` or `customConnectorId`). They are not scoped to a connector account or connection ID, and changing account selection must not create, remove, or duplicate connector grants.

## Deployment compatibility

Authorization state persists the new contract value between requests. Deploy this API reader before Platform or CLI clients begin writing `single-account`.

## Validation

- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/connector-accounts.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connector-accounts.test.ts src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/connectors-openid.bdd.test.ts src/signals/routes/__tests__/connectors-external-code.bdd.test.ts src/signals/routes/__tests__/feishu-integration.test.ts --silent=passed-only`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/db lint`
- `pnpm -F @okouai/db check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm format`
- `pnpm knip`
- pre-commit full Turbo type checks (14/14 successful)

Closes #28587

Parent context: #28570

