### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -450,32 +450,6 @@ async function prepareUsagePackCheckoutOrg(
   );
 }
 
-async function seedPreviousUsagePackCheckoutWriter(
-  fixture: BillingOrgFixture,
-  customerId: string,
-): Promise<string> {
-  const seeded = await usagePackStateAction({
-    action: "seed",
-    orgId: fixture.orgId,
-    tier: "pro",
-    stripePlanPriceId: TEST_PRICE_USAGE_PACK_PLAN_PRO,
-    stripeCustomerId: customerId,
-    stripeCheckoutSessionId: null,
-    allocations: [
-      {
-        userId: fixture.userId,
-        invitationId: null,
-        usagePackUsd: 20,
-        stripePriceId: TEST_PRICE_USAGE_PACK_20,
-      },
-    ],
-  });
-  if (seeded.action !== "seeded") {
-    throw new Error("Failed to seed the previous writer snapshot");
-  }
-  return seeded.usagePackSubscriptionId;
-}
-
 function cleanupUsagePackSnapshotOnTestFinished(
   fixture: BillingOrgFixture,
   usagePackSubscriptionId: string,
@@ -3357,105 +3331,6 @@ describe("POST /api/billing/usage-pack-checkout", () => {
         deleteOrgMetadata: true,
       });
     });
-  });
-
-  it("waits when the previous writer claims a fresh Checkout snapshot", async () => {
-    const fixture = createOrgFixture();
-    const customerId = `cus_${randomUUID()}`;
-    await prepareUsagePackCheckoutOrg(fixture, customerId);
-    const sessionStates = mockStatefulUsagePackCheckoutSessions();
-    const legacySessionId = `cs_legacy_${randomUUID()}`;
-    // The previous API has created this payable Session but is paused before
-    // its unconditional snapshot correlation.
-    sessionStates.set(legacySessionId, "open");
-    const legacySnapshotId = await seedPreviousUsagePackCheckoutWriter(
-      fixture,
-      customerId,
-    );
-    cleanupUsagePackSnapshotOnTestFinished(fixture, legacySnapshotId);
-    // The previous API can claim a snapshot created by another writer. Keep
-    // its freshness timestamp distinct from creation so ownership never
-    // depends on timestamp equality.
-    await usagePackStateAction({
-      action: "set-updated-at",
-      orgId: fixture.orgId,
-      usagePackSubscriptionId: legacySnapshotId,
-      updatedAt: new Date(now() - 1000).toISOString(),
-    });
-    const client = setupApp({ context, routes: billingCheckoutRoutes })(
-      billingUsagePackCheckoutContract,
-    );
-    const request = () => {
-      return client.create({
-        body: {
-          tier: "pro",
-          memberUsagePacks: [{ memberId: fixture.userId, usagePackUsd: 50 }],
-          successUrl: `${APP_ORIGIN}/billing?billing=success`,
-          cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
-        },
-        headers: { authorization: "Bearer clerk-session" },
-      });
-    };
-    const blocked = await accept(request(), [409]);
-
-    expect(blocked.body).toStrictEqual({
-      error: {
-        message: "Another usage pack purchase is still being prepared",
-        code: "CONFLICT",
-      },
-    });
-    expect(
-      context.mocks.stripe.checkout.sessions.create,
-    ).not.toHaveBeenCalled();
-    expect(sessionStates.get(legacySessionId)).toBe("open");
-    const blockedState = await readUsagePackState(
-      fixture.orgId,
-      legacySnapshotId,
-    );
-    expect(blockedState.subscriptionCount).toBe(1);
-    expect(blockedState.subscription).toMatchObject({
-      stripeCheckoutSessionId: null,
-      subscriptionStatus: "checkout_pending",
-    });
-
-    await usagePackStateAction({
-      action: "correlate-legacy-checkout-session",
-      orgId: fixture.orgId,
-      usagePackSubscriptionId: legacySnapshotId,
-      stripeCheckoutSessionId: legacySessionId,
-      updatedAt: new Date(now()).toISOString(),
-    });
-    const replaced = await accept(request(), [200]);
-
-    expect(replaced.body).toStrictEqual({
-      url: expect.stringMatching(/^https:\/\/checkout\.stripe\.test\//),
-    });
-    expect(sessionStates.get(legacySessionId)).toBe("expired");
-    expect(
-      [...sessionStates.values()].filter((status) => {
-        return status === "open";
-      }),
-    ).toHaveLength(1);
-    expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledTimes(
-      1,
-    );
-    expect(context.mocks.stripe.checkout.sessions.expire).toHaveBeenCalledWith(
-      legacySessionId,
-    );
-    expect(
-      (await readUsagePackState(fixture.orgId, legacySnapshotId)).subscription,
-    ).toMatchObject({
-      stripeCheckoutSessionId: legacySessionId,
-      subscriptionStatus: "checkout_expired",
-    });
-    const [createInput] = context.mocks.stripe.checkout.sessions.create.mock
-      .calls[0] ?? [undefined];
-    const replacementSnapshotId =
-      stripeInputMetadata(createInput).usagePackSubscriptionId;
-    if (!replacementSnapshotId) {
-      throw new Error("Replacement Checkout did not expose its snapshot ID");
-    }
-    cleanupUsagePackSnapshotOnTestFinished(fixture, replacementSnapshotId);
   });
 
   it("keeps a reused purchase preview snapshot until its latest token expires", async () => {

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -838,9 +838,6 @@ const usagePackCheckoutAuthed$ = command(
       signal,
     );
     signal.throwIfAborted();
-    if (result.status === "purchase_in_progress") {
-      return conflict("Another usage pack purchase is still being prepared");
-    }
     return {
       status: 200 as const,
       body: result.status === "preview" ? result.preview : { url: result.url },

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
@@ -150,7 +150,6 @@ interface StartUsagePackPurchaseArgs extends CreateUsagePackCheckoutSessionArgs 
 
 type StartUsagePackPurchaseResult =
   | { readonly status: "checkout"; readonly url: string }
-  | { readonly status: "purchase_in_progress" }
   | {
       readonly status: "preview";
       readonly preview: UsagePackPurchasePreviewResponse;
@@ -678,27 +677,9 @@ async function retireUsagePackCheckout(
 
 type PendingUsagePackCheckoutResolution =
   | { readonly kind: "create" }
-  | { readonly kind: "previous_writer_pending" }
   | { readonly kind: "redirect"; readonly url: string }
   | { readonly kind: "retry" }
   | { readonly kind: "reuse"; readonly usagePackSubscriptionId: string };
-
-function previousUsagePackCheckoutWriterPending(
-  snapshot: UsagePackContext,
-  at: Date,
-): boolean {
-  // DB/API revisions have overlapped for an observed maximum of ~102 minutes.
-  // Previous API versions only write checkout_pending and may still create a
-  // Stripe Session after releasing the organization lock. New snapshots use
-  // purchase_pending so the previous reader cannot take them over. Preserve
-  // every fresh legacy-visible writer for the 15-minute snapshot TTL. Remove
-  // this compatibility branch after the rollback/drain window: #28372.
-  return (
-    snapshot.subscription.subscriptionStatus === "checkout_pending" &&
-    snapshot.subscription.updatedAt.getTime() >
-      at.getTime() - USAGE_PACK_PENDING_SNAPSHOT_STALE_MS
-  );
-}
 
 async function resolvePendingUsagePackSnapshots(
   tx: WriteTx,
@@ -770,14 +751,6 @@ async function resolvePendingUsagePackCheckout(
   const snapshots = contexts.filter((context) => {
     return !context.subscription.stripeCheckoutSessionId;
   });
-  const at = nowDate();
-  if (
-    snapshots.some((snapshot) => {
-      return previousUsagePackCheckoutWriterPending(snapshot, at);
-    })
-  ) {
-    return { kind: "previous_writer_pending" };
-  }
   const resolved: {
     readonly context: UsagePackContext;
     readonly session: UsagePackCheckoutSessionInput;
@@ -888,7 +861,6 @@ async function insertUsagePackPurchaseSnapshot(
 }
 
 type PreparedUsagePackPurchaseSnapshot =
-  | { readonly kind: "previous_writer_pending" }
   | { readonly kind: "redirect"; readonly url: string }
   | { readonly kind: "snapshot"; readonly usagePackSubscriptionId: string };
 
@@ -908,10 +880,7 @@ async function prepareUsagePackPurchaseSnapshot(
       undefined,
       signal,
     );
-    if (
-      resolution.kind === "redirect" ||
-      resolution.kind === "previous_writer_pending"
-    ) {
+    if (resolution.kind === "redirect") {
       return resolution;
     }
     if (resolution.kind === "retry") {
@@ -1011,9 +980,6 @@ async function createSerializedUsagePackCheckout(
       if (resolution.kind === "redirect") {
         return { kind: "complete" as const, url: resolution.url };
       }
-      if (resolution.kind === "previous_writer_pending") {
-        return { kind: "previous_writer_pending" as const };
-      }
       if (resolution.kind !== "reuse") {
         return { kind: "retry" as const };
       }
@@ -1028,9 +994,6 @@ async function createSerializedUsagePackCheckout(
         }),
       };
     });
-    if (attempt.kind === "previous_writer_pending") {
-      return { status: "purchase_in_progress" };
-    }
     if (attempt.kind === "complete") {
       return { status: "checkout", url: attempt.url };
     }
@@ -1042,9 +1005,6 @@ async function createSerializedUsagePackCheckout(
     );
     if (prepared.kind === "redirect") {
       return { status: "checkout", url: prepared.url };
-    }
-    if (prepared.kind === "previous_writer_pending") {
-      return { status: "purchase_in_progress" };
     }
     preferredSnapshotId = prepared.usagePackSubscriptionId;
   }
@@ -1079,9 +1039,6 @@ const createUsagePackCheckoutSession$ = command(
     );
     if (prepared.kind === "redirect") {
       return { status: "checkout", url: prepared.url };
-    }
-    if (prepared.kind === "previous_writer_pending") {
-      return { status: "purchase_in_progress" };
     }
     return await createSerializedUsagePackCheckout(
       db,
@@ -1142,12 +1099,6 @@ async function createSerializedUsagePackPurchasePreviewAttempt(
       return {
         kind: "complete",
         result: { status: "checkout", url: resolution.url },
-      };
-    }
-    if (resolution.kind === "previous_writer_pending") {
-      return {
-        kind: "complete",
-        result: { status: "purchase_in_progress" },
       };
     }
     if (resolution.kind !== "reuse") {
@@ -1259,9 +1210,6 @@ async function createSerializedUsagePackPurchasePreview(
     if (prepared.kind === "redirect") {
       return { status: "checkout", url: prepared.url };
     }
-    if (prepared.kind === "previous_writer_pending") {
-      return { status: "purchase_in_progress" };
-    }
     preferredSnapshotId = prepared.usagePackSubscriptionId;
   }
 }
@@ -1308,9 +1256,6 @@ export const startUsagePackPurchase$ = command(
     );
     if (prepared.kind === "redirect") {
       return { status: "checkout", url: prepared.url };
-    }
-    if (prepared.kind === "previous_writer_pending") {
-      return { status: "purchase_in_progress" };
     }
     if (route.kind === "checkout") {
       return await createSerializedUsagePackCheckout(


### PR DESCRIPTION
Daily deployment-compatibility cleanup. One cohort survived evidence collection. The report below also flags a recurring infrastructure problem that is now blocking several DB-class cleanups outright.

## Cohort — remove the previous usage-pack checkout writer branch (#28372)

**Old → new boundary.** [PR #28304](https://github.com/vm0-ai/vm0/pull/28304) made the new API write uncorrelated usage-pack purchase snapshots as `purchase_pending`, a status the previous API does not claim, and migration `0952` enforces one pending snapshot per organization across both statuses. During the mixed-version window, `previousUsagePackCheckoutWriterPending` treated every *fresh, sessionless* `checkout_pending` snapshot as owned by a previous API request still creating its Stripe Checkout Session outside the organization lock, and returned `previous_writer_pending` instead of replacing it.

**Window.** #28372's condition is the API deployment containing #28304 being outside the production rollback/drain window (documented observed maximum ~102 minutes) **plus one additional 15-minute purchase-snapshot TTL** — about two hours in total.

**Rollout evidence.** #28304 merged 2026-08-20T14:10:04Z (`17ba3cdfd57c`); `api/production` promoted `772de1c01b70` at **2026-08-20T15:22:42Z**, verified to contain that commit with `git merge-base --is-ancestor`. Five further promotions followed, through `65d5775e3883`, which also contains it. At this run that is **29.6 hours** against a ~2-hour gate. Both halves are satisfied independently: no pre-#28304 request can still be in flight, and any `checkout_pending` snapshot such a request left is now roughly 118 TTLs old, so the freshness test in the removed branch would evaluate `false` for it regardless.

**Persisted-data reasoning.** Nothing is read, written, or migrated. The branch only chose between replacing and deferring to a pending snapshot; stale `checkout_pending` rows keep being resolved by the normal path.

**Removed, and why the removal cascades.** `previousUsagePackCheckoutWriterPending` was the sole producer of `previous_writer_pending`. Deleting it made that result unreachable, so its two union members, all seven handling sites, the now-dead `purchase_in_progress` variant of `StartUsagePackPurchaseResult`, and the `billing-checkout.ts` branch that turned it into a 409 went with it. The cascade was compiler-guided: the variant was removed from the unions first and `tsc` located every remaining site. The `purchase_in_progress` **status itself is not gone** — `usage-pack-invitation-purchase.service.ts` still produces it as an independent conflict reason for the invitation flow, which this PR does not touch.

**Test removed.** `waits when the previous writer claims a fresh Checkout snapshot`, together with its `seedPreviousUsagePackCheckoutWriter` helper, which existed only to construct the previous-writer shape. It was the only failing test after the change and it asserts exactly the removed 409.

## Checks

Run once against the combined diff, with a local PostgreSQL 18 cluster created for this run and set to `UTC`:

- `pnpm format`; `pnpm check-types` (all tasks, no errors); `pnpm knip` (exit 0); `pnpm -F api lint` (exit 0)
- `pnpm -F api exec vitest run billing-checkout.test.ts` → **210 passed** (the suite that owned the deleted test and covers the whole usage-pack checkout surface)
- `pnpm -F api exec vitest run billing-usage-pack-credits.test.ts` → **6 passed**

Per repo guidance the full local Vitest suite was not run and no dev server was started.

## Open-PR overlap

**None.** No open PR touches any of the three changed files.

## Blocking infrastructure problem: the masked production database is roughly two weeks stale

This is worth raising on its own because it is now the single largest blocker in this workflow's backlog. `vm0-prod-ro` does not reflect recent DDL:

| probe | MaskDB result | reality |
|---|---|---|
| `usage_pack_credit_refunds` (migration 0898, ~2026-08-11) | **not listed** among 121 tables | exists |
| `usage_pack_subscriptions` | `table not found` | exists |
| `org_plan_entitlements.member_invite_usage_pack_required` (0899) | absent from 26 columns | exists |
| `shared_threads.public_brand` (0934) | absent; table reported with only 2 columns | proven present on 2026-08-19 |
| `browser_*` | never listed | exists |

Consequences for today's run, stated as evidence gaps rather than worked around:

- **`memberInviteUsagePackEntitlementSchemaAvailable`** (`org-plan-entitlement-read.service.ts`) plus its `orgPlanEntitlementsBeforeMemberInviteUsagePack` shadow table and the `to_jsonb(...) ->> 'member_invite_usage_pack_required'` tolerant read — migration 0899 shipped 2026-08-11 and **66 migrations** have followed, so the window is long closed. But *every* reader of that column is guarded, so no production request fails observably if it were missing, and MaskDB cannot confirm it exists. No positive evidence is obtainable, so this is deferred rather than inferred.
- **`browser_*` identity contraction** — unchanged: proving `chat_thread_id` uniqueness across retained rows needs row-level access MaskDB will not give.
- **`usage-pack-credit-refund.service.ts`** — its gate requires "production has zero unresolved Credit-Note rows", also unobtainable.

Fixing the masked-branch refresh would unblock all three.

Other deferrals:

- **#27356** zero-agent default-avatar bridge — window long closed, but `apps/api/src/signals/routes/agents.ts:322` still reads `avatarUrl: args.body.avatarUrl ?? null` while only the create path at line 399 uses `randomPresetAvatar()`. That upsert reaches its INSERT branch from the PUT route for a compose-backed agent with no `zero_agents` row, so the trigger compensates a **live** writer. **Seventh consecutive run reporting this; the unblocking change is one line.**
- **#27660's OAuth half** — the shim is not separable; the ternary collapses *absent* and *malformed* into one branch, so removing it requires deciding new malformed-input behavior the issue does not specify.
- **#28449**, **#27750**, **#27695**, **#28275**, **#28356 / #28278** — recent rollout and rebranding programs with their own removal owners and open windows.
- **#26938** agent/compose consolidation, **#26672 / #26519** Website template archive pins (`LatestWebsiteTemplates` still `enabled: false`), `PersonalModelProviderAccounts` fallbacks (still `enabled: false`) — product gates, not time windows.
- **#25620** avatar flat-field read fallback — still needs a jsonb backfill.
